### PR TITLE
ci(release): wire semantic-release into release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,32 @@ on:
 permissions:
   contents: write
   packages: write
+  issues: write
+  pull-requests: write
 
 jobs:
+  release:
+    name: Semantic Release
+    runs-on: ubuntu-latest
+    outputs:
+      new-release-published: ${{ steps.semantic.outputs.new_release_published }}
+      new-release-version: ${{ steps.semantic.outputs.new_release_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Semantic Release
+        id: semantic
+        uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build-and-push:
     name: Build & Push Docker Image
+    needs: release
+    if: needs.release.outputs.new-release-published == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -50,8 +72,9 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=sha,prefix=,format=short,priority=300
-            type=raw,value=latest,enable=true
+            type=semver,pattern={{version}},value=v${{ needs.release.outputs.new-release-version }}
+            type=semver,pattern={{major}}.{{minor}},value=v${{ needs.release.outputs.new-release-version }}
+            type=raw,value=latest
 
       - name: Build and push Docker image
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
@@ -70,4 +93,4 @@ jobs:
           token: ${{ secrets.INFRA_DISPATCH_TOKEN }}
           repository: TheSemicolon/agent-expertise-api-infra
           event-type: deploy
-          client-payload: '{"image_tag": "${{ steps.meta.outputs.version }}"}'
+          client-payload: '{"image_tag": "v${{ needs.release.outputs.new-release-version }}"}'

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,8 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/github"
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,8 @@ All endpoints except `/health` and `/query` require `Authorization: Bearer <api-
 | Workflow | Trigger | What it does |
 | -------- | ------- | ------------ |
 | `ci.yml` | PR to main, push to dev | `dotnet build` + `dotnet test` |
-| `release.yml` | Push to main | Download models (cached), Docker build linux/amd64+arm64, push to GHCR |
+| `release.yml` | Push to main | semantic-release version bump + tag, then Docker build linux/amd64+arm64, push to GHCR (only when a new version is released) |
+| `lint-pr-title.yml` | PR to dev | Validates PR title follows Conventional Commits format |
 
 GHCR image: `ghcr.io/thesemicolon/agent-expertise-api` (multi-arch: amd64 + arm64).
 


### PR DESCRIPTION
## Summary

Adds semantic-release automation to the release workflow. Version bumps are now derived automatically from Conventional Commits on push to `main`. Docker images are tagged with SemVer versions instead of commit SHAs.

**Why:** The release pipeline was documented as using semantic-release but it was never implemented (#23). Images were tagged with `sha-<short>` and `latest` only — no `vX.Y.Z` tags for deployment tracking or rollback.

## Type of Change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [x] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes

## How It Works

1. Push to `main` triggers the `release` job
2. `cycjimmy/semantic-release-action` analyzes commits since the last tag (`v0.1.0`)
3. If releasable commits exist (`feat` → minor, `fix` → patch): creates annotated tag + GitHub Release
4. `build-and-push` job runs only if a release was created (`if: new_release_published == 'true'`)
5. Docker images tagged with SemVer (`0.2.0`, `0.2`, `latest`) instead of SHA
6. Infra dispatch payload uses versioned tag (`v0.2.0`) instead of SHA

## Files Changed

| File | Change |
|---|---|
| `.releaserc.json` | New — release config (branches: main, plugins: analyzer + notes + github) |
| `.github/workflows/release.yml` | Restructured into two jobs with conditional Docker build |
| `CLAUDE.md` | Updated CI/CD table to reflect semantic-release and lint-pr-title |

## Key Design Decisions

- **`cycjimmy/semantic-release-action`** over `npx` — typed outputs, no `package.json` needed
- **No CHANGELOG.md commit** — avoids branch protection bypass; release notes in GitHub Release body
- **No Chart.yaml bump** — deferred to follow-up (needs `@semantic-release/exec` + branch protection config)
- **`@semantic-release/npm` removed** — default plugin breaks non-Node projects

## Test Plan

- [x] `yamllint` — valid YAML (line-length warnings only, pre-existing)
- [x] `.releaserc.json` — valid JSON
- [ ] Manual: after merge to dev → promote to main, verify semantic-release creates a GitHub Release
- [ ] Manual: verify Docker image is tagged with SemVer version on GHCR
- [ ] Manual: verify infra dispatch receives versioned tag

## Checklist

- [x] CLAUDE.md updated (CI/CD table)
- [x] All GitHub Actions pinned by SHA
- [x] No secrets or credentials in committed files

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)