### PR TITLE
fix: harden embedding pipeline — dimension guard and container security

### DIFF
--- a/helm/expertise-api/templates/deployment.yaml
+++ b/helm/expertise-api/templates/deployment.yaml
@@ -17,9 +17,9 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
+        runAsUser: 1654
+        runAsGroup: 1654
+        fsGroup: 1654
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -46,6 +46,8 @@ spec:
               value: "models/vocab.txt"
             - name: TMPDIR
               value: /tmp
+            - name: DOTNET_EnableDiagnostics
+              value: "0"
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
           volumeMounts:

--- a/src/ExpertiseApi/Data/ExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/ExpertiseRepository.cs
@@ -5,7 +5,7 @@ using Pgvector.EntityFrameworkCore;
 
 namespace ExpertiseApi.Data;
 
-public class ExpertiseRepository(ExpertiseDbContext db) : IExpertiseRepository
+public class ExpertiseRepository(ExpertiseDbContext db, ILogger<ExpertiseRepository> logger) : IExpertiseRepository
 {
     public async Task<ExpertiseEntry?> GetByIdAsync(Guid id, CancellationToken ct)
     {
@@ -138,6 +138,27 @@ public class ExpertiseRepository(ExpertiseDbContext db) : IExpertiseRepository
         // Threshold check in memory on the single returned vector to avoid double SQL evaluation
         var a = candidate.Embedding.ToArray();
         var b = queryVector.ToArray();
+        var distance = CosineDistance(a, b);
+
+        if (distance is null)
+        {
+            logger.LogWarning(
+                "Embedding dimension mismatch in domain {Domain}: stored {StoredDim}, query {QueryDim}. Run 'reembed' to regenerate stored embeddings",
+                domain, a.Length, b.Length);
+            return null;
+        }
+
+        return distance.Value <= maxDistance ? candidate : null;
+    }
+
+    /// <summary>
+    /// Computes cosine distance between two vectors. Returns null if dimensions differ.
+    /// </summary>
+    internal static double? CosineDistance(float[] a, float[] b)
+    {
+        if (a.Length != b.Length)
+            return null;
+
         double dot = 0, normA = 0, normB = 0;
         for (var i = 0; i < a.Length; i++)
         {
@@ -145,8 +166,6 @@ public class ExpertiseRepository(ExpertiseDbContext db) : IExpertiseRepository
             normA += a[i] * (double)a[i];
             normB += b[i] * (double)b[i];
         }
-        var distance = 1.0 - dot / (Math.Sqrt(normA) * Math.Sqrt(normB));
-
-        return distance <= maxDistance ? candidate : null;
+        return 1.0 - dot / (Math.Sqrt(normA) * Math.Sqrt(normB));
     }
 }

--- a/src/ExpertiseApi/ExpertiseApi.csproj
+++ b/src/ExpertiseApi/ExpertiseApi.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="ExpertiseApi.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/ExpertiseApi.Tests/Unit/CosineDistanceTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/CosineDistanceTests.cs
@@ -1,26 +1,15 @@
+using ExpertiseApi.Data;
 using FluentAssertions;
 
 namespace ExpertiseApi.Tests.Unit;
 
 public class CosineDistanceTests
 {
-    private static double ComputeCosineDistance(float[] a, float[] b)
-    {
-        double dot = 0, normA = 0, normB = 0;
-        for (var i = 0; i < a.Length; i++)
-        {
-            dot += a[i] * (double)b[i];
-            normA += a[i] * (double)a[i];
-            normB += b[i] * (double)b[i];
-        }
-        return 1.0 - dot / (Math.Sqrt(normA) * Math.Sqrt(normB));
-    }
-
     [Fact]
     public void IdenticalVectors_ShouldHaveZeroDistance()
     {
         var v = new float[] { 1.0f, 0.0f, 0.0f };
-        ComputeCosineDistance(v, v).Should().BeApproximately(0.0, 1e-10);
+        ExpertiseRepository.CosineDistance(v, v).Should().BeApproximately(0.0, 1e-10);
     }
 
     [Fact]
@@ -28,7 +17,7 @@ public class CosineDistanceTests
     {
         var a = new float[] { 1.0f, 0.0f };
         var b = new float[] { 0.0f, 1.0f };
-        ComputeCosineDistance(a, b).Should().BeApproximately(1.0, 1e-10);
+        ExpertiseRepository.CosineDistance(a, b).Should().BeApproximately(1.0, 1e-10);
     }
 
     [Fact]
@@ -36,7 +25,7 @@ public class CosineDistanceTests
     {
         var a = new float[] { 1.0f, 0.0f };
         var b = new float[] { -1.0f, 0.0f };
-        ComputeCosineDistance(a, b).Should().BeApproximately(2.0, 1e-10);
+        ExpertiseRepository.CosineDistance(a, b).Should().BeApproximately(2.0, 1e-10);
     }
 
     [Fact]
@@ -44,9 +33,10 @@ public class CosineDistanceTests
     {
         var a = new float[] { 1.0f, 0.1f, 0.0f };
         var b = new float[] { 1.0f, 0.2f, 0.0f };
-        var distance = ComputeCosineDistance(a, b);
-        distance.Should().BeGreaterThan(0.0);
-        distance.Should().BeLessThan(0.05);
+        var distance = ExpertiseRepository.CosineDistance(a, b);
+        distance.Should().NotBeNull();
+        distance!.Value.Should().BeGreaterThan(0.0);
+        distance.Value.Should().BeLessThan(0.05);
     }
 
     [Fact]
@@ -54,7 +44,41 @@ public class CosineDistanceTests
     {
         var a = new float[] { 1.0f, 0.0f };
         var b = new float[] { 0.0f, 0.0f };
-        var distance = ComputeCosineDistance(a, b);
-        double.IsNaN(distance).Should().BeTrue();
+        var distance = ExpertiseRepository.CosineDistance(a, b);
+        distance.Should().NotBeNull();
+        double.IsNaN(distance!.Value).Should().BeTrue();
+    }
+
+    [Fact]
+    public void MismatchedDimensions_StoredShorter_ShouldReturnNull()
+    {
+        var stored = new float[] { 1.0f, 0.5f };
+        var query = new float[] { 1.0f, 0.5f, 0.3f };
+        ExpertiseRepository.CosineDistance(stored, query).Should().BeNull();
+    }
+
+    [Fact]
+    public void MismatchedDimensions_StoredLonger_ShouldReturnNull()
+    {
+        var stored = new float[] { 1.0f, 0.5f, 0.3f };
+        var query = new float[] { 1.0f, 0.5f };
+        ExpertiseRepository.CosineDistance(stored, query).Should().BeNull();
+    }
+
+    [Fact]
+    public void MatchingDimensions_384dim_ShouldReturnValidDistance()
+    {
+        var a = new float[384];
+        var b = new float[384];
+        var rng = new Random(42);
+        for (var i = 0; i < 384; i++)
+        {
+            a[i] = (float)(rng.NextDouble() * 2 - 1);
+            b[i] = (float)(rng.NextDouble() * 2 - 1);
+        }
+
+        var distance = ExpertiseRepository.CosineDistance(a, b);
+        distance.Should().NotBeNull();
+        distance!.Value.Should().BeInRange(0.0, 2.0);
     }
 }


### PR DESCRIPTION
## Summary

Combines #24 (readOnlyRootFilesystem + ONNX verification) and #29 (embedding dimension mismatch guard) into a single hardening pass for the embedding pipeline.

**Why:** Both issues share the same narrative — the embedding/ONNX lifecycle is fragile during model transitions. The dimension guard prevents silent wrong dedup results, and the container security fixes ensure the deployment is correctly configured for the .NET base image.

## Type of Change

- [x] `fix` — bug fix
- [ ] Breaking change (add `!` to PR title)

## Changes

### Dimension mismatch guard (`ExpertiseRepository.cs`)
- Extracted in-memory cosine distance into `internal static CosineDistance(float[], float[])` helper
- Returns `null` on dimension mismatch (instead of silently computing partial dot product)
- Logs warning with stored/query dimensions so operator knows to run `reembed`
- Added `ILogger<ExpertiseRepository>` injection
- Added `InternalsVisibleTo` for test project access

### Container security (`deployment.yaml`)
- Fixed `runAsUser: 1000` → `1654` to match .NET base image `APP_UID`
- Added `DOTNET_EnableDiagnostics=0` to suppress diagnostic socket writes

### Research finding: `/home/app` emptyDir NOT needed
The dotnet-expert verified that `Microsoft.ML.OnnxRuntime` deploys native libraries at publish time (not extracted at runtime). The existing `/tmp` emptyDir is sufficient. No additional volume mount required.

### Tests (`CosineDistanceTests.cs`)
- Rewrote to test production `ExpertiseRepository.CosineDistance` (not a private copy)
- Added: `MismatchedDimensions_StoredShorter_ShouldReturnNull`
- Added: `MismatchedDimensions_StoredLonger_ShouldReturnNull`
- Added: `MatchingDimensions_384dim_ShouldReturnValidDistance`
- Total: 40 tests (was 37), all passing

## Test Plan

- [x] `dotnet test` — 40/40 passing
- [x] `dotnet build` — 0 warnings, 0 errors
- [ ] Manual: verify Helm template renders correctly with `helm template`

## Checklist

- [x] Tests added for new behavior
- [x] No secrets or credentials in committed files

Closes #24, closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)