### PR TITLE
fix: remaining PR #37 review items (exit code, metrics gate, serilog dev config)

### DIFF
--- a/src/ExpertiseApi/Data/ExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/ExpertiseRepository.cs
@@ -129,7 +129,7 @@ public class ExpertiseRepository(ExpertiseDbContext db, ILogger<ExpertiseReposit
         return await db.ExpertiseEntries
             .Where(e => e.DeprecatedAt == null)
             .Where(e => e.Domain == domain)
-            .Where(e => lowerTitles.Contains(e.Title.ToLower()))
+            .Where(e => lowerTitles.Contains(e.Title.ToLowerInvariant()))
             .ToListAsync(ct);
     }
 

--- a/src/ExpertiseApi/Migrations/20260416062516_AddTitleLowerIndex.cs
+++ b/src/ExpertiseApi/Migrations/20260416062516_AddTitleLowerIndex.cs
@@ -10,23 +10,19 @@ namespace ExpertiseApi.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.Sql(
-                """
-                CREATE INDEX CONCURRENTLY "IX_ExpertiseEntries_TitleLower"
+            migrationBuilder.Sql("""
+                CREATE INDEX "IX_ExpertiseEntries_TitleLower"
                     ON "ExpertiseEntries" (LOWER("Title"))
                     WHERE "DeprecatedAt" IS NULL;
-                """,
-                suppressTransaction: true);
+                """);
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.Sql(
-                """
-                DROP INDEX CONCURRENTLY IF EXISTS "IX_ExpertiseEntries_TitleLower";
-                """,
-                suppressTransaction: true);
+            migrationBuilder.Sql("""
+                DROP INDEX IF EXISTS "IX_ExpertiseEntries_TitleLower";
+                """);
         }
     }
 }

--- a/src/ExpertiseApi/Migrations/20260416062516_AddTitleLowerIndex.cs
+++ b/src/ExpertiseApi/Migrations/20260416062516_AddTitleLowerIndex.cs
@@ -10,19 +10,23 @@ namespace ExpertiseApi.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.Sql("""
-                CREATE INDEX "IX_ExpertiseEntries_TitleLower"
+            migrationBuilder.Sql(
+                """
+                CREATE INDEX CONCURRENTLY "IX_ExpertiseEntries_TitleLower"
                     ON "ExpertiseEntries" (LOWER("Title"))
                     WHERE "DeprecatedAt" IS NULL;
-                """);
+                """,
+                suppressTransaction: true);
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.Sql("""
-                DROP INDEX IF EXISTS "IX_ExpertiseEntries_TitleLower";
-                """);
+            migrationBuilder.Sql(
+                """
+                DROP INDEX CONCURRENTLY IF EXISTS "IX_ExpertiseEntries_TitleLower";
+                """,
+                suppressTransaction: true);
         }
     }
 }

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -62,7 +62,9 @@ if (ReembedCommand.IsReembedRequested(args))
 
 app.UseExceptionHandler();
 app.UseStatusCodePages();
-app.UseHttpMetrics();
+var metricsEnabled = app.Configuration.GetValue<bool>("Metrics:Enabled", true);
+if (metricsEnabled)
+    app.UseHttpMetrics();
 app.UseSerilogRequestLogging();
 
 app.UseStaticFiles();
@@ -85,10 +87,15 @@ app.MapHealthEndpoints();
 app.MapExpertiseEndpoints();
 app.MapSearchEndpoints();
 app.MapSemanticSearchEndpoints();
-app.MapMetrics().AllowAnonymous();
+if (metricsEnabled)
+    app.MapMetrics().AllowAnonymous();
 
 try { app.Run(); }
-catch (Exception ex) { Log.Fatal(ex, "Application terminated unexpectedly"); }
+catch (Exception ex)
+{
+    Log.Fatal(ex, "Application terminated unexpectedly");
+    Environment.ExitCode = 1;
+}
 finally { Log.CloseAndFlush(); }
 
 public partial class Program;

--- a/src/ExpertiseApi/appsettings.Development.json
+++ b/src/ExpertiseApi/appsettings.Development.json
@@ -1,8 +1,10 @@
 {
-  "Logging": {
-    "LogLevel": {
+  "Serilog": {
+    "MinimumLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Override": {
+        "Microsoft.AspNetCore": "Warning"
+      }
     }
   },
   "Auth": {

--- a/src/ExpertiseApi/appsettings.json
+++ b/src/ExpertiseApi/appsettings.json
@@ -25,5 +25,8 @@
   "Deduplication": {
     "Enabled": true,
     "SemanticThreshold": 0.10
+  },
+  "Metrics": {
+    "Enabled": true
   }
 }

--- a/tests/ExpertiseApi.Tests/Unit/DeduplicationServiceTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/DeduplicationServiceTests.cs
@@ -175,6 +175,57 @@ public class DeduplicationServiceTests
     }
 
     [Fact]
+    public async Task CheckBatchAsync_WithSemanticMatch_ReturnsDuplicate()
+    {
+        var service = CreateService();
+        var requests = new List<CreateExpertiseRequest> { CreateRequest(title: "Unique Title") };
+        var vectors = new List<Vector> { _testVector };
+
+        // No exact title match — entry title differs
+        var domainEntry = TestHelpers.SeedEntry(title: "Similar But Different Title");
+        // Use the same vector so cosine distance == 0, well below the 0.10 threshold
+        domainEntry.Embedding = _testVector;
+
+        _repo.FindExactMatchesAsync("shared", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns(new List<ExpertiseEntry>());
+        _repo.FindAllEmbeddingsInDomainAsync("shared", Arg.Any<CancellationToken>())
+            .Returns([domainEntry]);
+
+        var results = await service.CheckBatchAsync(requests, vectors);
+
+        results.Should().HaveCount(1);
+        results[0].IsDuplicate.Should().BeTrue();
+        results[0].Existing.Should().Be(domainEntry);
+    }
+
+    [Fact]
+    public async Task CheckBatchAsync_WithSemanticMatchAboveThreshold_ReturnsNotDuplicate()
+    {
+        var service = CreateService(threshold: 0.01); // very tight threshold
+        var requests = new List<CreateExpertiseRequest> { CreateRequest(title: "Unique Title") };
+
+        // Build a vector that is orthogonal to _testVector (cosine distance == 1)
+        var orthogonalValues = new float[384];
+        orthogonalValues[0] = 1.0f; // all other dims zero — orthogonal to random _testVector
+        var farVector = new Vector(orthogonalValues);
+
+        var vectors = new List<Vector> { farVector };
+
+        var domainEntry = TestHelpers.SeedEntry(title: "Similar But Different Title");
+        domainEntry.Embedding = _testVector; // very different direction
+
+        _repo.FindExactMatchesAsync("shared", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns(new List<ExpertiseEntry>());
+        _repo.FindAllEmbeddingsInDomainAsync("shared", Arg.Any<CancellationToken>())
+            .Returns([domainEntry]);
+
+        var results = await service.CheckBatchAsync(requests, vectors);
+
+        results.Should().HaveCount(1);
+        results[0].IsDuplicate.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task CheckBatchAsync_WithMixedResults_ReturnsCorrectPerItem()
     {
         var service = CreateService();


### PR DESCRIPTION
## Summary

Rescues review-comment items from PR #37 that were left orphaned when PR
#38 merged a different subset of fixes. Branch was originally pushed by
the Copilot agent and never opened as a PR.

The original orphan commit also retrofitted `CREATE INDEX CONCURRENTLY`
onto the `AddTitleLowerIndex` migration. That change was reverted in
21b3221 — see the commit message for rationale. Future index migrations
should use `CONCURRENTLY` as a convention.

## Type of Change

- [x] `fix` — bug fix

## Changes

- **`Program.cs`** — set `Environment.ExitCode = 1` on fatal exception so
  the process exits non-zero on crash; gate `UseHttpMetrics()` and
  `MapMetrics()` behind a `Metrics:Enabled` config flag.
- **`appsettings.json`** — add `Metrics: { Enabled: true }` default.
- **`appsettings.Development.json`** — switch from `Logging:LogLevel` to
  `Serilog:MinimumLevel` schema. The project uses Serilog so the prior
  `Logging:LogLevel` block was being ignored in development.
- **`ExpertiseRepository.cs:132`** — `ToLower()` → `ToLowerInvariant()`
  for culture-safe lowercasing in dedup title matching.
- **`DeduplicationServiceTests.cs`** — adds two batch semantic dedup
  tests covering match-found and threshold-tight cases.

## Test Plan

- [ ] `dotnet test` passes locally
- [x] New tests included for batch semantic dedup
- [x] No migration changes — historical migration preserved

## Checklist

- [x] No secrets or credentials committed
- [ ] Linter clean on changed files
- [x] Database migrations are reversible (no migration changes)
- [x] API changes are backward-compatible (no API changes)
- [x] CLAUDE.md updated (no command/endpoint/workflow changes — N/A)

## Notes

- Branch is 1 commit behind \`dev\` (the unrelated Dockerfile chown fix
  from #41); merges cleanly without rebase.