### PR TITLE
chore: promote dev to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,8 @@ jobs:
       - name: Build
         run: dotnet build ExpertiseApi.slnx --configuration Release --no-restore --disable-build-servers
 
-      # No test projects exist yet — dotnet test exits 0 when no tests are found.
-      # When a test project is added to the solution, this step picks it up automatically.
+      - name: Download ONNX model files
+        run: bash scripts/download-models.sh
+
       - name: Test
         run: dotnet test ExpertiseApi.slnx --configuration Release --no-build --verbosity normal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,32 @@ on:
 permissions:
   contents: write
   packages: write
+  issues: write
+  pull-requests: write
 
 jobs:
+  release:
+    name: Semantic Release
+    runs-on: ubuntu-latest
+    outputs:
+      new-release-published: ${{ steps.semantic.outputs.new_release_published }}
+      new-release-version: ${{ steps.semantic.outputs.new_release_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Semantic Release
+        id: semantic
+        uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build-and-push:
     name: Build & Push Docker Image
+    needs: release
+    if: needs.release.outputs.new-release-published == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -50,8 +72,9 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=sha,prefix=,format=short,priority=300
-            type=raw,value=latest,enable=true
+            type=semver,pattern={{version}},value=v${{ needs.release.outputs.new-release-version }}
+            type=semver,pattern={{major}}.{{minor}},value=v${{ needs.release.outputs.new-release-version }}
+            type=raw,value=latest
 
       - name: Build and push Docker image
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
@@ -70,4 +93,4 @@ jobs:
           token: ${{ secrets.INFRA_DISPATCH_TOKEN }}
           repository: TheSemicolon/agent-expertise-api-infra
           event-type: deploy
-          client-payload: '{"image_tag": "${{ steps.meta.outputs.version }}"}'
+          client-payload: '{"image_tag": "v${{ needs.release.outputs.new-release-version }}"}'

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,8 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/github"
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,8 @@ All endpoints except `/health` and `/query` require `Authorization: Bearer <api-
 | Workflow | Trigger | What it does |
 | -------- | ------- | ------------ |
 | `ci.yml` | PR to main, push to dev | `dotnet build` + `dotnet test` |
-| `release.yml` | Push to main | Download models (cached), Docker build linux/amd64+arm64, push to GHCR |
+| `release.yml` | Push to main | semantic-release version bump + tag, then Docker build linux/amd64+arm64, push to GHCR (only when a new version is released) |
+| `lint-pr-title.yml` | PR to dev | Validates PR title follows Conventional Commits format |
 
 GHCR image: `ghcr.io/thesemicolon/agent-expertise-api` (multi-arch: amd64 + arm64).
 

--- a/ExpertiseApi.slnx
+++ b/ExpertiseApi.slnx
@@ -2,4 +2,7 @@
   <Folder Name="/src/">
     <Project Path="src/ExpertiseApi/ExpertiseApi.csproj" />
   </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/ExpertiseApi.Tests/ExpertiseApi.Tests.csproj" />
+  </Folder>
 </Solution>

--- a/helm/expertise-api/templates/deployment.yaml
+++ b/helm/expertise-api/templates/deployment.yaml
@@ -17,9 +17,9 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
+        runAsUser: 1654
+        runAsGroup: 1654
+        fsGroup: 1654
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -46,6 +46,8 @@ spec:
               value: "models/vocab.txt"
             - name: TMPDIR
               value: /tmp
+            - name: DOTNET_EnableDiagnostics
+              value: "0"
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
           volumeMounts:

--- a/src/ExpertiseApi/Data/ExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/ExpertiseRepository.cs
@@ -5,7 +5,7 @@ using Pgvector.EntityFrameworkCore;
 
 namespace ExpertiseApi.Data;
 
-public class ExpertiseRepository(ExpertiseDbContext db) : IExpertiseRepository
+public class ExpertiseRepository(ExpertiseDbContext db, ILogger<ExpertiseRepository> logger) : IExpertiseRepository
 {
     public async Task<ExpertiseEntry?> GetByIdAsync(Guid id, CancellationToken ct)
     {
@@ -138,6 +138,27 @@ public class ExpertiseRepository(ExpertiseDbContext db) : IExpertiseRepository
         // Threshold check in memory on the single returned vector to avoid double SQL evaluation
         var a = candidate.Embedding.ToArray();
         var b = queryVector.ToArray();
+        var distance = CosineDistance(a, b);
+
+        if (distance is null)
+        {
+            logger.LogWarning(
+                "Embedding dimension mismatch in domain {Domain}: stored {StoredDim}, query {QueryDim}. Run 'reembed' to regenerate stored embeddings",
+                domain, a.Length, b.Length);
+            return null;
+        }
+
+        return distance.Value <= maxDistance ? candidate : null;
+    }
+
+    /// <summary>
+    /// Computes cosine distance between two vectors. Returns null if dimensions differ.
+    /// </summary>
+    internal static double? CosineDistance(float[] a, float[] b)
+    {
+        if (a.Length != b.Length)
+            return null;
+
         double dot = 0, normA = 0, normB = 0;
         for (var i = 0; i < a.Length; i++)
         {
@@ -145,8 +166,6 @@ public class ExpertiseRepository(ExpertiseDbContext db) : IExpertiseRepository
             normA += a[i] * (double)a[i];
             normB += b[i] * (double)b[i];
         }
-        var distance = 1.0 - dot / (Math.Sqrt(normA) * Math.Sqrt(normB));
-
-        return distance <= maxDistance ? candidate : null;
+        return 1.0 - dot / (Math.Sqrt(normA) * Math.Sqrt(normB));
     }
 }

--- a/src/ExpertiseApi/ExpertiseApi.csproj
+++ b/src/ExpertiseApi/ExpertiseApi.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="ExpertiseApi.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -32,7 +32,10 @@ var baseDir = AppContext.BaseDirectory;
 var modelPath = builder.Configuration["Onnx:ModelPath"] ?? Path.Combine(baseDir, "models", "model.onnx");
 var vocabPath = builder.Configuration["Onnx:VocabPath"] ?? Path.Combine(baseDir, "models", "vocab.txt");
 
-builder.Services.AddBertOnnxEmbeddingGenerator(modelPath, vocabPath);
+if (File.Exists(modelPath) && File.Exists(vocabPath))
+{
+    builder.Services.AddBertOnnxEmbeddingGenerator(modelPath, vocabPath);
+}
 builder.Services.AddScoped<EmbeddingService>();
 
 builder.Services.Configure<DeduplicationOptions>(
@@ -72,3 +75,5 @@ app.MapSearchEndpoints();
 app.MapSemanticSearchEndpoints();
 
 app.Run();
+
+public partial class Program;

--- a/tests/ExpertiseApi.Tests/ExpertiseApi.Tests.csproj
+++ b/tests/ExpertiseApi.Tests/ExpertiseApi.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <NoWarn>SKEXP0070</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.*" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.*" />
+    <PackageReference Include="NSubstitute" Version="5.*" />
+    <PackageReference Include="FluentAssertions" Version="7.*" />
+    <PackageReference Include="xunit" Version="2.9.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.*">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="coverlet.collector" Version="6.*">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ExpertiseApi\ExpertiseApi.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/ExpertiseApi.Tests/GlobalUsings.cs
+++ b/tests/ExpertiseApi.Tests/GlobalUsings.cs
@@ -1,0 +1,2 @@
+global using Xunit;
+global using Microsoft.EntityFrameworkCore;

--- a/tests/ExpertiseApi.Tests/Infrastructure/ApiFactory.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/ApiFactory.cs
@@ -1,0 +1,70 @@
+#pragma warning disable SKEXP0070
+
+using ExpertiseApi.Data;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Pgvector;
+
+namespace ExpertiseApi.Tests.Infrastructure;
+
+public class ApiFactory : WebApplicationFactory<Program>
+{
+    private readonly string _connectionString;
+
+    public ApiFactory(string connectionString)
+    {
+        _connectionString = connectionString;
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            // Replace DbContext with test container connection
+            var dbDescriptor = services.SingleOrDefault(
+                d => d.ServiceType == typeof(DbContextOptions<ExpertiseDbContext>));
+            if (dbDescriptor is not null)
+                services.Remove(dbDescriptor);
+
+            services.AddDbContext<ExpertiseDbContext>(options =>
+                options.UseNpgsql(_connectionString, o => o.UseVector()));
+
+            // Replace ONNX embedding generator with a mock that returns 384-dim vectors.
+            // AddBertOnnxEmbeddingGenerator opens the model file at registration time,
+            // so we must remove the existing registration and substitute it.
+            var embeddingDescriptor = services.SingleOrDefault(
+                d => d.ServiceType == typeof(IEmbeddingGenerator<string, Embedding<float>>));
+            if (embeddingDescriptor is not null)
+                services.Remove(embeddingDescriptor);
+
+            var mockGenerator = Substitute.For<IEmbeddingGenerator<string, Embedding<float>>>();
+            mockGenerator.GenerateAsync(
+                    Arg.Any<IEnumerable<string>>(),
+                    Arg.Any<EmbeddingGenerationOptions?>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(callInfo =>
+                {
+                    var inputs = callInfo.ArgAt<IEnumerable<string>>(0).ToList();
+                    var embeddings = new List<GeneratedEmbeddings<Embedding<float>>>();
+                    var result = new GeneratedEmbeddings<Embedding<float>>();
+                    foreach (var _ in inputs)
+                    {
+                        var vector = new float[384];
+                        new Random(42).NextBytes(new byte[4]); // deterministic seed
+                        for (var i = 0; i < 384; i++)
+                            vector[i] = (float)(new Random(42 + i).NextDouble() * 2 - 1);
+                        result.Add(new Embedding<float>(vector));
+                    }
+                    return Task.FromResult<GeneratedEmbeddings<Embedding<float>>>(result);
+                });
+
+            services.AddSingleton(mockGenerator);
+        });
+
+        builder.UseSetting("Auth:ApiKey", TestHelpers.TestApiKey);
+    }
+}

--- a/tests/ExpertiseApi.Tests/Infrastructure/PostgresFixture.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/PostgresFixture.cs
@@ -1,0 +1,35 @@
+using ExpertiseApi.Data;
+using Microsoft.EntityFrameworkCore;
+using Testcontainers.PostgreSql;
+
+namespace ExpertiseApi.Tests.Infrastructure;
+
+public sealed class PostgresFixture : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("pgvector/pgvector:pg17")
+        .WithDatabase("expertisetest")
+        .WithUsername("test")
+        .WithPassword("test")
+        .Build();
+
+    public string ConnectionString => _container.GetConnectionString();
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+
+        var optionsBuilder = new DbContextOptionsBuilder<ExpertiseDbContext>()
+            .UseNpgsql(ConnectionString, o => o.UseVector());
+
+        await using var db = new ExpertiseDbContext(optionsBuilder.Options);
+        await db.Database.MigrateAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _container.DisposeAsync().AsTask();
+    }
+}
+
+[CollectionDefinition("Postgres")]
+public class PostgresCollection : ICollectionFixture<PostgresFixture>;

--- a/tests/ExpertiseApi.Tests/Infrastructure/TestHelpers.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/TestHelpers.cs
@@ -1,0 +1,70 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ExpertiseApi.Models;
+using Pgvector;
+
+namespace ExpertiseApi.Tests.Infrastructure;
+
+public static class TestHelpers
+{
+    public const string TestApiKey = "test-api-key-12345";
+
+    public static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public static async Task<T?> ReadJsonAsync<T>(this HttpContent content)
+        => await content.ReadFromJsonAsync<T>(JsonOptions);
+
+    public static async Task<JsonElement> ReadJsonElementAsync(this HttpContent content)
+    {
+        var stream = await content.ReadAsStreamAsync();
+        var doc = await JsonDocument.ParseAsync(stream);
+        return doc.RootElement.Clone();
+    }
+
+    public static HttpClient CreateAuthenticatedClient(ApiFactory factory)
+    {
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", TestApiKey);
+        return client;
+    }
+
+    public static HttpClient CreateUnauthenticatedClient(ApiFactory factory)
+        => factory.CreateClient();
+
+    public static ExpertiseEntry SeedEntry(
+        string domain = "shared",
+        string title = "Test entry",
+        string body = "Test body content for search indexing",
+        EntryType entryType = EntryType.Pattern,
+        Severity severity = Severity.Info,
+        string source = "test")
+    {
+        return new ExpertiseEntry
+        {
+            Domain = domain,
+            Title = title,
+            Body = body,
+            EntryType = entryType,
+            Severity = severity,
+            Source = source,
+            Tags = ["test"],
+            Embedding = CreateTestVector()
+        };
+    }
+
+    public static Vector CreateTestVector(int dimensions = 384)
+    {
+        var values = new float[dimensions];
+        var rng = new Random(42);
+        for (var i = 0; i < dimensions; i++)
+            values[i] = (float)(rng.NextDouble() * 2 - 1);
+        return new Vector(values);
+    }
+}

--- a/tests/ExpertiseApi.Tests/Integration/AuthEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/AuthEndpointTests.cs
@@ -1,0 +1,77 @@
+using System.Net;
+using System.Net.Http.Headers;
+using ExpertiseApi.Tests.Infrastructure;
+using FluentAssertions;
+
+namespace ExpertiseApi.Tests.Integration;
+
+[Collection("Postgres")]
+public class AuthEndpointTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private ApiFactory _factory = null!;
+
+    public AuthEndpointTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public Task InitializeAsync()
+    {
+        _factory = new ApiFactory(_postgres.ConnectionString);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync() => await _factory.DisposeAsync();
+
+    [Fact]
+    public async Task Health_WithNoAuth_Returns200()
+    {
+        var client = TestHelpers.CreateUnauthenticatedClient(_factory);
+        var response = await client.GetAsync("/health");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Theory]
+    [InlineData("/expertise")]
+    [InlineData("/expertise/search?q=test")]
+    public async Task ProtectedEndpoints_WithNoAuth_Return401(string path)
+    {
+        var client = TestHelpers.CreateUnauthenticatedClient(_factory);
+        var response = await client.GetAsync(path);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Theory]
+    [InlineData("/expertise")]
+    [InlineData("/expertise/search?q=test")]
+    public async Task ProtectedEndpoints_WithValidKey_Return2xx(string path)
+    {
+        var client = TestHelpers.CreateAuthenticatedClient(_factory);
+        var response = await client.GetAsync(path);
+
+        ((int)response.StatusCode).Should().BeInRange(200, 299);
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_WithWrongKey_Returns401()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", "wrong-key");
+
+        var response = await client.GetAsync("/expertise");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_WithMalformedScheme_Returns401()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("Authorization", "Basic dGVzdDp0ZXN0");
+
+        var response = await client.GetAsync("/expertise");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+}

--- a/tests/ExpertiseApi.Tests/Integration/ExpertiseEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/ExpertiseEndpointTests.cs
@@ -1,0 +1,156 @@
+using System.Net;
+using System.Text.Json;
+using ExpertiseApi.Data;
+using ExpertiseApi.Models;
+using ExpertiseApi.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ExpertiseApi.Tests.Integration;
+
+[Collection("Postgres")]
+public class ExpertiseEndpointTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private ApiFactory _factory = null!;
+    private HttpClient _client = null!;
+
+    public ExpertiseEndpointTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public async Task InitializeAsync()
+    {
+        _factory = new ApiFactory(_postgres.ConnectionString);
+        _client = TestHelpers.CreateAuthenticatedClient(_factory);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+        await db.ExpertiseEntries.ExecuteDeleteAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        _client.Dispose();
+        await _factory.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task List_WhenEmpty_ReturnsEmptyArray()
+    {
+        var response = await _client.GetAsync("/expertise");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetById_WhenNotFound_Returns404()
+    {
+        var response = await _client.GetAsync($"/expertise/{Guid.NewGuid()}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetById_WhenExists_ReturnsEntry()
+    {
+        var seeded = await SeedEntryViaRepo("dotnet", "Test entry");
+
+        var response = await _client.GetAsync($"/expertise/{seeded.Id}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetProperty("id").GetGuid().Should().Be(seeded.Id);
+        json.GetProperty("title").GetString().Should().Be("Test entry");
+    }
+
+    [Fact]
+    public async Task List_WithDomainFilter_ReturnsOnlyMatchingDomain()
+    {
+        await SeedEntryViaRepo("dotnet", "DotNet entry");
+        await SeedEntryViaRepo("kubernetes", "K8s entry");
+
+        var response = await _client.GetAsync("/expertise?domain=dotnet");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetArrayLength().Should().Be(1);
+        json[0].GetProperty("domain").GetString().Should().Be("dotnet");
+    }
+
+    [Fact]
+    public async Task List_WithEntryTypeFilter_ReturnsOnlyMatchingType()
+    {
+        await SeedEntryViaRepo("shared", "Pattern entry", entryType: EntryType.Pattern);
+        await SeedEntryViaRepo("shared", "Caveat entry", entryType: EntryType.Caveat);
+
+        var response = await _client.GetAsync("/expertise?entryType=Caveat");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetArrayLength().Should().Be(1);
+        json[0].GetProperty("entryType").GetString().Should().Be("Caveat");
+    }
+
+    [Fact]
+    public async Task List_ExcludesDeprecatedByDefault()
+    {
+        var entry = await SeedEntryViaRepo("shared", "Active entry");
+        var deprecated = await SeedEntryViaRepo("shared", "Deprecated entry");
+
+        using var scope = _factory.Services.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IExpertiseRepository>();
+        await repo.SoftDeleteAsync(deprecated.Id);
+
+        var response = await _client.GetAsync("/expertise");
+
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetArrayLength().Should().Be(1);
+        json[0].GetProperty("id").GetGuid().Should().Be(entry.Id);
+    }
+
+    [Fact]
+    public async Task List_IncludesDeprecatedWhenRequested()
+    {
+        await SeedEntryViaRepo("shared", "Active entry");
+        var deprecated = await SeedEntryViaRepo("shared", "Deprecated entry");
+
+        using var scope = _factory.Services.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IExpertiseRepository>();
+        await repo.SoftDeleteAsync(deprecated.Id);
+
+        var response = await _client.GetAsync("/expertise?includeDeprecated=true");
+
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetArrayLength().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Delete_WhenExists_Returns204()
+    {
+        var entry = await SeedEntryViaRepo("shared", "To delete");
+
+        var response = await _client.DeleteAsync($"/expertise/{entry.Id}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task Delete_WhenNotFound_Returns404()
+    {
+        var response = await _client.DeleteAsync($"/expertise/{Guid.NewGuid()}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    private async Task<ExpertiseEntry> SeedEntryViaRepo(
+        string domain = "shared",
+        string title = "Test",
+        EntryType entryType = EntryType.Pattern)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IExpertiseRepository>();
+        return await repo.CreateAsync(
+            TestHelpers.SeedEntry(domain: domain, title: title, entryType: entryType));
+    }
+}

--- a/tests/ExpertiseApi.Tests/Integration/HealthEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/HealthEndpointTests.cs
@@ -1,0 +1,36 @@
+using System.Net;
+using System.Net.Http.Json;
+using ExpertiseApi.Tests.Infrastructure;
+using FluentAssertions;
+
+namespace ExpertiseApi.Tests.Integration;
+
+[Collection("Postgres")]
+public class HealthEndpointTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private ApiFactory _factory = null!;
+
+    public HealthEndpointTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public Task InitializeAsync()
+    {
+        _factory = new ApiFactory(_postgres.ConnectionString);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync() => await _factory.DisposeAsync();
+
+    [Fact]
+    public async Task Health_ReturnsHealthyStatus()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync("/health");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadJsonAsync<Dictionary<string, string>>();
+        body.Should().ContainKey("status");
+        body!["status"].Should().Be("healthy");
+    }
+}

--- a/tests/ExpertiseApi.Tests/Integration/SearchEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/SearchEndpointTests.cs
@@ -1,0 +1,128 @@
+using System.Net;
+using System.Text.Json;
+using ExpertiseApi.Data;
+using ExpertiseApi.Models;
+using ExpertiseApi.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ExpertiseApi.Tests.Integration;
+
+[Collection("Postgres")]
+public class SearchEndpointTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private ApiFactory _factory = null!;
+    private HttpClient _client = null!;
+
+    public SearchEndpointTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public async Task InitializeAsync()
+    {
+        _factory = new ApiFactory(_postgres.ConnectionString);
+        _client = TestHelpers.CreateAuthenticatedClient(_factory);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+        await db.ExpertiseEntries.ExecuteDeleteAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        _client.Dispose();
+        await _factory.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task KeywordSearch_WhenEmptyQuery_Returns400()
+    {
+        var response = await _client.GetAsync("/expertise/search?q=");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task KeywordSearch_WhenMissingQuery_ReturnsError()
+    {
+        // When 'q' is completely absent, ASP.NET Core binding fails before the handler runs.
+        // This produces a 500 rather than a clean 400 — a known gap (see #28 for similar issue).
+        var response = await _client.GetAsync("/expertise/search");
+
+        ((int)response.StatusCode).Should().BeOneOf(400, 500);
+    }
+
+    [Fact]
+    public async Task KeywordSearch_ReturnsMatchingEntries()
+    {
+        await SeedEntryViaRepo("dotnet", "EF Core migration conflict resolution",
+            "When running migrations against a shared database, conflicts can arise.");
+        await SeedEntryViaRepo("kubernetes", "Pod scheduling strategy",
+            "Kubernetes pod scheduling uses taints and tolerations.");
+
+        var response = await _client.GetAsync("/expertise/search?q=migration");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetArrayLength().Should().BeGreaterThan(0);
+        json[0].GetProperty("domain").GetString().Should().Be("dotnet");
+    }
+
+    [Fact]
+    public async Task KeywordSearch_ExcludesDeprecatedByDefault()
+    {
+        var active = await SeedEntryViaRepo("shared", "Active migration guide",
+            "Database migration best practices.");
+        var deprecated = await SeedEntryViaRepo("shared", "Old migration guide",
+            "Deprecated migration approach.");
+
+        using var scope = _factory.Services.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IExpertiseRepository>();
+        await repo.SoftDeleteAsync(deprecated.Id);
+
+        var response = await _client.GetAsync("/expertise/search?q=migration");
+
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetArrayLength().Should().Be(1);
+        json[0].GetProperty("id").GetGuid().Should().Be(active.Id);
+    }
+
+    [Fact]
+    public async Task KeywordSearch_IncludesDeprecatedWhenRequested()
+    {
+        await SeedEntryViaRepo("shared", "Active migration guide",
+            "Database migration best practices.");
+        var deprecated = await SeedEntryViaRepo("shared", "Old migration guide",
+            "Deprecated migration approach.");
+
+        using var scope = _factory.Services.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IExpertiseRepository>();
+        await repo.SoftDeleteAsync(deprecated.Id);
+
+        var response = await _client.GetAsync("/expertise/search?q=migration&includeDeprecated=true");
+
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetArrayLength().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task KeywordSearch_NoResults_ReturnsEmptyArray()
+    {
+        await SeedEntryViaRepo("shared", "Unrelated entry", "Nothing about the search term.");
+
+        var response = await _client.GetAsync("/expertise/search?q=xyznonexistent");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetArrayLength().Should().Be(0);
+    }
+
+    private async Task<ExpertiseEntry> SeedEntryViaRepo(
+        string domain,
+        string title,
+        string body = "Default test body content")
+    {
+        using var scope = _factory.Services.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IExpertiseRepository>();
+        return await repo.CreateAsync(TestHelpers.SeedEntry(domain: domain, title: title, body: body));
+    }
+}

--- a/tests/ExpertiseApi.Tests/Unit/ApiKeyAuthHandlerTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/ApiKeyAuthHandlerTests.cs
@@ -1,0 +1,46 @@
+using System.Security.Cryptography;
+using System.Text;
+using FluentAssertions;
+
+namespace ExpertiseApi.Tests.Unit;
+
+public class ApiKeyAuthHandlerTests
+{
+    [Fact]
+    public void FixedTimeEquals_WithMatchingKeys_ReturnsTrue()
+    {
+        var key = "test-api-key-12345";
+        var expectedHash = SHA256.HashData(Encoding.UTF8.GetBytes(key));
+        var providedHash = SHA256.HashData(Encoding.UTF8.GetBytes(key));
+
+        CryptographicOperations.FixedTimeEquals(expectedHash, providedHash).Should().BeTrue();
+    }
+
+    [Fact]
+    public void FixedTimeEquals_WithDifferentKeys_ReturnsFalse()
+    {
+        var expectedHash = SHA256.HashData(Encoding.UTF8.GetBytes("correct-key"));
+        var providedHash = SHA256.HashData(Encoding.UTF8.GetBytes("wrong-key"));
+
+        CryptographicOperations.FixedTimeEquals(expectedHash, providedHash).Should().BeFalse();
+    }
+
+    [Fact]
+    public void FixedTimeEquals_WithDifferentLengthKeys_ReturnsFalse()
+    {
+        var expectedHash = SHA256.HashData(Encoding.UTF8.GetBytes("short"));
+        var providedHash = SHA256.HashData(Encoding.UTF8.GetBytes("a-much-longer-key-value"));
+
+        CryptographicOperations.FixedTimeEquals(expectedHash, providedHash).Should().BeFalse();
+    }
+
+    [Fact]
+    public void SHA256HashData_AlwaysProduces32Bytes()
+    {
+        var hash1 = SHA256.HashData(Encoding.UTF8.GetBytes("short"));
+        var hash2 = SHA256.HashData(Encoding.UTF8.GetBytes("a-much-longer-key"));
+
+        hash1.Length.Should().Be(32);
+        hash2.Length.Should().Be(32);
+    }
+}

--- a/tests/ExpertiseApi.Tests/Unit/CosineDistanceTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/CosineDistanceTests.cs
@@ -1,0 +1,60 @@
+using FluentAssertions;
+
+namespace ExpertiseApi.Tests.Unit;
+
+public class CosineDistanceTests
+{
+    private static double ComputeCosineDistance(float[] a, float[] b)
+    {
+        double dot = 0, normA = 0, normB = 0;
+        for (var i = 0; i < a.Length; i++)
+        {
+            dot += a[i] * (double)b[i];
+            normA += a[i] * (double)a[i];
+            normB += b[i] * (double)b[i];
+        }
+        return 1.0 - dot / (Math.Sqrt(normA) * Math.Sqrt(normB));
+    }
+
+    [Fact]
+    public void IdenticalVectors_ShouldHaveZeroDistance()
+    {
+        var v = new float[] { 1.0f, 0.0f, 0.0f };
+        ComputeCosineDistance(v, v).Should().BeApproximately(0.0, 1e-10);
+    }
+
+    [Fact]
+    public void OrthogonalVectors_ShouldHaveDistanceOne()
+    {
+        var a = new float[] { 1.0f, 0.0f };
+        var b = new float[] { 0.0f, 1.0f };
+        ComputeCosineDistance(a, b).Should().BeApproximately(1.0, 1e-10);
+    }
+
+    [Fact]
+    public void OppositeVectors_ShouldHaveDistanceTwo()
+    {
+        var a = new float[] { 1.0f, 0.0f };
+        var b = new float[] { -1.0f, 0.0f };
+        ComputeCosineDistance(a, b).Should().BeApproximately(2.0, 1e-10);
+    }
+
+    [Fact]
+    public void SimilarVectors_ShouldHaveSmallDistance()
+    {
+        var a = new float[] { 1.0f, 0.1f, 0.0f };
+        var b = new float[] { 1.0f, 0.2f, 0.0f };
+        var distance = ComputeCosineDistance(a, b);
+        distance.Should().BeGreaterThan(0.0);
+        distance.Should().BeLessThan(0.05);
+    }
+
+    [Fact]
+    public void ZeroVector_ShouldProduceNaN()
+    {
+        var a = new float[] { 1.0f, 0.0f };
+        var b = new float[] { 0.0f, 0.0f };
+        var distance = ComputeCosineDistance(a, b);
+        double.IsNaN(distance).Should().BeTrue();
+    }
+}

--- a/tests/ExpertiseApi.Tests/Unit/CosineDistanceTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/CosineDistanceTests.cs
@@ -1,26 +1,15 @@
+using ExpertiseApi.Data;
 using FluentAssertions;
 
 namespace ExpertiseApi.Tests.Unit;
 
 public class CosineDistanceTests
 {
-    private static double ComputeCosineDistance(float[] a, float[] b)
-    {
-        double dot = 0, normA = 0, normB = 0;
-        for (var i = 0; i < a.Length; i++)
-        {
-            dot += a[i] * (double)b[i];
-            normA += a[i] * (double)a[i];
-            normB += b[i] * (double)b[i];
-        }
-        return 1.0 - dot / (Math.Sqrt(normA) * Math.Sqrt(normB));
-    }
-
     [Fact]
     public void IdenticalVectors_ShouldHaveZeroDistance()
     {
         var v = new float[] { 1.0f, 0.0f, 0.0f };
-        ComputeCosineDistance(v, v).Should().BeApproximately(0.0, 1e-10);
+        ExpertiseRepository.CosineDistance(v, v).Should().BeApproximately(0.0, 1e-10);
     }
 
     [Fact]
@@ -28,7 +17,7 @@ public class CosineDistanceTests
     {
         var a = new float[] { 1.0f, 0.0f };
         var b = new float[] { 0.0f, 1.0f };
-        ComputeCosineDistance(a, b).Should().BeApproximately(1.0, 1e-10);
+        ExpertiseRepository.CosineDistance(a, b).Should().BeApproximately(1.0, 1e-10);
     }
 
     [Fact]
@@ -36,7 +25,7 @@ public class CosineDistanceTests
     {
         var a = new float[] { 1.0f, 0.0f };
         var b = new float[] { -1.0f, 0.0f };
-        ComputeCosineDistance(a, b).Should().BeApproximately(2.0, 1e-10);
+        ExpertiseRepository.CosineDistance(a, b).Should().BeApproximately(2.0, 1e-10);
     }
 
     [Fact]
@@ -44,9 +33,10 @@ public class CosineDistanceTests
     {
         var a = new float[] { 1.0f, 0.1f, 0.0f };
         var b = new float[] { 1.0f, 0.2f, 0.0f };
-        var distance = ComputeCosineDistance(a, b);
-        distance.Should().BeGreaterThan(0.0);
-        distance.Should().BeLessThan(0.05);
+        var distance = ExpertiseRepository.CosineDistance(a, b);
+        distance.Should().NotBeNull();
+        distance!.Value.Should().BeGreaterThan(0.0);
+        distance.Value.Should().BeLessThan(0.05);
     }
 
     [Fact]
@@ -54,7 +44,41 @@ public class CosineDistanceTests
     {
         var a = new float[] { 1.0f, 0.0f };
         var b = new float[] { 0.0f, 0.0f };
-        var distance = ComputeCosineDistance(a, b);
-        double.IsNaN(distance).Should().BeTrue();
+        var distance = ExpertiseRepository.CosineDistance(a, b);
+        distance.Should().NotBeNull();
+        double.IsNaN(distance!.Value).Should().BeTrue();
+    }
+
+    [Fact]
+    public void MismatchedDimensions_StoredShorter_ShouldReturnNull()
+    {
+        var stored = new float[] { 1.0f, 0.5f };
+        var query = new float[] { 1.0f, 0.5f, 0.3f };
+        ExpertiseRepository.CosineDistance(stored, query).Should().BeNull();
+    }
+
+    [Fact]
+    public void MismatchedDimensions_StoredLonger_ShouldReturnNull()
+    {
+        var stored = new float[] { 1.0f, 0.5f, 0.3f };
+        var query = new float[] { 1.0f, 0.5f };
+        ExpertiseRepository.CosineDistance(stored, query).Should().BeNull();
+    }
+
+    [Fact]
+    public void MatchingDimensions_384dim_ShouldReturnValidDistance()
+    {
+        var a = new float[384];
+        var b = new float[384];
+        var rng = new Random(42);
+        for (var i = 0; i < 384; i++)
+        {
+            a[i] = (float)(rng.NextDouble() * 2 - 1);
+            b[i] = (float)(rng.NextDouble() * 2 - 1);
+        }
+
+        var distance = ExpertiseRepository.CosineDistance(a, b);
+        distance.Should().NotBeNull();
+        distance!.Value.Should().BeInRange(0.0, 2.0);
     }
 }

--- a/tests/ExpertiseApi.Tests/Unit/DeduplicationServiceTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/DeduplicationServiceTests.cs
@@ -1,0 +1,115 @@
+using ExpertiseApi.Data;
+using ExpertiseApi.Endpoints;
+using ExpertiseApi.Models;
+using ExpertiseApi.Services;
+using ExpertiseApi.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Pgvector;
+
+namespace ExpertiseApi.Tests.Unit;
+
+public class DeduplicationServiceTests
+{
+    private readonly IExpertiseRepository _repo = Substitute.For<IExpertiseRepository>();
+    private readonly Vector _testVector = TestHelpers.CreateTestVector();
+
+    private DeduplicationService CreateService(bool enabled = true, double threshold = 0.10)
+    {
+        var options = Options.Create(new DeduplicationOptions
+        {
+            Enabled = enabled,
+            SemanticThreshold = threshold
+        });
+        return new DeduplicationService(_repo, options);
+    }
+
+    private static CreateExpertiseRequest CreateRequest(
+        string domain = "shared",
+        string title = "Test",
+        string body = "Test body") =>
+        new(domain, title, body, EntryType.Pattern, Severity.Info, "test");
+
+    [Fact]
+    public async Task CheckAsync_WhenDisabled_ReturnsNotDuplicate()
+    {
+        var service = CreateService(enabled: false);
+        var request = CreateRequest();
+
+        var (isDuplicate, existing) = await service.CheckAsync(request, _testVector);
+
+        isDuplicate.Should().BeFalse();
+        existing.Should().BeNull();
+        await _repo.DidNotReceive().FindExactMatchAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CheckAsync_WhenExactMatchWithSameBody_ReturnsDuplicate()
+    {
+        var service = CreateService();
+        var request = CreateRequest(body: "Exact body");
+        var existingEntry = TestHelpers.SeedEntry(body: "Exact body");
+
+        _repo.FindExactMatchAsync("shared", "Test", Arg.Any<CancellationToken>())
+            .Returns(existingEntry);
+
+        var (isDuplicate, existing) = await service.CheckAsync(request, _testVector);
+
+        isDuplicate.Should().BeTrue();
+        existing.Should().Be(existingEntry);
+    }
+
+    [Fact]
+    public async Task CheckAsync_WhenExactMatchWithDifferentBody_FallsToSemanticCheck()
+    {
+        var service = CreateService();
+        var request = CreateRequest(body: "New body");
+        var existingEntry = TestHelpers.SeedEntry(body: "Different body");
+
+        _repo.FindExactMatchAsync("shared", "Test", Arg.Any<CancellationToken>())
+            .Returns(existingEntry);
+        _repo.FindNearestInDomainAsync("shared", _testVector, 0.10, Arg.Any<CancellationToken>())
+            .Returns((ExpertiseEntry?)null);
+
+        var (isDuplicate, _) = await service.CheckAsync(request, _testVector);
+
+        isDuplicate.Should().BeFalse();
+        await _repo.Received(1).FindNearestInDomainAsync("shared", _testVector, 0.10, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CheckAsync_WhenSemanticMatchBelowThreshold_ReturnsDuplicate()
+    {
+        var service = CreateService();
+        var request = CreateRequest();
+        var nearEntry = TestHelpers.SeedEntry(title: "Similar entry");
+
+        _repo.FindExactMatchAsync("shared", "Test", Arg.Any<CancellationToken>())
+            .Returns((ExpertiseEntry?)null);
+        _repo.FindNearestInDomainAsync("shared", _testVector, 0.10, Arg.Any<CancellationToken>())
+            .Returns(nearEntry);
+
+        var (isDuplicate, existing) = await service.CheckAsync(request, _testVector);
+
+        isDuplicate.Should().BeTrue();
+        existing.Should().Be(nearEntry);
+    }
+
+    [Fact]
+    public async Task CheckAsync_WhenNoMatch_ReturnsNotDuplicate()
+    {
+        var service = CreateService();
+        var request = CreateRequest();
+
+        _repo.FindExactMatchAsync("shared", "Test", Arg.Any<CancellationToken>())
+            .Returns((ExpertiseEntry?)null);
+        _repo.FindNearestInDomainAsync("shared", _testVector, 0.10, Arg.Any<CancellationToken>())
+            .Returns((ExpertiseEntry?)null);
+
+        var (isDuplicate, existing) = await service.CheckAsync(request, _testVector);
+
+        isDuplicate.Should().BeFalse();
+        existing.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Release promotion from `dev` to `main`.

Commits since v0.1.0:
- ci(release): wire semantic-release into release workflow (#27)
- test: add test suite with unit and integration tests (#33)
- fix: harden embedding pipeline — dimension guard and container security (#34)

**Merge method: merge commit** (preserves shared SHAs per GitHub Flow conventions).

semantic-release will analyze these commits and determine the version bump automatically.