### PR TITLE
feat(data-model): tenancy fields, integrity hash, and audit log table

### DIFF
--- a/.claude/skills/expertise-api-design/SKILL.md
+++ b/.claude/skills/expertise-api-design/SKILL.md
@@ -47,18 +47,54 @@ public class ExpertiseEntry
     public required string Body { get; set; }        // markdown
     public EntryType EntryType { get; set; }
     public Severity Severity { get; set; }
-    public required string Source { get; set; }      // agent id, "human", pipeline name
+    public required string Source { get; set; }      // self-reported — informational only post-rebuild
     public string? SourceVersion { get; set; }       // e.g. "EF Core 10.0.1" — staleness signal
     public Vector? Embedding { get; set; }           // pgvector vector(384), nullable until embedded
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
     public DateTime? DeprecatedAt { get; set; }      // soft delete
     public NpgsqlTsVector? SearchVector { get; set; } // stored generated tsvector column
+
+    // Secure-rebuild additions (PR 1)
+    public required string Tenant { get; set; }      // owning team; "shared" is first-class
+    public Visibility Visibility { get; set; }       // Private (default) | Shared
+    public required string AuthorPrincipal { get; set; } // OIDC sub of writer, server-set
+    public string? AuthorAgent { get; set; }         // agent name if written by an agent
+    public string? IntegrityHash { get; set; }       // SHA-256 hex; nullable until rehash CLI runs
+    public ReviewState ReviewState { get; set; }     // Draft (default) | Approved | Rejected
+    public string? ReviewedBy { get; set; }
+    public DateTime? ReviewedAt { get; set; }
+    public string? RejectionReason { get; set; }
 }
 
-public enum EntryType { IssueFix, Caveat, Requirement, Pattern }
-public enum Severity  { Info, Warning, Critical }
+public enum EntryType  { IssueFix, Caveat, Requirement, Pattern }
+public enum Severity   { Info, Warning, Critical }
+public enum Visibility { Private, Shared }
+public enum ReviewState { Draft, Approved, Rejected }
+public enum AuditAction { Created, Updated, Approved, Rejected, Deleted }
+
+public class ExpertiseAuditLog
+{
+    public Guid Id { get; set; }
+    public DateTime Timestamp { get; set; }
+    public AuditAction Action { get; set; }
+    public Guid EntryId { get; set; }                // FK to ExpertiseEntries with ON DELETE RESTRICT
+    public required string Tenant { get; set; }
+    public required string Principal { get; set; }
+    public string? Agent { get; set; }
+    public string? BeforeHash { get; set; }
+    public string? AfterHash { get; set; }
+    public string? IpAddress { get; set; }
+}
 ```
+
+Trust decisions are based on `AuthorPrincipal` (token-asserted) and `ReviewState` (gate-enforced) — `Source` is self-reported and informational only post-rebuild.
+
+`IntegrityHash` is SHA-256 over canonical JSON of `{tenant, title, body, entryType, severity}` with alphabetical key order. Computed via `IntegrityHashService.Compute`. The `rehash` CLI command backfills `IntegrityHash` for any entry with a null hash (pre-rebuild rows or rows created before the audit-write path lands).
+
+Indexes on `ExpertiseEntries`: standalone B-tree on `Tenant`; covering composite on `(Tenant, ReviewState)` `INCLUDE (Id, EntryType, Severity)`. Existing GIN on `Tags`, GIN on `SearchVector`, HNSW on `Embedding`, B-tree on `Domain` and `DeprecatedAt`, expression index on `LOWER("Title")` are unchanged.
+
+Indexes on `ExpertiseAuditLogs`: covering composite `(EntryId, Timestamp)` `INCLUDE (Action)`; composite `(Principal, Timestamp)`.
 
 Single-row `EmbeddingMetadata` table tracks model name, dimensions, and `LastReembedAt`.
 
@@ -77,7 +113,10 @@ Single-row `EmbeddingMetadata` table tracks model name, dimensions, and `LastRee
 | GET | `/health` | none | Liveness probe | |
 | GET | `/query` | none | Interactive browser UI for read-only API exploration | |
 
-CLI: `dotnet run --project src/ExpertiseApi -- reembed [--batch-size 50]`
+CLI:
+
+- `dotnet run --project src/ExpertiseApi -- reembed [--batch-size 50]` — regenerate all embeddings.
+- `dotnet run --project src/ExpertiseApi -- rehash [--batch-size 50]` — backfill `IntegrityHash` for entries with a null hash. Idempotent.
 
 ## Authentication
 
@@ -94,7 +133,7 @@ The embedding input text is constructed by `EmbeddingService.BuildInputText(titl
 
 ## Repository Structure
 
-```
+```text
 src/ExpertiseApi/
   Program.cs               # Entry point, service registration, middleware
   wwwroot/                 # Static files — query page UI
@@ -104,7 +143,7 @@ src/ExpertiseApi/
   Migrations/              # EF Core migrations (InitialCreate, AddSearchVector)
   Services/                # EmbeddingService, DeduplicationService
   Auth/                    # ApiKeyAuthHandler, AuthExtensions, AuthConstants
-  Cli/                     # ReembedCommand
+  Cli/                     # ReembedCommand, RehashCommand
   models/                  # ONNX model files (bge-micro-v2) — not committed, needed at runtime
 helm/expertise-api/        # Helm chart (shared templates, generic values)
 deploy/local/              # Docker Compose, .env.example, pgvector init script

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -3,3 +3,5 @@
 #        80 chars and compact style conflicts with aligned in the same file
 MD013: false
 MD060: false
+# MD041: first-line-heading — disabled because skill files start with YAML frontmatter
+MD041: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,10 @@ docker compose -f deploy/local/docker-compose.yml up
 
 # Regenerate all embeddings (CLI command)
 dotnet run --project src/ExpertiseApi -- reembed [--batch-size 50]
+
+# Backfill IntegrityHash for entries created before the secure-rebuild data model
+# (entries with IntegrityHash = NULL). Idempotent — only touches null rows.
+dotnet run --project src/ExpertiseApi -- rehash [--batch-size 50]
 ```
 
 ## Model Download
@@ -171,6 +175,7 @@ tests/ExpertiseApi.Tests/
   Infrastructure/     # Test fixtures, ApiFactory, helpers
   Unit/               # Fast tests, no external dependencies
   Integration/        # Full-stack tests via WebApplicationFactory + Testcontainers
+  Architecture/       # Reflection-based architectural guards (e.g. DbContext encapsulation)
 ```
 
 ### Framework Stack
@@ -190,6 +195,28 @@ tests/ExpertiseApi.Tests/
 - **Helm chart changes** should be validated with the render test script.
 - CI runs `dotnet test` on every PR and push to `dev`.
 
+## Data Model — Secure Rebuild
+
+The `ExpertiseEntry` entity carries the original content fields (`Domain`, `Tags`, `Title`, `Body`, `EntryType`, `Severity`, `Source`, `SourceVersion`, `Embedding`, `CreatedAt`, `UpdatedAt`, `DeprecatedAt`, `SearchVector`) plus the secure-rebuild additions:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `Tenant` | `string`, required, indexed | Owning team. `shared` is a first-class tenant value. Migration backfills `legacy` for pre-rebuild rows; column-level default dropped post-backfill. |
+| `Visibility` | `enum { Private, Shared }` | Stored as string. Defaults to `Private`. Setting `Shared` requires `expertise.write.approve`. |
+| `AuthorPrincipal` | `string`, required | OIDC `sub` of the writer. Server-set. Migration backfills `pre-rebuild`. |
+| `AuthorAgent` | `string?` | Agent name when written via an agent. Distinct from `AuthorPrincipal`. |
+| `IntegrityHash` | `string?` | SHA-256 hex over canonical JSON of `{tenant, title, body, entryType, severity}`. Backfilled by the `rehash` CLI. |
+| `ReviewState` | `enum { Draft, Approved, Rejected }` | Stored as string. Defaults to `Draft`. |
+| `ReviewedBy`, `ReviewedAt`, `RejectionReason` | `string?`, `DateTime?`, `string?` | Approval/rejection metadata, server-set on `/approve` or `/reject` (later PR). |
+
+Indexes added: standalone B-tree on `Tenant`; composite B-tree on `(Tenant, ReviewState)` with `INCLUDE (Id, EntryType, Severity)` covering the hot read path.
+
+A separate **`ExpertiseAuditLog`** table records every state-changing operation: `{Id, Timestamp, Action, EntryId, Tenant, Principal, Agent?, BeforeHash, AfterHash, IpAddress}`. FK to `ExpertiseEntries.Id` with `ON DELETE RESTRICT` (audit must survive entry deletion). Reads are not audited. Indexes on `(EntryId, Timestamp)` and `(Principal, Timestamp)`.
+
+The `ExpertiseDbContext` exposes both as `DbSet<>`. **`IExpertiseRepository` is the only sanctioned consumer of `ExpertiseDbContext` for entry data** — the architectural test in `tests/ExpertiseApi.Tests/Architecture/` enforces this for everything outside `Data/` and `Cli/`. CLI commands (`reembed`, `rehash`) are intentional exceptions because they need cursor-based paging the repository interface does not expose.
+
 ## Architecture & Design
 
-For data model, API surface, authentication, embedding architecture, and known gotchas, see `.claude/skills/expertise-api-design/SKILL.md` (authoritative reference). Use the `expertise-api-owner` agent for design and implementation questions.
+For API surface, authentication, embedding architecture, and known gotchas, see `.claude/skills/expertise-api-design/SKILL.md` (authoritative reference). Use the `expertise-api-owner` agent for design and implementation questions.
+
+For the secure-rebuild design rationale, see `adrs/001-tenancy-model.md`, `adrs/002-multi-idp-oidc.md`, and `adrs/003-scope-split.md`.

--- a/src/ExpertiseApi/Cli/RehashCommand.cs
+++ b/src/ExpertiseApi/Cli/RehashCommand.cs
@@ -1,0 +1,59 @@
+using ExpertiseApi.Data;
+using ExpertiseApi.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace ExpertiseApi.Cli;
+
+public static class RehashCommand
+{
+    public static bool IsRehashRequested(string[] args) =>
+        args.Length > 0 && args[0].Equals("rehash", StringComparison.OrdinalIgnoreCase);
+
+    public static async Task RunAsync(WebApplication app, string[] args)
+    {
+        using var scope = app.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+        var logger = scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Rehash");
+
+        var batchSize = GetBatchSize(args);
+        var processed = 0;
+        Guid? lastId = null;
+
+        logger.LogInformation("Starting rehash with batch size {BatchSize}", batchSize);
+
+        while (true)
+        {
+            var query = db.ExpertiseEntries
+                .Where(e => e.IntegrityHash == null)
+                .OrderBy(e => e.Id)
+                .AsQueryable();
+
+            if (lastId is not null)
+                query = query.Where(e => e.Id > lastId.Value);
+
+            var entries = await query.Take(batchSize).ToListAsync();
+            if (entries.Count == 0)
+                break;
+
+            foreach (var entry in entries)
+            {
+                entry.IntegrityHash = IntegrityHashService.Compute(entry);
+            }
+
+            await db.SaveChangesAsync();
+            lastId = entries[^1].Id;
+            processed += entries.Count;
+            logger.LogInformation("Rehashed {Processed} entries", processed);
+        }
+
+        logger.LogInformation("Rehash complete — {Processed} entries processed", processed);
+    }
+
+    private static int GetBatchSize(string[] args)
+    {
+        var idx = Array.IndexOf(args, "--batch-size");
+        if (idx >= 0 && idx + 1 < args.Length && int.TryParse(args[idx + 1], out var size))
+            return size;
+        return 50;
+    }
+}

--- a/src/ExpertiseApi/Data/ExpertiseDbContext.cs
+++ b/src/ExpertiseApi/Data/ExpertiseDbContext.cs
@@ -7,6 +7,7 @@ public class ExpertiseDbContext(DbContextOptions<ExpertiseDbContext> options) : 
 {
     public DbSet<ExpertiseEntry> ExpertiseEntries => Set<ExpertiseEntry>();
     public DbSet<EmbeddingMetadata> EmbeddingMetadata => Set<EmbeddingMetadata>();
+    public DbSet<ExpertiseAuditLog> ExpertiseAuditLogs => Set<ExpertiseAuditLog>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -42,6 +43,22 @@ public class ExpertiseDbContext(DbContextOptions<ExpertiseDbContext> options) : 
             entity.HasIndex(e => e.Domain);
             entity.HasIndex(e => e.DeprecatedAt);
 
+            entity.Property(e => e.Tenant).IsRequired();
+            entity.HasIndex(e => e.Tenant);
+
+            entity.Property(e => e.Visibility)
+                .HasConversion<string>()
+                .IsRequired();
+
+            entity.Property(e => e.AuthorPrincipal).IsRequired();
+
+            entity.Property(e => e.ReviewState)
+                .HasConversion<string>()
+                .IsRequired();
+
+            entity.HasIndex(e => new { e.Tenant, e.ReviewState })
+                .IncludeProperties(e => new { e.Id, e.EntryType, e.Severity });
+
             entity.HasGeneratedTsVectorColumn(
                 e => e.SearchVector,
                 "english",
@@ -55,6 +72,30 @@ public class ExpertiseDbContext(DbContextOptions<ExpertiseDbContext> options) : 
         {
             entity.HasKey(e => e.Id);
             entity.Property(e => e.ModelName).IsRequired();
+        });
+
+        modelBuilder.Entity<ExpertiseAuditLog>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+            entity.Property(e => e.Timestamp).HasDefaultValueSql("now()");
+
+            entity.Property(e => e.Action)
+                .HasConversion<string>()
+                .IsRequired();
+
+            entity.Property(e => e.Tenant).IsRequired();
+            entity.Property(e => e.Principal).IsRequired();
+
+            entity.HasOne<ExpertiseEntry>()
+                .WithMany()
+                .HasForeignKey(e => e.EntryId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity.HasIndex(e => new { e.EntryId, e.Timestamp })
+                .IncludeProperties(e => e.Action);
+
+            entity.HasIndex(e => new { e.Principal, e.Timestamp });
         });
     }
 }

--- a/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
@@ -248,7 +248,11 @@ public static class ExpertiseEndpoints
         Severity = request.Severity,
         Source = request.Source,
         SourceVersion = request.SourceVersion,
-        Embedding = embedding
+        Embedding = embedding,
+        // Transitional placeholders matching the migration backfill values.
+        // Replaced by TenantContext-derived values once OIDC scaffolding lands.
+        Tenant = "legacy",
+        AuthorPrincipal = "pre-rebuild"
     };
 
     private static async Task<IResult> DeleteEntry(

--- a/src/ExpertiseApi/Migrations/20260428204727_AddTenantAuditFields.Designer.cs
+++ b/src/ExpertiseApi/Migrations/20260428204727_AddTenantAuditFields.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using ExpertiseApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -14,9 +15,11 @@ using Pgvector;
 namespace ExpertiseApi.Migrations
 {
     [DbContext(typeof(ExpertiseDbContext))]
-    partial class ExpertiseDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260428204727_AddTenantAuditFields")]
+    partial class AddTenantAuditFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ExpertiseApi/Migrations/20260428204727_AddTenantAuditFields.cs
+++ b/src/ExpertiseApi/Migrations/20260428204727_AddTenantAuditFields.cs
@@ -1,0 +1,178 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ExpertiseApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTenantAuditFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AuthorAgent",
+                table: "ExpertiseEntries",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "AuthorPrincipal",
+                table: "ExpertiseEntries",
+                type: "text",
+                nullable: false,
+                defaultValue: "pre-rebuild");
+
+            migrationBuilder.AddColumn<string>(
+                name: "IntegrityHash",
+                table: "ExpertiseEntries",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "RejectionReason",
+                table: "ExpertiseEntries",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ReviewState",
+                table: "ExpertiseEntries",
+                type: "text",
+                nullable: false,
+                defaultValue: "Draft");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ReviewedAt",
+                table: "ExpertiseEntries",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ReviewedBy",
+                table: "ExpertiseEntries",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Tenant",
+                table: "ExpertiseEntries",
+                type: "text",
+                nullable: false,
+                defaultValue: "legacy");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Visibility",
+                table: "ExpertiseEntries",
+                type: "text",
+                nullable: false,
+                defaultValue: "Private");
+
+            // Drop column-level defaults for Tenant and AuthorPrincipal after backfill.
+            // New rows must supply both explicitly — preventing silent "legacy"/"pre-rebuild" writes.
+            // Visibility and ReviewState retain their defaults as secure-by-default values.
+            migrationBuilder.Sql("""ALTER TABLE "ExpertiseEntries" ALTER COLUMN "Tenant" DROP DEFAULT;""");
+            migrationBuilder.Sql("""ALTER TABLE "ExpertiseEntries" ALTER COLUMN "AuthorPrincipal" DROP DEFAULT;""");
+
+            migrationBuilder.CreateTable(
+                name: "ExpertiseAuditLogs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    Timestamp = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    Action = table.Column<string>(type: "text", nullable: false),
+                    EntryId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Tenant = table.Column<string>(type: "text", nullable: false),
+                    Principal = table.Column<string>(type: "text", nullable: false),
+                    Agent = table.Column<string>(type: "text", nullable: true),
+                    BeforeHash = table.Column<string>(type: "text", nullable: true),
+                    AfterHash = table.Column<string>(type: "text", nullable: true),
+                    IpAddress = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ExpertiseAuditLogs", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ExpertiseAuditLogs_ExpertiseEntries_EntryId",
+                        column: x => x.EntryId,
+                        principalTable: "ExpertiseEntries",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExpertiseEntries_Tenant",
+                table: "ExpertiseEntries",
+                column: "Tenant");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExpertiseEntries_Tenant_ReviewState",
+                table: "ExpertiseEntries",
+                columns: new[] { "Tenant", "ReviewState" })
+                .Annotation("Npgsql:IndexInclude", new[] { "Id", "EntryType", "Severity" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExpertiseAuditLogs_EntryId_Timestamp",
+                table: "ExpertiseAuditLogs",
+                columns: new[] { "EntryId", "Timestamp" })
+                .Annotation("Npgsql:IndexInclude", new[] { "Action" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExpertiseAuditLogs_Principal_Timestamp",
+                table: "ExpertiseAuditLogs",
+                columns: new[] { "Principal", "Timestamp" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ExpertiseAuditLogs");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ExpertiseEntries_Tenant",
+                table: "ExpertiseEntries");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ExpertiseEntries_Tenant_ReviewState",
+                table: "ExpertiseEntries");
+
+            migrationBuilder.DropColumn(
+                name: "AuthorAgent",
+                table: "ExpertiseEntries");
+
+            migrationBuilder.DropColumn(
+                name: "AuthorPrincipal",
+                table: "ExpertiseEntries");
+
+            migrationBuilder.DropColumn(
+                name: "IntegrityHash",
+                table: "ExpertiseEntries");
+
+            migrationBuilder.DropColumn(
+                name: "RejectionReason",
+                table: "ExpertiseEntries");
+
+            migrationBuilder.DropColumn(
+                name: "ReviewState",
+                table: "ExpertiseEntries");
+
+            migrationBuilder.DropColumn(
+                name: "ReviewedAt",
+                table: "ExpertiseEntries");
+
+            migrationBuilder.DropColumn(
+                name: "ReviewedBy",
+                table: "ExpertiseEntries");
+
+            migrationBuilder.DropColumn(
+                name: "Tenant",
+                table: "ExpertiseEntries");
+
+            migrationBuilder.DropColumn(
+                name: "Visibility",
+                table: "ExpertiseEntries");
+        }
+    }
+}

--- a/src/ExpertiseApi/Models/AuditAction.cs
+++ b/src/ExpertiseApi/Models/AuditAction.cs
@@ -1,0 +1,10 @@
+namespace ExpertiseApi.Models;
+
+public enum AuditAction
+{
+    Created,
+    Updated,
+    Approved,
+    Rejected,
+    Deleted
+}

--- a/src/ExpertiseApi/Models/ExpertiseAuditLog.cs
+++ b/src/ExpertiseApi/Models/ExpertiseAuditLog.cs
@@ -1,0 +1,24 @@
+namespace ExpertiseApi.Models;
+
+public class ExpertiseAuditLog
+{
+    public Guid Id { get; set; }
+
+    public DateTime Timestamp { get; set; }
+
+    public AuditAction Action { get; set; }
+
+    public Guid EntryId { get; set; }
+
+    public required string Tenant { get; set; }
+
+    public required string Principal { get; set; }
+
+    public string? Agent { get; set; }
+
+    public string? BeforeHash { get; set; }
+
+    public string? AfterHash { get; set; }
+
+    public string? IpAddress { get; set; }
+}

--- a/src/ExpertiseApi/Models/ExpertiseEntry.cs
+++ b/src/ExpertiseApi/Models/ExpertiseEntry.cs
@@ -34,4 +34,22 @@ public class ExpertiseEntry
     public DateTime? DeprecatedAt { get; set; }
 
     public NpgsqlTsVector SearchVector { get; set; } = null!;
+
+    public required string Tenant { get; set; }
+
+    public Visibility Visibility { get; set; } = Visibility.Private;
+
+    public required string AuthorPrincipal { get; set; }
+
+    public string? AuthorAgent { get; set; }
+
+    public string? IntegrityHash { get; set; }
+
+    public ReviewState ReviewState { get; set; } = ReviewState.Draft;
+
+    public string? ReviewedBy { get; set; }
+
+    public DateTime? ReviewedAt { get; set; }
+
+    public string? RejectionReason { get; set; }
 }

--- a/src/ExpertiseApi/Models/ReviewState.cs
+++ b/src/ExpertiseApi/Models/ReviewState.cs
@@ -1,0 +1,8 @@
+namespace ExpertiseApi.Models;
+
+public enum ReviewState
+{
+    Draft,
+    Approved,
+    Rejected
+}

--- a/src/ExpertiseApi/Models/Visibility.cs
+++ b/src/ExpertiseApi/Models/Visibility.cs
@@ -1,0 +1,7 @@
+namespace ExpertiseApi.Models;
+
+public enum Visibility
+{
+    Private,
+    Shared
+}

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -60,6 +60,12 @@ if (ReembedCommand.IsReembedRequested(args))
     return;
 }
 
+if (RehashCommand.IsRehashRequested(args))
+{
+    await RehashCommand.RunAsync(app, args);
+    return;
+}
+
 app.UseExceptionHandler();
 app.UseStatusCodePages();
 app.UseHttpMetrics();

--- a/src/ExpertiseApi/Services/IntegrityHashService.cs
+++ b/src/ExpertiseApi/Services/IntegrityHashService.cs
@@ -1,0 +1,35 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using ExpertiseApi.Models;
+
+namespace ExpertiseApi.Services;
+
+public static class IntegrityHashService
+{
+    public static string Compute(
+        string tenant,
+        string title,
+        string body,
+        EntryType entryType,
+        Severity severity)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            // Alphabetical key order — canonical JSON (RFC 8785-style) for stable hashes.
+            writer.WriteStartObject();
+            writer.WriteString("body", body);
+            writer.WriteString("entryType", entryType.ToString());
+            writer.WriteString("severity", severity.ToString());
+            writer.WriteString("tenant", tenant);
+            writer.WriteString("title", title);
+            writer.WriteEndObject();
+        }
+
+        var hash = SHA256.HashData(stream.ToArray());
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    public static string Compute(ExpertiseEntry entry) =>
+        Compute(entry.Tenant, entry.Title, entry.Body, entry.EntryType, entry.Severity);
+}

--- a/tests/ExpertiseApi.Tests/Architecture/DbContextEncapsulationTests.cs
+++ b/tests/ExpertiseApi.Tests/Architecture/DbContextEncapsulationTests.cs
@@ -1,0 +1,32 @@
+using ExpertiseApi.Data;
+using FluentAssertions;
+
+namespace ExpertiseApi.Tests.Architecture;
+
+public class DbContextEncapsulationTests
+{
+    [Fact]
+    public void NonRepositoryCode_ShouldNotDependOnDbContextViaConstructor()
+    {
+        // Only Data/ types may take ExpertiseDbContext as a constructor parameter.
+        // Cli/ types (e.g. ReembedCommand, RehashCommand) resolve the context via
+        // IServiceProvider directly and are intentionally exempt from this rule.
+        var assembly = typeof(ExpertiseDbContext).Assembly;
+
+        var violations = assembly.GetTypes()
+            .Where(t => t.Namespace is not null
+                        && t.Namespace.StartsWith("ExpertiseApi.")
+                        && !t.Namespace.StartsWith("ExpertiseApi.Data")
+                        && !t.Namespace.StartsWith("ExpertiseApi.Cli")
+                        && !t.Namespace.StartsWith("ExpertiseApi.Migrations"))
+            .Where(t => t.GetConstructors()
+                         .SelectMany(c => c.GetParameters())
+                         .Any(p => p.ParameterType == typeof(ExpertiseDbContext)))
+            .Select(t => t.FullName)
+            .ToList();
+
+        violations.Should().BeEmpty(
+            "only Data/ layer types may take ExpertiseDbContext as a constructor parameter; " +
+            "everything else must consume IExpertiseRepository instead");
+    }
+}

--- a/tests/ExpertiseApi.Tests/Infrastructure/TestHelpers.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/TestHelpers.cs
@@ -44,7 +44,9 @@ public static class TestHelpers
         string body = "Test body content for search indexing",
         EntryType entryType = EntryType.Pattern,
         Severity severity = Severity.Info,
-        string source = "test")
+        string source = "test",
+        string tenant = "test",
+        string authorPrincipal = "test-principal")
     {
         return new ExpertiseEntry
         {
@@ -55,7 +57,9 @@ public static class TestHelpers
             Severity = severity,
             Source = source,
             Tags = ["test"],
-            Embedding = CreateTestVector()
+            Embedding = CreateTestVector(),
+            Tenant = tenant,
+            AuthorPrincipal = authorPrincipal
         };
     }
 

--- a/tests/ExpertiseApi.Tests/Integration/MigrationReversibilityTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/MigrationReversibilityTests.cs
@@ -1,0 +1,129 @@
+using ExpertiseApi.Data;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.Extensions.DependencyInjection;
+using Testcontainers.PostgreSql;
+
+namespace ExpertiseApi.Tests.Integration;
+
+public class MigrationReversibilityTests : IAsyncLifetime
+{
+    private const string BaselineMigration = "20260416062516_AddTitleLowerIndex";
+    private const string TargetMigration = "20260428204727_AddTenantAuditFields";
+
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("pgvector/pgvector:pg17")
+        .WithDatabase("migration_reversibility")
+        .WithUsername("test")
+        .WithPassword("test")
+        .Build();
+
+    public async Task InitializeAsync() => await _container.StartAsync();
+
+    public async Task DisposeAsync() => await _container.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task AddTenantAuditFields_AppliesAndRollsBack_Cleanly()
+    {
+        await using var db = NewContext();
+        var migrator = db.GetInfrastructure().GetRequiredService<IMigrator>();
+
+        // Arrange — apply migrations up to the baseline (state before TargetMigration).
+        await migrator.MigrateAsync(BaselineMigration);
+
+        // Act — apply TargetMigration.
+        await migrator.MigrateAsync(TargetMigration);
+
+        var afterUp = await db.Database.GetAppliedMigrationsAsync();
+        afterUp.Should().Contain(TargetMigration);
+
+        // The new columns and table should exist after Up().
+        await AssertColumnsExist(db, expected: true);
+        await AssertAuditTableExists(db, expected: true);
+
+        // Act — roll back to baseline.
+        await migrator.MigrateAsync(BaselineMigration);
+
+        var afterDown = await db.Database.GetAppliedMigrationsAsync();
+        afterDown.Should().NotContain(TargetMigration);
+
+        // The new columns and table should be gone after Down().
+        await AssertColumnsExist(db, expected: false);
+        await AssertAuditTableExists(db, expected: false);
+
+        // And TargetMigration should now be reported as pending again.
+        var pending = await db.Database.GetPendingMigrationsAsync();
+        pending.Should().Contain(TargetMigration);
+    }
+
+    private ExpertiseDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<ExpertiseDbContext>()
+            .UseNpgsql(_container.GetConnectionString(), o => o.UseVector())
+            .Options;
+        return new ExpertiseDbContext(options);
+    }
+
+    private static async Task AssertColumnsExist(ExpertiseDbContext db, bool expected)
+    {
+        var newColumns = new[]
+        {
+            "Tenant", "Visibility", "AuthorPrincipal", "AuthorAgent", "IntegrityHash",
+            "ReviewState", "ReviewedBy", "ReviewedAt", "RejectionReason"
+        };
+
+        foreach (var column in newColumns)
+        {
+            var exists = await ColumnExists(db, "ExpertiseEntries", column);
+            exists.Should().Be(expected, $"column '{column}' should{(expected ? "" : " not")} exist");
+        }
+    }
+
+    private static async Task AssertAuditTableExists(ExpertiseDbContext db, bool expected)
+    {
+        var exists = await TableExists(db, "ExpertiseAuditLogs");
+        exists.Should().Be(expected, $"ExpertiseAuditLogs should{(expected ? "" : " not")} exist");
+    }
+
+    private static async Task<bool> ColumnExists(ExpertiseDbContext db, string table, string column)
+    {
+        var conn = db.Database.GetDbConnection();
+        if (conn.State != System.Data.ConnectionState.Open)
+            await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            SELECT COUNT(*)
+            FROM information_schema.columns
+            WHERE table_name = @table AND column_name = @column;
+            """;
+        AddParam(cmd, "@table", table);
+        AddParam(cmd, "@column", column);
+        var count = Convert.ToInt64(await cmd.ExecuteScalarAsync());
+        return count > 0;
+    }
+
+    private static async Task<bool> TableExists(ExpertiseDbContext db, string table)
+    {
+        var conn = db.Database.GetDbConnection();
+        if (conn.State != System.Data.ConnectionState.Open)
+            await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            SELECT COUNT(*) FROM information_schema.tables WHERE table_name = @table;
+            """;
+        AddParam(cmd, "@table", table);
+        var count = Convert.ToInt64(await cmd.ExecuteScalarAsync());
+        return count > 0;
+    }
+
+    private static void AddParam(System.Data.Common.DbCommand cmd, string name, string value)
+    {
+        var p = cmd.CreateParameter();
+        p.ParameterName = name;
+        p.Value = value;
+        cmd.Parameters.Add(p);
+    }
+}

--- a/tests/ExpertiseApi.Tests/Unit/IntegrityHashServiceTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/IntegrityHashServiceTests.cs
@@ -1,0 +1,135 @@
+using ExpertiseApi.Models;
+using ExpertiseApi.Services;
+using FluentAssertions;
+
+namespace ExpertiseApi.Tests.Unit;
+
+public class IntegrityHashServiceTests
+{
+    [Fact]
+    public void Compute_IsLowercaseHex_64Chars()
+    {
+        var hash = IntegrityHashService.Compute(
+            tenant: "team-alpha",
+            title: "Title",
+            body: "Body",
+            entryType: EntryType.Pattern,
+            severity: Severity.Info);
+
+        hash.Should().HaveLength(64);
+        hash.Should().MatchRegex("^[0-9a-f]{64}$");
+    }
+
+    [Fact]
+    public void Compute_IsDeterministic_AcrossInvocations()
+    {
+        var first = IntegrityHashService.Compute("t", "title", "body", EntryType.Pattern, Severity.Info);
+        var second = IntegrityHashService.Compute("t", "title", "body", EntryType.Pattern, Severity.Info);
+
+        first.Should().Be(second);
+    }
+
+    [Fact]
+    public void Compute_DiffersByTenant()
+    {
+        var a = IntegrityHashService.Compute("tenant-a", "title", "body", EntryType.Pattern, Severity.Info);
+        var b = IntegrityHashService.Compute("tenant-b", "title", "body", EntryType.Pattern, Severity.Info);
+
+        a.Should().NotBe(b);
+    }
+
+    [Fact]
+    public void Compute_DiffersByTitle()
+    {
+        var a = IntegrityHashService.Compute("t", "title-a", "body", EntryType.Pattern, Severity.Info);
+        var b = IntegrityHashService.Compute("t", "title-b", "body", EntryType.Pattern, Severity.Info);
+
+        a.Should().NotBe(b);
+    }
+
+    [Fact]
+    public void Compute_DiffersByBody()
+    {
+        var a = IntegrityHashService.Compute("t", "title", "body-a", EntryType.Pattern, Severity.Info);
+        var b = IntegrityHashService.Compute("t", "title", "body-b", EntryType.Pattern, Severity.Info);
+
+        a.Should().NotBe(b);
+    }
+
+    [Fact]
+    public void Compute_DiffersByEntryType()
+    {
+        var a = IntegrityHashService.Compute("t", "title", "body", EntryType.Pattern, Severity.Info);
+        var b = IntegrityHashService.Compute("t", "title", "body", EntryType.IssueFix, Severity.Info);
+
+        a.Should().NotBe(b);
+    }
+
+    [Fact]
+    public void Compute_DiffersBySeverity()
+    {
+        var a = IntegrityHashService.Compute("t", "title", "body", EntryType.Pattern, Severity.Info);
+        var b = IntegrityHashService.Compute("t", "title", "body", EntryType.Pattern, Severity.Critical);
+
+        a.Should().NotBe(b);
+    }
+
+    [Fact]
+    public void Compute_IgnoresFieldsNotInCanonicalForm()
+    {
+        // SourceVersion, Source, AuthorPrincipal, Visibility, ReviewState, etc. are NOT
+        // part of the integrity hash — only {tenant, title, body, entryType, severity} are.
+        var entry1 = new ExpertiseEntry
+        {
+            Domain = "shared",
+            Tenant = "t",
+            Title = "title",
+            Body = "body",
+            EntryType = EntryType.Pattern,
+            Severity = Severity.Info,
+            Source = "agent-a",
+            SourceVersion = "v1",
+            AuthorPrincipal = "p1",
+            Visibility = Visibility.Private,
+            ReviewState = ReviewState.Draft
+        };
+        var entry2 = new ExpertiseEntry
+        {
+            Domain = "different-domain",
+            Tenant = "t",
+            Title = "title",
+            Body = "body",
+            EntryType = EntryType.Pattern,
+            Severity = Severity.Info,
+            Source = "agent-b",
+            SourceVersion = "v99",
+            AuthorPrincipal = "p2",
+            Visibility = Visibility.Shared,
+            ReviewState = ReviewState.Approved
+        };
+
+        IntegrityHashService.Compute(entry1).Should().Be(IntegrityHashService.Compute(entry2));
+    }
+
+    [Fact]
+    public void Compute_OverloadFromEntry_MatchesScalarOverload()
+    {
+        var entry = new ExpertiseEntry
+        {
+            Domain = "shared",
+            Tenant = "team-alpha",
+            Title = "Title",
+            Body = "Body",
+            EntryType = EntryType.Caveat,
+            Severity = Severity.Warning,
+            Source = "human",
+            AuthorPrincipal = "test"
+        };
+
+        var fromEntry = IntegrityHashService.Compute(entry);
+        var fromScalar = IntegrityHashService.Compute(
+            "team-alpha", "Title", "Body", EntryType.Caveat, Severity.Warning);
+
+        fromEntry.Should().Be(fromScalar);
+    }
+}


### PR DESCRIPTION
Closes #46. Part of #45.

## Summary

PR 1 of the secure rebuild. Data-model and migration only — no behavior change visible at the API surface. Adds nine fields to `ExpertiseEntry`, a new `ExpertiseAuditLog` table, the `IntegrityHashService`, and the `rehash` CLI command. Existing API key auth, CRUD, and search continue to work; new columns are populated via transitional placeholders (`Tenant=legacy`, `AuthorPrincipal=pre-rebuild`) until PR 2/3 wires `TenantContext`-derived values.

## Type of Change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [ ] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change (add `!` to PR title)

## Test Plan

- [x] `dotnet test ExpertiseApi.slnx` — 65/65 passing locally (includes new tests)
- [x] New tests added:
  - `IntegrityHashServiceTests` — unit, 9 cases covering determinism, sensitivity to each input field, output format, entry/scalar overload parity
  - `MigrationReversibilityTests` — integration, applies and rolls back the new migration via `IMigrator.MigrateAsync(targetMigration)` against a dedicated Testcontainers container
  - `DbContextEncapsulationTests` — architectural, asserts no `ExpertiseDbContext` constructor dependency outside `Data/` and `Cli/`
- [x] `TestHelpers.SeedEntry` updated with new required fields; existing endpoint tests still pass
- [x] Helm render test — N/A (no chart change)
- [x] Endpoint smoke — existing API key flow continues to work via transitional placeholders in `BuildEntry`

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files (markdownlint, dotnet format)
- [x] Database migrations are reversible — verified by integration test
- [x] API changes are backward-compatible — no endpoint behavior change in this PR
- [x] CLAUDE.md updated (new Data Model section, `rehash` CLI command, Architecture/ test directory)

## Deviation from plan

The original plan (per the brief and Q4 confirmation) was to split the migration into two: `AddTenantAuditFields` and `AddExpertiseAuditLog`. EF tooling combined them into one when scaffolded, and my harness's destructive-guard hook prevents `rm`/`mv` on project paths, so I couldn't cleanly split mid-flight. I chose to ship the combined migration rather than block on file-deletion permissions. **Functionally equivalent** — backfill is correct, `Up`/`Down` round-trip is verified by `MigrationReversibilityTests`, and the only cost is a slightly larger `Down()` block (11 column drops + 2 index drops + 1 table drop).

If you want a re-split before merge, ack and I'll need help running `rm` on the two generated files; everything else is automatable.

## Resolved decisions (Q1–Q5 from planning)

1. **`IntegrityHash` inputs** — `{tenant, title, body, entryType, severity}` only. `sourceVersion` excluded (it's a staleness label, not content).
2. **`Tenant` / `AuthorPrincipal` defaults** — backfilled `legacy` / `pre-rebuild`, then **defaults dropped** in the same migration. Future inserts must supply both explicitly. `Visibility` and `ReviewState` keep their secure-by-default `Private` / `Draft` defaults.
3. **`IntegrityHash` nullability** — `string?` (nullable) until the `rehash` CLI runs in all envs; a follow-up PR will make it `NOT NULL` once verified populated everywhere.
4. **Migration split** — see "Deviation from plan" above.
5. **`ExpertiseAuditLog.EntryId` FK** — hard FK with `ON DELETE RESTRICT`. Audit survives soft deletes; refuses cascade on hard delete (the safer audit posture).

## What is NOT in this PR

- `IAuditLogRepository` and audit write path → PR 4 (#49)
- Tenant filtering in repository methods → PR 3 (#48)
- Repository signatures taking `TenantContext` → PR 2/3 (#47/#48)
- EF global query filter on `ExpertiseEntry.Tenant` → PR 3 (#48)
- Make `IntegrityHash` `NOT NULL` → follow-up after `rehash` CLI ships and runs in all envs
- All auth, OIDC, scope-policy work → PR 2+ (#47–#51)