### PR TITLE
feat: add observability stack — Serilog, Prometheus metrics, auth failure logging

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,14 +16,15 @@
 
 ## Test Plan
 
-- [ ] Local build passes (`dotnet build`)
-- [ ] Linter clean on changed files
-- [ ] API health check passes after local run
-- [ ] Relevant endpoint(s) tested via curl or Scalar UI
+- [ ] `dotnet test` passes locally (requires Docker for integration tests)
+- [ ] New features and bug fixes include tests
+- [ ] Helm render tests pass (if chart changed): `bash helm/expertise-api/tests/test-render.sh`
+- [ ] Relevant endpoint(s) manually verified via curl or Scalar UI (for API changes)
 
 ## Checklist
 
 - [ ] No secrets or credentials committed
+- [ ] Linter clean on changed files
 - [ ] Database migrations are reversible (if applicable)
 - [ ] API changes are backward-compatible (if applicable)
 - [ ] CLAUDE.md updated (if commands, endpoints, or workflow changed)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@ Self-hosted .NET 10 REST API for storing and serving expertise entries consumed 
 - **EF Core** for data access (repository pattern via `IExpertiseRepository`)
 - **PgBouncer 1.21+** sidecar for connection pooling (transaction mode)
 - **In-process ONNX** embeddings via `Microsoft.SemanticKernel.Connectors.Onnx` (bge-micro-v2, 384-dim)
+- **Serilog** for structured logging (`Serilog.AspNetCore`)
+- **prometheus-net** for Prometheus metrics endpoint (`/metrics`)
 - **OpenAPI** docs via Scalar (`Scalar.AspNetCore`)
 - **Docker Compose** for local dev; **Helm** chart for k8s deployment
 
@@ -37,6 +39,9 @@ dotnet run --project src/ExpertiseApi/ExpertiseApi.csproj
 # EF Core migrations
 dotnet ef migrations add <MigrationName> --project src/ExpertiseApi
 dotnet ef database update --project src/ExpertiseApi
+
+# Run tests (requires Docker for integration tests)
+dotnet test ExpertiseApi.slnx
 
 # Docker Compose local dev stack (database only)
 docker compose -f deploy/local/docker-compose.yml up postgres pgbouncer
@@ -124,7 +129,7 @@ AI agents (Claude Code, GitHub Copilot) consume this API via HTTP with a bearer 
 2. **Create** a new entry when discovering a fix, caveat, or pattern: `POST /expertise`
 3. **Update** an entry when information changes: `PATCH /expertise/{id}`
 
-All endpoints except `/health` and `/query` require `Authorization: Bearer <api-key>`.
+All endpoints except `/health`, `/query`, and `/metrics` require `Authorization: Bearer <api-key>`.
 
 ## CI/CD
 
@@ -135,6 +140,55 @@ All endpoints except `/health` and `/query` require `Authorization: Bearer <api-
 | `lint-pr-title.yml` | PR to dev | Validates PR title follows Conventional Commits format |
 
 GHCR image: `ghcr.io/thesemicolon/agent-expertise-api` (multi-arch: amd64 + arm64).
+
+## Testing
+
+### Test Prerequisites
+
+- **Docker** must be running — integration tests use [Testcontainers](https://dotnet.testcontainers.org/) to spin up a PostgreSQL + pgvector instance per test run.
+- Unit tests run without Docker.
+
+### Commands
+
+```bash
+# Run all tests (unit + integration)
+dotnet test ExpertiseApi.slnx
+
+# Run unit tests only (no Docker required)
+dotnet test ExpertiseApi.slnx --filter "FullyQualifiedName~Unit"
+
+# Run integration tests only
+dotnet test ExpertiseApi.slnx --filter "FullyQualifiedName~Integration"
+
+# Helm chart render tests
+bash helm/expertise-api/tests/test-render.sh
+```
+
+### Test Project Structure
+
+```text
+tests/ExpertiseApi.Tests/
+  Infrastructure/     # Test fixtures, ApiFactory, helpers
+  Unit/               # Fast tests, no external dependencies
+  Integration/        # Full-stack tests via WebApplicationFactory + Testcontainers
+```
+
+### Framework Stack
+
+| Component | Package | Purpose |
+|-----------|---------|---------|
+| Test framework | xUnit | Test runner and assertions |
+| Assertions | FluentAssertions | Readable assertion syntax |
+| Mocking | NSubstitute | Interface mocking (embedding generator, etc.) |
+| Database | Testcontainers.PostgreSql | Disposable PostgreSQL + pgvector container |
+| HTTP testing | Microsoft.AspNetCore.Mvc.Testing | `WebApplicationFactory` for integration tests |
+| Log assertions | Microsoft.Extensions.Diagnostics.Testing | `FakeLogCollector` for verifying log output |
+
+### Test Expectations
+
+- **New features and bug fixes must include tests.** Unit tests for logic, integration tests for endpoint behavior.
+- **Helm chart changes** should be validated with the render test script.
+- CI runs `dotnet test` on every PR and push to `dev`.
 
 ## Architecture & Design
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ flowchart LR
 | GET | `/expertise/search?q=` | Keyword full-text search (tsvector) |
 | GET | `/expertise/search/semantic?q=` | Semantic vector search (pgvector) |
 | GET | `/health` | Liveness probe (no auth required) |
+| GET | `/metrics` | Prometheus scrape endpoint (no auth required) |
 | GET | `/query` | Interactive query page (read-only, no auth to load) |
 
-All endpoints except `/health` and `/query` require `Authorization: Bearer <api-key>`. See [SKILL.md](.claude/skills/expertise-api-design/SKILL.md) for scopes and optional parameters.
+All endpoints except `/health`, `/query`, and `/metrics` require `Authorization: Bearer <api-key>`. See [SKILL.md](.claude/skills/expertise-api-design/SKILL.md) for scopes and optional parameters.
 
 ## Quick Start
 
@@ -95,6 +96,20 @@ Docker images are published to GHCR on every push to `main`:
 ghcr.io/thesemicolon/agent-expertise-api:latest
 ghcr.io/thesemicolon/agent-expertise-api:<short-sha>
 ```
+
+## Testing
+
+The test suite uses xUnit, FluentAssertions, NSubstitute, and [Testcontainers](https://dotnet.testcontainers.org/) (PostgreSQL + pgvector). **Docker must be running** for integration tests.
+
+```bash
+# Run all tests
+dotnet test ExpertiseApi.slnx
+
+# Helm chart render tests
+bash helm/expertise-api/tests/test-render.sh
+```
+
+New features and bug fixes should include tests. See [CLAUDE.md](CLAUDE.md) for test project structure and filtering commands.
 
 ## Documentation
 

--- a/helm/expertise-api/templates/service.yaml
+++ b/helm/expertise-api/templates/service.yaml
@@ -8,7 +8,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: {{ .Values.service.port }}
+    - name: http
+      port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
   selector:

--- a/helm/expertise-api/templates/servicemonitor.yaml
+++ b/helm/expertise-api/templates/servicemonitor.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "expertise-api.fullname" . }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "expertise-api.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "expertise-api.apiSelectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/helm/expertise-api/tests/test-render.sh
+++ b/helm/expertise-api/tests/test-render.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# test-render.sh — Helm template render assertions for expertise-api chart
+#
+# Usage: bash helm/expertise-api/tests/test-render.sh
+# Exit codes: 0 = all checks passed, 1 = one or more errors, 2 = missing prerequisite
+
+set -euo pipefail
+
+CHART="$(cd "$(dirname "$0")/.." && pwd)"
+ERRORS=0
+WARNINGS=0
+
+ok()    { echo "OK    [$1] $2"; }
+skip()  { echo "SKIP  [$1] $2"; }
+warn()  { echo "WARN  [$1] $2"; WARNINGS=$((WARNINGS + 1)); }
+err()   { echo "ERROR [$1] $2" >&2; ERRORS=$((ERRORS + 1)); }
+
+if ! command -v helm &>/dev/null; then
+    echo "ERROR [prereq] helm not found in PATH" >&2
+    exit 2
+fi
+
+# 1. ServiceMonitor present when metrics.enabled=true
+output=$(helm template test-release "$CHART" --set metrics.enabled=true 2>&1)
+if echo "$output" | grep -q "kind: ServiceMonitor"; then
+    ok "sm-enabled" "ServiceMonitor renders when metrics.enabled=true"
+else
+    err "sm-enabled" "ServiceMonitor missing when metrics.enabled=true"
+fi
+
+# 2. ServiceMonitor absent when metrics.enabled=false (default)
+output=$(helm template test-release "$CHART" 2>&1)
+if ! echo "$output" | grep -q "kind: ServiceMonitor"; then
+    ok "sm-disabled" "ServiceMonitor absent when metrics.enabled=false"
+else
+    err "sm-disabled" "ServiceMonitor present when metrics.enabled=false"
+fi
+
+# 3. Service port has name 'http'
+output=$(helm template test-release "$CHART" 2>&1)
+if echo "$output" | grep -q "name: http"; then
+    ok "port-name" "Service port name is 'http'"
+else
+    err "port-name" "Service port name 'http' not found"
+fi
+
+# 4. ServiceMonitor references port 'http'
+output=$(helm template test-release "$CHART" --set metrics.enabled=true 2>&1)
+if echo "$output" | grep -q "port: http"; then
+    ok "sm-port-ref" "ServiceMonitor references port 'http'"
+else
+    err "sm-port-ref" "ServiceMonitor does not reference port 'http'"
+fi
+
+# 5. ServiceMonitor scrapes /metrics path
+if echo "$output" | grep -q "path: /metrics"; then
+    ok "sm-path" "ServiceMonitor scrapes /metrics path"
+else
+    err "sm-path" "ServiceMonitor /metrics path not found"
+fi
+
+echo "=================================="
+if [ "$ERRORS" -eq 0 ]; then
+    echo "PASS — 0 errors, $WARNINGS warning(s)"
+    exit 0
+else
+    echo "FAIL — $ERRORS error(s), $WARNINGS warning(s)"
+    exit 1
+fi

--- a/helm/expertise-api/values.yaml
+++ b/helm/expertise-api/values.yaml
@@ -53,6 +53,14 @@ pgbouncer:
       cpu: 200m
       memory: 128Mi
 
+metrics:
+  enabled: false
+  serviceMonitor:
+    namespace: ""
+    interval: 30s
+    scrapeTimeout: 10s
+    labels: {}
+
 backup:
   enabled: true
   schedule: "0 2 * * *"

--- a/src/ExpertiseApi/Auth/ApiKeyAuthHandler.cs
+++ b/src/ExpertiseApi/Auth/ApiKeyAuthHandler.cs
@@ -20,20 +20,32 @@ public class ApiKeyAuthHandler(
     {
         var expectedKey = configuration["Auth:ApiKey"];
         if (string.IsNullOrEmpty(expectedKey))
+        {
+            Logger.LogWarning("Authentication failed: {Reason}", "API key not configured on server");
             return Task.FromResult(AuthenticateResult.Fail("API key not configured"));
+        }
 
         if (!Request.Headers.TryGetValue("Authorization", out var authHeader))
+        {
+            Logger.LogWarning("Authentication failed: {Reason}", "missing Authorization header");
             return Task.FromResult(AuthenticateResult.Fail("Missing Authorization header"));
+        }
 
         var header = authHeader.ToString();
         if (!header.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+        {
+            Logger.LogWarning("Authentication failed: {Reason}", "invalid Authorization scheme");
             return Task.FromResult(AuthenticateResult.Fail("Invalid Authorization scheme"));
+        }
 
         var providedKey = header["Bearer ".Length..].Trim();
         var expectedHash = SHA256.HashData(Encoding.UTF8.GetBytes(expectedKey));
         var providedHash = SHA256.HashData(Encoding.UTF8.GetBytes(providedKey));
         if (!CryptographicOperations.FixedTimeEquals(expectedHash, providedHash))
+        {
+            Logger.LogWarning("Authentication failed: {Reason}", "invalid API key");
             return Task.FromResult(AuthenticateResult.Fail("Invalid API key"));
+        }
 
         var claims = new[]
         {

--- a/src/ExpertiseApi/ExpertiseApi.csproj
+++ b/src/ExpertiseApi/ExpertiseApi.csproj
@@ -19,7 +19,10 @@
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.Onnx" Version="1.74.0-alpha" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageReference Include="Pgvector.EntityFrameworkCore" Version="0.3.0" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.13.14" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -7,10 +7,20 @@ using ExpertiseApi.Endpoints;
 using ExpertiseApi.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.SemanticKernel;
+using Prometheus;
+using Serilog;
 using System.Text.Json.Serialization;
 using Scalar.AspNetCore;
 
+Log.Logger = new LoggerConfiguration()
+    .WriteTo.Console()
+    .CreateBootstrapLogger();
+
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Host.UseSerilog((context, services, config) =>
+    config.ReadFrom.Configuration(context.Configuration)
+          .ReadFrom.Services(services));
 
 builder.Services.AddOpenApi();
 builder.Services.AddProblemDetails();
@@ -52,6 +62,8 @@ if (ReembedCommand.IsReembedRequested(args))
 
 app.UseExceptionHandler();
 app.UseStatusCodePages();
+app.UseHttpMetrics();
+app.UseSerilogRequestLogging();
 
 app.UseStaticFiles();
 
@@ -73,7 +85,10 @@ app.MapHealthEndpoints();
 app.MapExpertiseEndpoints();
 app.MapSearchEndpoints();
 app.MapSemanticSearchEndpoints();
+app.MapMetrics().AllowAnonymous();
 
-app.Run();
+try { app.Run(); }
+catch (Exception ex) { Log.Fatal(ex, "Application terminated unexpectedly"); }
+finally { Log.CloseAndFlush(); }
 
 public partial class Program;

--- a/src/ExpertiseApi/appsettings.json
+++ b/src/ExpertiseApi/appsettings.json
@@ -1,9 +1,18 @@
 {
-  "Logging": {
-    "LogLevel": {
+  "Serilog": {
+    "MinimumLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
+      "Override": {
+        "Microsoft.AspNetCore": "Warning",
+        "Microsoft.EntityFrameworkCore": "Warning",
+        "Microsoft.EntityFrameworkCore.Database.Command": "Warning",
+        "Microsoft.SemanticKernel": "Warning"
+      }
+    },
+    "Enrich": ["FromLogContext", "WithMachineName"],
+    "WriteTo": [
+      { "Name": "Console" }
+    ]
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {

--- a/tests/ExpertiseApi.Tests/ExpertiseApi.Tests.csproj
+++ b/tests/ExpertiseApi.Tests/ExpertiseApi.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.5.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.*" />
     <PackageReference Include="NSubstitute" Version="5.*" />
     <PackageReference Include="FluentAssertions" Version="7.*" />

--- a/tests/ExpertiseApi.Tests/Infrastructure/ApiFactory.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/ApiFactory.cs
@@ -8,6 +8,9 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using Pgvector;
+using Microsoft.Extensions.Logging;
+using Serilog;
+using Serilog.Extensions.Logging;
 
 namespace ExpertiseApi.Tests.Infrastructure;
 
@@ -22,6 +25,13 @@ public class ApiFactory : WebApplicationFactory<Program>
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
+        builder.ConfigureLogging(logging =>
+        {
+            logging.ClearProviders();
+            var silentLogger = new LoggerConfiguration().MinimumLevel.Fatal().CreateLogger();
+            logging.AddSerilog(silentLogger, dispose: true);
+        });
+
         builder.ConfigureServices(services =>
         {
             // Replace DbContext with test container connection

--- a/tests/ExpertiseApi.Tests/Integration/MetricsEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/MetricsEndpointTests.cs
@@ -1,0 +1,43 @@
+using System.Net;
+using ExpertiseApi.Tests.Infrastructure;
+using FluentAssertions;
+
+namespace ExpertiseApi.Tests.Integration;
+
+[Collection("Postgres")]
+public class MetricsEndpointTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private ApiFactory _factory = null!;
+
+    public MetricsEndpointTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public Task InitializeAsync()
+    {
+        _factory = new ApiFactory(_postgres.ConnectionString);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync() => await _factory.DisposeAsync();
+
+    [Fact]
+    public async Task Metrics_WithNoAuth_Returns200()
+    {
+        var client = TestHelpers.CreateUnauthenticatedClient(_factory);
+        var response = await client.GetAsync("/metrics");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Metrics_ReturnsPrometheusFormat()
+    {
+        var client = TestHelpers.CreateUnauthenticatedClient(_factory);
+        var response = await client.GetAsync("/metrics");
+
+        response.Content.Headers.ContentType!.MediaType.Should().StartWith("text/plain");
+
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("http_request_duration_seconds");
+    }
+}

--- a/tests/ExpertiseApi.Tests/Unit/ApiKeyAuthHandlerLoggingTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/ApiKeyAuthHandlerLoggingTests.cs
@@ -1,0 +1,124 @@
+using System.Text.Encodings.Web;
+using ExpertiseApi.Auth;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace ExpertiseApi.Tests.Unit;
+
+public class ApiKeyAuthHandlerLoggingTests
+{
+    private static (ApiKeyAuthHandler handler, FakeLogCollector collector) BuildHandler(
+        string? configuredKey = "test-key",
+        Action<HttpContext>? configureContext = null)
+    {
+        var options = Substitute.For<IOptionsMonitor<AuthenticationSchemeOptions>>();
+        options.Get(Arg.Any<string>()).Returns(new AuthenticationSchemeOptions());
+        options.CurrentValue.Returns(new AuthenticationSchemeOptions());
+
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.AddFakeLogging());
+        var sp = services.BuildServiceProvider();
+        var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+        var collector = sp.GetRequiredService<FakeLogCollector>();
+
+        var configEntries = configuredKey is not null
+            ? new Dictionary<string, string?> { ["Auth:ApiKey"] = configuredKey }
+            : new Dictionary<string, string?>();
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(configEntries)
+            .Build();
+
+        var handler = new ApiKeyAuthHandler(options, loggerFactory, UrlEncoder.Default, config);
+
+        var context = new DefaultHttpContext();
+        configureContext?.Invoke(context);
+
+        var scheme = new AuthenticationScheme(
+            ApiKeyAuthHandler.SchemeName,
+            displayName: null,
+            typeof(ApiKeyAuthHandler));
+
+        handler.InitializeAsync(scheme, context).GetAwaiter().GetResult();
+
+        return (handler, collector);
+    }
+
+    [Fact]
+    public async Task HandleAuthenticate_WhenApiKeyNotConfigured_LogsWarning()
+    {
+        var (handler, collector) = BuildHandler(configuredKey: null);
+
+        var result = await handler.AuthenticateAsync();
+
+        result.Succeeded.Should().BeFalse();
+        var logs = collector.GetSnapshot();
+        logs.Should().ContainSingle(r =>
+            r.Level == LogLevel.Warning &&
+            r.Message.Contains("API key not configured on server"));
+    }
+
+    [Fact]
+    public async Task HandleAuthenticate_WhenMissingAuthHeader_LogsWarning()
+    {
+        var (handler, collector) = BuildHandler();
+
+        var result = await handler.AuthenticateAsync();
+
+        result.Succeeded.Should().BeFalse();
+        var logs = collector.GetSnapshot();
+        logs.Should().ContainSingle(r =>
+            r.Level == LogLevel.Warning &&
+            r.Message.Contains("missing Authorization header"));
+    }
+
+    [Fact]
+    public async Task HandleAuthenticate_WhenInvalidScheme_LogsWarning()
+    {
+        var (handler, collector) = BuildHandler(configureContext: ctx =>
+            ctx.Request.Headers.Authorization = "Basic dGVzdDp0ZXN0");
+
+        var result = await handler.AuthenticateAsync();
+
+        result.Succeeded.Should().BeFalse();
+        var logs = collector.GetSnapshot();
+        logs.Should().ContainSingle(r =>
+            r.Level == LogLevel.Warning &&
+            r.Message.Contains("invalid Authorization scheme"));
+    }
+
+    [Fact]
+    public async Task HandleAuthenticate_WhenInvalidKey_LogsWarning()
+    {
+        var (handler, collector) = BuildHandler(configureContext: ctx =>
+            ctx.Request.Headers.Authorization = "Bearer wrong-key");
+
+        var result = await handler.AuthenticateAsync();
+
+        result.Succeeded.Should().BeFalse();
+        var logs = collector.GetSnapshot();
+        logs.Should().ContainSingle(r =>
+            r.Level == LogLevel.Warning &&
+            r.Message.Contains("invalid API key"));
+    }
+
+    [Fact]
+    public async Task HandleAuthenticate_WhenValidKey_DoesNotLogWarning()
+    {
+        var (handler, collector) = BuildHandler(configureContext: ctx =>
+            ctx.Request.Headers.Authorization = "Bearer test-key");
+
+        var result = await handler.AuthenticateAsync();
+
+        result.Succeeded.Should().BeTrue();
+        var logs = collector.GetSnapshot();
+        logs.Should().NotContain(r => r.Level == LogLevel.Warning);
+    }
+}


### PR DESCRIPTION
## Summary

Adds the foundational observability stack: Serilog structured logging replacing the default Microsoft.Extensions.Logging provider, a prometheus-net `/metrics` scrape endpoint with default HTTP request metrics, and structured auth failure logging on all four `ApiKeyAuthHandler` failure paths. Includes Helm ServiceMonitor support (gated behind `metrics.enabled`) and full test coverage for all new functionality.

Closes #17, #18, #30

## Type of Change

- [x] `feat` — new feature

## Changes

### Serilog (#17)
- `Serilog.AspNetCore` 10.0.0 with bootstrap logger for startup crash capture
- `ReadFrom.Configuration()` with EF Core, SemanticKernel, and ASP.NET Core log level overrides to suppress pgvector SQL noise
- `UseSerilogRequestLogging()` for structured per-request HTTP logs
- try/catch/finally around `app.Run()` for clean shutdown flush

### Prometheus Metrics (#18)
- `prometheus-net.AspNetCore` 8.2.1 with `UseHttpMetrics()` and `MapMetrics().AllowAnonymous()`
- Middleware ordered after `UseExceptionHandler()` to capture correct status codes
- Helm ServiceMonitor CRD template gated behind `metrics.enabled`
- Service port named `http` (required by ServiceMonitor port reference)

### Auth Failure Logging (#30)
- `Logger.LogWarning` on all 4 failure paths in `ApiKeyAuthHandler`
- Uses inherited `Logger` property from `AuthenticationHandler<T>` (idiomatic .NET 10)
- Never logs the provided key value — only the failure reason

### Tests
- **MetricsEndpointTests** (2 integration tests): `/metrics` returns 200 without auth, response contains Prometheus format with `http_request_duration_seconds`
- **ApiKeyAuthHandlerLoggingTests** (5 unit tests): verifies `LogWarning` on all 4 failure paths + no warning on success, using `FakeLogCollector` from `Microsoft.Extensions.Diagnostics.Testing`
- **Helm render tests** (5 assertions): ServiceMonitor renders/absent based on `metrics.enabled`, port name, port ref, scrape path

### Documentation
- CLAUDE.md: Testing section, Tech Stack updated, `/metrics` in auth note, `dotnet test` in Build & Run
- README.md: `/metrics` in API Surface table, Testing section, auth note updated
- PR template: Test Plan checklist updated for automated test suite

## Test plan

- [x] `dotnet test` passes locally — 47/47 tests pass (40 existing + 7 new)
- [x] Helm render tests pass: `bash helm/expertise-api/tests/test-render.sh` — 5/5 assertions
- [x] Lint clean: markdownlint, yamllint, dotnet format, helm lint all pass
- [x] New features include tests (MetricsEndpointTests, ApiKeyAuthHandlerLoggingTests, test-render.sh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)