### PR TITLE
docs: add tenancy, multi-IdP OIDC, and scope-split ADRs

### DIFF
--- a/adrs/001-tenancy-model.md
+++ b/adrs/001-tenancy-model.md
@@ -1,0 +1,49 @@
+# Single-store tenancy with row-level tenant column and RBAC
+
+- Status: accepted
+- Date: 2026-04-28
+
+## Context and Problem Statement
+
+The expertise API today has a single keyspace shared by every authenticated client. With ASI06 (agent-written entries auto-injected into every other agent's context with no human in the loop), one client's writes silently influence every other client's read path. There is no isolation between teams, no notion of "shared" versus "private" expertise, and no way to scope a search to one team's data without losing the cross-cutting expertise that genuinely benefits everyone.
+
+How should the API isolate expertise between consumers (teams, agents, individuals) while still allowing deliberate sharing of cross-cutting knowledge?
+
+## Considered Options
+
+- Per-tenant database instance (one Postgres database per consumer)
+- Per-tenant schema in a single database (one schema per consumer)
+- Single store with a row-level `Tenant` column, RBAC by tenant claim, and `shared` as a first-class tenant value
+- Single store with PostgreSQL row-level security (RLS) policies enforced in the database
+
+## Decision Outcome
+
+Chosen option: **single store with a row-level `Tenant` column and RBAC by tenant claim**, with `shared` modelled as a first-class tenant value rather than a separate flag.
+
+Reasons:
+
+- One database, one set of migrations, one connection pool. Operationally simple at the scale the API targets.
+- The HNSW vector index stays unified, so semantic search remains efficient across tenant + shared data when the caller is permitted to read both.
+- `shared` as a tenant value makes the read filter explicit and uniform: every read uses `WHERE tenant IN (caller_tenant, 'shared') AND review_state = 'Approved'`. There is no special-case branch in the query path.
+- RLS in the database (option 4) duplicates the policy in two places (app code and Postgres policies) and is hard to reason about under PgBouncer transaction-mode pooling, which loses session state between transactions.
+- Per-tenant deployments (options 1 and 2) trade operational simplicity for stronger isolation that the threat model does not require — the tenants here are cooperating teams sharing the same trust boundary, not adversarial customers.
+
+The trade-off — that a tenant-filter bug becomes a cross-tenant data leak — is mitigated with belt-and-braces:
+
+1. Every `IExpertiseRepository` method is required to take a `TenantContext` argument. The `WHERE` clause is constructed from `TenantContext`, never from request input.
+2. EF Core global query filter on `ExpertiseEntry.Tenant` as a defense-in-depth fallback, **not** the primary safeguard (filters can be silently bypassed with `IgnoreQueryFilters()`).
+3. An architectural test fails the build if anything outside the `Data/` and `Cli/` namespaces takes `ExpertiseDbContext` as a constructor dependency.
+4. Cross-tenant reads return **404, not 403** — never leak the existence of an entry the caller is not permitted to see.
+
+### Consequences
+
+- Good, because operational footprint stays small (one DB, one backup, one Helm chart, one migration history).
+- Good, because shared-knowledge entries remain searchable from every tenant's read path without query duplication.
+- Good, because adding a new tenant is a configuration change (group → tenant mapping in the IdP config block), not a deployment.
+- Bad, because a single bug in tenant filtering can leak data across tenants. Mitigated by the four belt-and-braces measures above.
+- Bad, because all tenants share the same blast radius for outages and bad migrations. Acceptable given the trust model and team scale.
+
+## Related
+
+- ADR-002 (multi-IdP OIDC) — defines how the `Tenant` claim is derived from group membership at each issuer.
+- ADR-003 (four-scope split) — defines which scopes can write `Tenant = 'shared'` versus a caller's own tenant.

--- a/adrs/002-multi-idp-oidc.md
+++ b/adrs/002-multi-idp-oidc.md
@@ -1,0 +1,53 @@
+# Multi-issuer OIDC via JwtBearerOptions.ValidIssuers allowlist
+
+- Status: accepted
+- Date: 2026-04-28
+
+## Context and Problem Statement
+
+The API needs to authenticate callers from two distinct identity providers without forking the codebase: Microsoft Entra ID for the business deployment and Authentik for the homelab/personal deployment. Authentik is being stood up in parallel on the same VPS as the API and will issue tokens for personal agents, CI runners, and humans operating in the homelab. The two IdPs use different audience values, different group-claim shapes, and emit different `iss` strings.
+
+The previous static API key handler is also a dead end for production: it has no scope differentiation, no per-principal rate limiting, no audit identity, and is the structural enabler of the ASI06 vulnerability documented in ADR-003. It must be replaced with proper OIDC validation before the API is exposed to any deployment that isn't a developer's laptop.
+
+How should a single codebase validate JWTs from multiple issuers, map issuer-specific group claims to a consistent `Tenant` value, and stay configurable without code changes when a new tenant or a new issuer is added?
+
+## Considered Options
+
+- Two separate API deployments, each with single-issuer `AddJwtBearer`
+- Single deployment with `JwtBearerOptions.ValidIssuers` allowlist plus a per-issuer config block (audience, group-to-tenant mapping, scope claim name)
+- Custom `AuthenticationHandler<>` that hand-rolls multi-issuer JWT validation with a per-issuer JWKS cache
+- Federate the two IdPs through a third broker (e.g., Keycloak) so the API only sees one issuer
+
+## Decision Outcome
+
+Chosen option: **single deployment with `JwtBearerOptions.ValidIssuers` allowlist and a per-issuer config block.**
+
+Concretely, `appsettings` carries an `Auth:Oidc:Issuers[]` array. Each entry specifies the issuer URL, the expected audience, the scope-claim name (Entra uses `scp`, Authentik uses `scope`), and a `GroupToTenantMapping` table. At startup the API registers `AddJwtBearer` once with `ValidIssuers` populated from the array; on each request, after the framework validates `iss`, `aud`, and signature, a custom token-validated handler looks up the matching issuer entry, walks the principal's group claims through that issuer's mapping, and attaches a `TenantContext { Tenant, Principal, Agent?, Scopes[] }` to `HttpContext.Features`.
+
+Reasons:
+
+- Native ASP.NET Core support. `JwtBearerOptions.ValidIssuers` was added specifically for this scenario. JWKS discovery and caching is handled by `IConfigurationManager<OpenIdConnectConfiguration>` per issuer, refreshed automatically.
+- Two deployments (option 1) means two release pipelines, two test matrices, and two opportunities for drift between Entra-shaped and Authentik-shaped behaviour. The actual delta is config, not code.
+- A custom handler (option 3) discards the framework's well-tested token validation, JWKS rotation handling, and clock-skew defaults. No upside.
+- A federation broker (option 4) adds a runtime dependency, a second hop, and a single point of failure for both deployments. The API would gain nothing it can't get from `ValidIssuers`.
+
+A startup guard hard-fails when `Auth:Mode != "Oidc"` and `ASPNETCORE_ENVIRONMENT != "Development"`. `LocalDev`, `ApiKey`, and `Hybrid` modes exist exclusively to keep developer workflows working during the cutover and are statically prohibited in any non-Development environment.
+
+### Trailing-slash gotcha
+
+Authentik's discovery document includes a trailing slash on the issuer URL (e.g. `https://auth.example.com/application/o/expertise-api/`) and Authentik tokens emit the matching `iss` claim. Entra omits the trailing slash on `https://login.microsoftonline.com/{tenant-id}/v2.0`. `iss` validation is byte-exact. The `Auth:Oidc:Issuers[*].Issuer` value must be copy-pasted from each issuer's `.well-known/openid-configuration` and never normalized.
+
+### Consequences
+
+- Good, because one binary, one Docker image, one Helm chart serves both deployments. Per-deployment differences are values overlays.
+- Good, because adding a third issuer (e.g. a future federated partner) is a config change, not a code change.
+- Good, because per-issuer `GroupToTenantMapping` keeps the IdP-specific group naming out of the application code — the application only ever sees a normalized `Tenant` string.
+- Good, because `expertise.write.approve` and `expertise.admin` scopes are issued by the IdP, so revoking them is an IdP operation, not an API redeploy.
+- Bad, because misconfigured `Issuer` strings (trailing-slash mismatch, wrong tenant ID, copy-paste error) fail with confusing validation errors that look like signature problems. Mitigated by integration tests that mint tokens with the configured issuer values and assert success.
+- Bad, because the operator now needs to understand both Entra group object IDs and Authentik group slugs to extend the mapping. Mitigated by ADR-001's tenant-as-config-string design and clear `appsettings` examples.
+- Bad, because two IdPs means twice the credential rotation and policy drift surface. Acceptable given the deployment topology — the homelab needs Authentik anyway for other services.
+
+## Related
+
+- ADR-001 (tenancy model) — `Tenant` is the value populated from each issuer's `GroupToTenantMapping`.
+- ADR-003 (four-scope split) — scope claim names differ between Entra (`scp`) and Authentik (`scope`); the per-issuer config selects the right one.

--- a/adrs/003-scope-split.md
+++ b/adrs/003-scope-split.md
@@ -1,0 +1,62 @@
+# Four-scope split with Draft/Approved review state for ASI06 mitigation
+
+- Status: accepted
+- Date: 2026-04-28
+
+## Context and Problem Statement
+
+The expertise API today issues two scopes: `expertise.read` and `expertise.write`. Every authenticated client receives both, and every successful `POST` immediately produces an entry that is auto-injected into every other agent's pre-flight context. A single compromised agent token — or a single agent that hallucinates a confident-sounding "fix" — propagates to every consumer's read path with no human in the loop. This is the ASI06 (autonomous self-injection) vulnerability: agents can rewrite the shared context that drives every other agent's behaviour, and the writer's identity, the writer's tenant, and the writer's intent are all asserted by the writer.
+
+In addition, the binary write scope makes it impossible to distinguish "an agent recording a candidate observation" from "a curator promoting that observation to canonical knowledge." Without that distinction, every agent write lands at the highest trust tier by default.
+
+How should the API gate writes so that compromised or hallucinating agents cannot escalate into a global injection vector, while still preserving low-friction draft submission as the agent's primary contribution path?
+
+## Considered Options
+
+- Keep two scopes; mitigate via an out-of-band review queue (current state, depends on framework-side enforcement)
+- Split write into `expertise.write.draft` and `expertise.write.approve`, with a separate `expertise.admin` for cross-tenant operations and audit access
+- Remove agent write entirely; only humans submit entries
+- Per-entry signed approvals via a separate signing key, in addition to OIDC scopes
+
+## Decision Outcome
+
+Chosen option: **four-scope split** — `expertise.read`, `expertise.write.draft`, `expertise.write.approve`, `expertise.admin` — combined with a `ReviewState` enum (`Draft | Approved | Rejected`) on every entry.
+
+Scope semantics:
+
+| Scope | Permits |
+|-------|---------|
+| `expertise.read` | All `GET` endpoints. Reads are always filtered to `Tenant IN (caller, 'shared') AND ReviewState = 'Approved'` unless `?includeDrafts=true` is passed and the caller also has `write.approve`. |
+| `expertise.write.draft` | `POST`, `PATCH` on caller's own tenant only. `ReviewState` is forced to `Draft`. `Tenant` is forced to the caller's tenant. `Visibility` is forced to `Private`. The caller cannot override these by sending them in the request body. |
+| `expertise.write.approve` | Everything `write.draft` permits, plus: setting `ReviewState = 'Approved'` directly on `POST`, calling `POST /expertise/{id}/approve` and `/reject`, setting `Tenant = 'shared'`, setting `Visibility = 'Shared'`, and editing Approved entries (which transitions them back to `Draft` for non-approvers, but stays `Approved` for approvers). |
+| `expertise.admin` | Everything `write.approve` permits, plus: `GET /audit`, soft-delete on shared entries, and tenant reassignment. |
+
+Scope expansion is **policy-side, not token-side**: a token carrying `expertise.admin` is treated as if it also carries `approve`, `draft`, and `read`. This keeps IdP configuration simple — operators issue exactly one scope per role — and centralizes the expansion logic in the authorization handler.
+
+Reasons:
+
+- Option 1 (status quo) depends on the framework's pre-flight queue and curator agent for enforcement. That enforcement lives outside the API's trust boundary; anything that bypasses the framework (e.g., a direct `curl` from a compromised agent token) lands directly in the canonical store. The API must enforce its own gate.
+- Option 3 (humans only) breaks the agent self-improvement workflow entirely. The API exists specifically to capture agent-discovered fixes; removing agent write defeats the purpose.
+- Option 4 (signed approvals) is overkill for the threat model. The blast radius is "an agent's hallucination becomes shared context," not "a malicious actor publishes signed lies." A scope-and-state model handles the realistic case at a fraction of the operational complexity (no signing key distribution, no signature verification path).
+- Option 2 makes the trust boundary explicit at the API surface: a compromised `write.draft` token can dirty the caller's own tenant draft pile but cannot reach any other agent. A human or curator with `write.approve` then triages drafts before they enter the canonical read path.
+
+`AuthorPrincipal` is always set from the token's `sub` claim, never from request body. `ReviewedBy` is always set from the token of the principal calling `/approve` or `/reject`. `IntegrityHash` is recomputed on every write. The audit log records `{Action, EntryId, Tenant, Principal, Agent?, BeforeHash, AfterHash}` for every state-changing operation.
+
+### Cross-tenant read returns 404, not 403
+
+A `GET /expertise/{id}` for an entry in another tenant returns 404 rather than 403, regardless of whether the entry exists. 403 leaks the existence of an entry the caller is not permitted to see; 404 does not. This applies to all read endpoints.
+
+### Consequences
+
+- Good, because a compromised agent token is now contained: drafts are visible only to approvers in the same tenant, never to other agents' read paths.
+- Good, because `Source` (self-reported by the writer) is no longer a trust signal — `AuthorPrincipal` (token-asserted) and `ReviewState` (gate-enforced) drive trust decisions.
+- Good, because the audit log gives the team a tamper-evident record of who promoted what and when, queryable via `/audit` for `expertise.admin` holders.
+- Good, because shared entries (`Tenant = 'shared'`) require an explicit `write.approve` action — drift into the shared keyspace is no longer accidental.
+- Bad, because curator workflow now requires a human-in-the-loop step for every entry that should reach canonical state. This is intentional; the framework's curator agent operates with `write.approve` scope to triage drafts on behalf of the operator. Operators must never grant `write.approve` to long-lived non-interactive service principals.
+- Bad, because the legacy `expertise.write` scope is now ambiguous and must be deprecated cleanly. The cutover plan handles this in PR 6 (production breaking change, Conventional Commits `!`).
+- Bad, because `?includeDrafts=true` adds a UI/agent path that must be tested for tenant-scoping. Approvers see drafts in their own tenant only, never drafts in other tenants — even with `expertise.admin`.
+
+## Related
+
+- ADR-001 (tenancy model) — `write.approve` is what permits writing `Tenant = 'shared'`.
+- ADR-002 (multi-IdP OIDC) — scope claim names differ per issuer (`scp` for Entra, `scope` for Authentik); the OIDC token-validated handler normalizes both into `TenantContext.Scopes`.


### PR DESCRIPTION
## Summary

Authors the three architectural decision records that ground the secure rebuild of the expertise API. These ADRs lock the design before any implementation lands. Subsequent PRs in the rebuild reference these ADRs as the authoritative source of design intent.

- **ADR-001** — single-store tenancy with row-level `Tenant` column and RBAC, `shared` as a first-class tenant value, four belt-and-braces measures (`TenantContext` arg, EF global filter, architectural test, 404-not-403 reads).
- **ADR-002** — multi-issuer OIDC via `JwtBearerOptions.ValidIssuers` allowlist accepting Microsoft Entra ID (business) and Authentik (homelab) from the same codebase. Documents the trailing-slash gotcha and the `Auth:Mode` startup guard.
- **ADR-003** — four-scope split (`expertise.read`, `expertise.write.draft`, `expertise.write.approve`, `expertise.admin`) with policy-side scope expansion and a `ReviewState` enum (`Draft | Approved | Rejected`) to mitigate ASI06.

## Type of Change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [x] `docs` — documentation only
- [ ] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [ ] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change (add `!` to PR title)

## Test Plan

- [x] No testable behavior changed — documentation only.
- [x] `markdownlint` clean on all three new ADR files (verified via `@linter`, 0 findings under repo's `.markdownlint.yaml`).
- [x] ADRs follow the MADR minimal template at `adrs/TEMPLATE.md` and use sequential numbering (001, 002, 003) with no gaps.
- [x] Cross-references wired in both directions (each ADR's "Related" section names the others).

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files
- [ ] Database migrations are reversible (if applicable) — N/A
- [ ] API changes are backward-compatible (if applicable) — N/A
- [ ] CLAUDE.md updated (if commands, endpoints, or workflow changed) — N/A; CLAUDE.md is updated by the implementation PRs that follow this one