### PR TITLE
feat(auth): jwt scaffolding with tenant context and scope policies

### DIFF
--- a/.claude/skills/expertise-api-design/SKILL.md
+++ b/.claude/skills/expertise-api-design/SKILL.md
@@ -21,8 +21,7 @@ user-invocable: false
 | Embedding model | `bge-micro-v2` (22.9MB, 384-dim, bundled in Docker image) |
 | Embedding abstraction | `IEmbeddingGenerator<string, Embedding<float>>` (Microsoft.Extensions.AI) |
 | Embedding input | `EmbeddingService.BuildInputText(title, body)` — single source of truth |
-| Auth — personal (current) | Static API key bearer token via `Auth:ApiKey` config |
-| Auth — business (future) | Azure Entra ID — OIDC client_credentials grant (production hardening phase) |
+| Auth | Multi-issuer OIDC (Entra + Authentik) via `JwtBearer` per issuer behind a `Bearer` policy scheme; `ApiKey`/`LocalDev`/`Hybrid` modes for Development only |
 | Tags storage | PostgreSQL `text[]` with GIN index (not JSONB — avoids EF Core 10 `Contains()` bug) |
 | Deployment | k3s — personal and business clusters |
 | Local dev | Docker Compose (not a deployment target) |
@@ -120,10 +119,51 @@ CLI:
 
 ## Authentication
 
-- **Current:** API key auth only. Custom `AuthenticationHandler<>` validating `Bearer` token against `Auth:ApiKey` config. All authenticated clients receive both `expertise.read` and `expertise.write` scopes.
-- **Future (production hardening):** Azure Entra ID OIDC client_credentials flow with per-token scope differentiation via `Auth:Mode` config switch.
-- Scopes enforced via ASP.NET Core authorization policies (`ReadAccess`, `WriteAccess`).
-- Scope claim constants defined in `Auth/AuthConstants.cs`.
+`Auth:Mode` config switch drives scheme registration. `Oidc` is the only mode permitted outside Development; `LocalDev`, `ApiKey`, and `Hybrid` hard-fail on startup in any non-Development environment. `Hybrid` is the default in Development.
+
+### Modes
+
+| Mode | Accepts | Default scheme behavior |
+| --- | --- | --- |
+| `Oidc` | Validated JWT from configured issuers | One named `JwtBearer` scheme per issuer behind a `Bearer` policy scheme that routes by token's `iss` |
+| `LocalDev` | `Bearer dev:{tenant}:{scope1}+{scope2}` ad-hoc tokens | Custom `LocalDevAuthHandler` |
+| `ApiKey` | Legacy static API key via `Auth:ApiKey` | `ApiKeyAuthHandler` (mints `expertise.write.draft` and `expertise.read`) |
+| `Hybrid` | All of the above | Policy scheme routes by token shape: `dev:` → LocalDev; `xxx.yyy.zzz` → JWT (per matching `iss`); else → ApiKey |
+
+### Multi-issuer JWT
+
+`Auth:Oidc:Issuers[]` carries one entry per IdP. Each is registered as its own named `JwtBearer` scheme so audience validation is pinned per issuer (a flat `ValidIssuers`/`ValidAudiences` list would allow cross-issuer audience contamination). The `Bearer` policy scheme uses `ForwardDefaultSelector` to route incoming tokens to the right named scheme.
+
+### Tenant derivation
+
+`OidcIssuerOptions.TenantSource`:
+
+- **`Groups`** — walk the principal's group claims through `GroupToTenantMapping`. Used for delegated flows and Authentik (which emits groups for both flows).
+- **`CompoundRole`** — parse each scope-claim entry as `{tenant}{separator}{scope}` (default separator: `:`). Required for Entra `client_credentials`, which does not emit `groups` for service principals.
+
+### Scope claims
+
+Per-issuer `ScopeClaims[]`:
+
+- Entra: `["scp", "roles"]` — `scp` for delegated, `roles` for `client_credentials`. Both unioned.
+- Authentik: `["scope"]` — RFC 9068 standard.
+
+### Scopes and policies
+
+Four scopes with hierarchical implication (`admin ⊇ approve ⊇ draft ⊇ read`). Scope expansion is precomputed on the principal during `OnTokenValidated` (`JwtTenantContextEvents.ExpandScopeClosure`) — the `ScopeAuthorizationHandler` is then a simple `Contains` check. The legacy `expertise.write` scope is normalized to `expertise.write.draft` for one transition cycle.
+
+| Scope | Policy |
+| --- | --- |
+| `expertise.read` | `ReadAccess` |
+| `expertise.write.draft` | `WriteAccess` |
+| `expertise.write.approve` | `WriteApproveAccess` |
+| `expertise.admin` | `AdminAccess` |
+
+### TenantContext
+
+A `TenantContext { Tenant, Principal, Agent?, Scopes[] }` is built per request and stashed on `HttpContext.Features`. All authentication paths (JWT, ApiKey, LocalDev) populate it. Endpoints read it via `HttpContext.RequireTenantContext()`. Repository methods (PR 3) will require it as an argument.
+
+When the principal authenticates successfully but no tenant maps (e.g. group not in `GroupToTenantMapping`), `TenantContext.Tenant` is `null` and the authorization handler returns 403.
 
 ## Embedding Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ dotnet run --project src/ExpertiseApi
 # 4. Verify — health check (no auth required)
 curl http://localhost:5000/health
 
-# 5. Create an entry (requires API key from .env AUTH__APIKEY)
+# 5. Create an entry (under Hybrid mode in Development — accepts the API key from .env)
 curl -X POST http://localhost:5000/expertise \
   -H "Authorization: Bearer dev-api-key-change-me" \
   -H "Content-Type: application/json" \
@@ -133,7 +133,71 @@ AI agents (Claude Code, GitHub Copilot) consume this API via HTTP with a bearer 
 2. **Create** a new entry when discovering a fix, caveat, or pattern: `POST /expertise`
 3. **Update** an entry when information changes: `PATCH /expertise/{id}`
 
-All endpoints except `/health`, `/query`, and `/metrics` require `Authorization: Bearer <api-key>`.
+All endpoints except `/health`, `/query`, and `/metrics` require `Authorization: Bearer <token>`.
+
+## Authentication
+
+`Auth:Mode` config switch governs which authentication scheme(s) are accepted:
+
+| Mode | Tokens accepted | Permitted environments |
+| --- | --- | --- |
+| `Oidc` | Validated JWT from any configured issuer | All — required outside Development |
+| `LocalDev` | Custom dev token `Bearer dev:{tenant}:{scope1}+{scope2}` | Development only |
+| `ApiKey` | Static `Auth:ApiKey` value (legacy) | Development only |
+| `Hybrid` | All of the above | Development only — default |
+
+The startup guard hard-fails if a non-`Oidc` mode is configured outside Development.
+
+### Scopes
+
+Four scopes drive the four authorization policies. The hierarchy is `admin ⊇ approve ⊇ draft ⊇ read` — a token carrying `expertise.admin` satisfies any policy:
+
+| Scope | Policy | Required for |
+| --- | --- | --- |
+| `expertise.read` | `ReadAccess` | All `GET` endpoints |
+| `expertise.write.draft` | `WriteAccess` | `POST`, `PATCH`, `DELETE` (drafts in caller's own tenant) |
+| `expertise.write.approve` | `WriteApproveAccess` | `/approve`, `/reject` (PR 4) |
+| `expertise.admin` | `AdminAccess` | `/audit`, cross-tenant ops (PR 4) |
+
+The legacy `expertise.write` scope is normalized to `expertise.write.draft` during one transition cycle.
+
+### OIDC issuers
+
+`Auth:Oidc:Issuers[]` is an array of per-issuer configs. Each entry:
+
+```jsonc
+{
+  "Name": "Entra",
+  "Issuer": "https://login.microsoftonline.com/{tenant-id}/v2.0",
+  "Audience": "{api-client-id-guid}",
+  "AdditionalAudiences": ["api://expertise-api"],
+  "ScopeClaims": ["scp", "roles"],
+  "TenantSource": "CompoundRole",     // for client_credentials — parses "team:scope"
+  "RoleSeparator": ":",
+  "GroupClaim": "groups",
+  "GroupToTenantMapping": { "<group-id>": "team-alpha" }
+}
+```
+
+Notes:
+
+- **Trailing slash on `Issuer`** must match the `iss` claim byte-exactly. Authentik includes one; Entra v2 does not. Copy from `.well-known/openid-configuration` verbatim.
+- **`TenantSource = "CompoundRole"`** is for Entra `client_credentials` flow, which does not emit `groups` for service principals. Roles are encoded as `{tenant}:{scope}` and parsed at validation time.
+- **`TenantSource = "Groups"`** is for delegated flows (and Authentik). Group claim values are mapped to tenant slugs.
+
+### LocalDev token format
+
+`Bearer dev:{tenant}:{scope1}+{scope2}+...`
+
+Examples:
+
+```text
+Bearer dev:legacy:read
+Bearer dev:team-alpha:draft+read
+Bearer dev:shared:admin
+```
+
+Scope shorthand (`read`, `draft`, `approve`, `admin`) expands to full scope strings; any other value passes through verbatim. The handler is registered only when `Auth:Mode` is `LocalDev` or `Hybrid` AND the environment is Development.
 
 ## CI/CD
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ flowchart LR
 | GET | `/metrics` | Prometheus scrape endpoint (no auth required) |
 | GET | `/query` | Interactive query page (read-only, no auth to load) |
 
-All endpoints except `/health`, `/query`, and `/metrics` require `Authorization: Bearer <api-key>`. See [SKILL.md](.claude/skills/expertise-api-design/SKILL.md) for scopes and optional parameters.
+All endpoints except `/health`, `/query`, and `/metrics` require `Authorization: Bearer <token>` — a JWT (`Auth:Mode = Oidc`) or, in Development, an API key or LocalDev token (`Auth:Mode = Hybrid`). See [SKILL.md](.claude/skills/expertise-api-design/SKILL.md) for scopes, modes, and configuration.
 
 ## Quick Start
 

--- a/src/ExpertiseApi/Auth/ApiKeyAuthHandler.cs
+++ b/src/ExpertiseApi/Auth/ApiKeyAuthHandler.cs
@@ -47,17 +47,40 @@ public class ApiKeyAuthHandler(
             return Task.FromResult(AuthenticateResult.Fail("Invalid API key"));
         }
 
-        var claims = new[]
+        var defaultTenant = configuration["Auth:ApiKeyDefaults:DefaultTenant"] ?? "legacy";
+        var defaultPrincipal = configuration["Auth:ApiKeyDefaults:DefaultPrincipal"] ?? "api-client";
+
+        // Issue the new draft + read scopes; LegacyWriteScope kept for one release cycle so
+        // any caller still configured against the pre-rebuild scope name continues to pass
+        // the WriteAccess policy. Both are normalized to expertise.write.draft via
+        // JwtTenantContextEvents.ExpandScopeClosure.
+        var rawScopes = new[]
         {
-            new Claim(ClaimTypes.Name, "api-client"),
-            new Claim(AuthConstants.ScopeClaimType, AuthConstants.ReadScope),
-            new Claim(AuthConstants.ScopeClaimType, AuthConstants.WriteScope)
+            AuthConstants.ReadScope,
+            AuthConstants.WriteDraftScope,
+            AuthConstants.LegacyWriteScope
         };
+        var expandedScopes = JwtTenantContextEvents.ExpandScopeClosure(rawScopes);
+
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.Name, defaultPrincipal),
+            new("sub", defaultPrincipal)
+        };
+        foreach (var scope in expandedScopes)
+            claims.Add(new Claim(AuthConstants.ScopeClaimType, scope));
 
         var identity = new ClaimsIdentity(claims, SchemeName);
         var principal = new ClaimsPrincipal(identity);
-        var ticket = new AuthenticationTicket(principal, SchemeName);
 
+        var tenantContext = new TenantContext(
+            Tenant: defaultTenant,
+            Principal: principal,
+            Agent: null,
+            Scopes: expandedScopes);
+        Context.SetTenantContext(tenantContext);
+
+        var ticket = new AuthenticationTicket(principal, SchemeName);
         return Task.FromResult(AuthenticateResult.Success(ticket));
     }
 }

--- a/src/ExpertiseApi/Auth/AuthConstants.cs
+++ b/src/ExpertiseApi/Auth/AuthConstants.cs
@@ -3,6 +3,24 @@ namespace ExpertiseApi.Auth;
 public static class AuthConstants
 {
     public const string ScopeClaimType = "scope";
+
     public const string ReadScope = "expertise.read";
-    public const string WriteScope = "expertise.write";
+    public const string WriteDraftScope = "expertise.write.draft";
+    public const string WriteApproveScope = "expertise.write.approve";
+    public const string AdminScope = "expertise.admin";
+
+    /// <summary>
+    /// Legacy scope retained for one release cycle so that callers issued tokens before the
+    /// scope split still pass <see cref="Policies.WriteAccess"/>. Removed in PR 6 alongside
+    /// the production OIDC cutover.
+    /// </summary>
+    public const string LegacyWriteScope = "expertise.write";
+
+    public static class Policies
+    {
+        public const string ReadAccess = "ReadAccess";
+        public const string WriteAccess = "WriteAccess";
+        public const string WriteApproveAccess = "WriteApproveAccess";
+        public const string AdminAccess = "AdminAccess";
+    }
 }

--- a/src/ExpertiseApi/Auth/AuthExtensions.cs
+++ b/src/ExpertiseApi/Auth/AuthExtensions.cs
@@ -1,21 +1,201 @@
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
 
 namespace ExpertiseApi.Auth;
 
 public static class AuthExtensions
 {
-    public static IServiceCollection AddApiKeyAuth(this IServiceCollection services)
+    public const string BearerScheme = "Bearer";
+
+    public static IServiceCollection AddExpertiseAuth(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        IHostEnvironment environment)
     {
-        services.AddAuthentication(ApiKeyAuthHandler.SchemeName)
-            .AddScheme<AuthenticationSchemeOptions, ApiKeyAuthHandler>(
+        var mode = ParseAuthMode(configuration["Auth:Mode"], environment);
+        EnforceModeGuard(mode, environment);
+
+        var issuers = LoadIssuers(configuration);
+
+        services.AddHttpContextAccessor();
+        services.AddSingleton<IAuthorizationHandler, ScopeAuthorizationHandler>();
+
+        var authBuilder = services.AddAuthentication(BearerScheme);
+
+        // Always register the policy scheme first so the default scheme exists even if we
+        // only end up registering one inner scheme — keeps endpoint configuration uniform.
+        authBuilder.AddPolicyScheme(BearerScheme, displayName: null, options =>
+        {
+            options.ForwardDefaultSelector = ctx => SelectScheme(ctx, mode, issuers);
+        });
+
+        if (mode is AuthMode.Oidc or AuthMode.Hybrid)
+        {
+            foreach (var issuer in issuers)
+            {
+                RegisterJwtBearer(authBuilder, issuer);
+            }
+        }
+
+        if (mode is AuthMode.LocalDev or AuthMode.Hybrid)
+        {
+            authBuilder.AddScheme<AuthenticationSchemeOptions, LocalDevAuthHandler>(
+                LocalDevAuthHandler.SchemeName, null);
+        }
+
+        if (mode is AuthMode.ApiKey or AuthMode.Hybrid)
+        {
+            authBuilder.AddScheme<AuthenticationSchemeOptions, ApiKeyAuthHandler>(
                 ApiKeyAuthHandler.SchemeName, null);
+        }
 
         services.AddAuthorizationBuilder()
-            .AddPolicy("ReadAccess", policy =>
-                policy.RequireClaim(AuthConstants.ScopeClaimType, AuthConstants.ReadScope))
-            .AddPolicy("WriteAccess", policy =>
-                policy.RequireClaim(AuthConstants.ScopeClaimType, AuthConstants.WriteScope));
+            .AddPolicy(AuthConstants.Policies.ReadAccess, p =>
+                p.AddRequirements(new ScopeRequirement(AuthConstants.ReadScope)))
+            .AddPolicy(AuthConstants.Policies.WriteAccess, p =>
+                p.AddRequirements(new ScopeRequirement(AuthConstants.WriteDraftScope)))
+            .AddPolicy(AuthConstants.Policies.WriteApproveAccess, p =>
+                p.AddRequirements(new ScopeRequirement(AuthConstants.WriteApproveScope)))
+            .AddPolicy(AuthConstants.Policies.AdminAccess, p =>
+                p.AddRequirements(new ScopeRequirement(AuthConstants.AdminScope)));
 
         return services;
+    }
+
+    internal static AuthMode ParseAuthMode(string? value, IHostEnvironment environment)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return environment.IsDevelopment() ? AuthMode.Hybrid : AuthMode.Oidc;
+
+        return Enum.TryParse<AuthMode>(value, ignoreCase: true, out var parsed)
+            ? parsed
+            : throw new InvalidOperationException(
+                $"Auth:Mode '{value}' is not a recognized mode. Valid values: " +
+                $"{string.Join(", ", Enum.GetNames<AuthMode>())}.");
+    }
+
+    internal static void EnforceModeGuard(AuthMode mode, IHostEnvironment environment)
+    {
+        if (mode == AuthMode.Oidc) return;
+        if (environment.IsDevelopment()) return;
+
+        throw new InvalidOperationException(
+            $"Auth:Mode '{mode}' is only permitted when ASPNETCORE_ENVIRONMENT='Development'. " +
+            $"Current environment: '{environment.EnvironmentName}'. " +
+            "Set Auth:Mode to 'Oidc' for non-Development deployments.");
+    }
+
+    internal static IReadOnlyList<OidcIssuerOptions> LoadIssuers(IConfiguration configuration)
+    {
+        var issuers = configuration.GetSection("Auth:Oidc:Issuers")
+            .Get<List<OidcIssuerOptions>>() ?? [];
+
+        // Strip placeholder entries (TODO markers in source-controlled configs) — they would
+        // otherwise fail JwtBearer setup with confusing discovery errors.
+        return issuers
+            .Where(i => !string.IsNullOrWhiteSpace(i.Issuer)
+                        && !i.Issuer.StartsWith("<TODO", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+    }
+
+    private static void RegisterJwtBearer(AuthenticationBuilder builder, OidcIssuerOptions issuer)
+    {
+        builder.AddJwtBearer(issuer.Name, options =>
+        {
+            options.Authority = issuer.Issuer;
+            options.Audience = issuer.Audience;
+            options.MapInboundClaims = false; // keep `sub`, `scp`, etc. as-is for parsing
+
+            options.TokenValidationParameters = new TokenValidationParameters
+            {
+                ValidateIssuer = true,
+                ValidateAudience = true,
+                ValidateLifetime = true,
+                ValidateIssuerSigningKey = true,
+                ValidIssuer = issuer.Issuer,
+                ValidAudiences = [issuer.Audience, .. issuer.AdditionalAudiences],
+                NameClaimType = "sub"
+            };
+
+            options.Events = new JwtBearerEvents
+            {
+                OnTokenValidated = ctx => JwtTenantContextEvents.BuildTenantContext(ctx, issuer)
+            };
+        });
+    }
+
+    private static string SelectScheme(HttpContext ctx, AuthMode mode, IReadOnlyList<OidcIssuerOptions> issuers)
+    {
+        var header = ctx.Request.Headers.Authorization.FirstOrDefault();
+        if (string.IsNullOrEmpty(header) || !header.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+            return FallbackSchemeForMode(mode, issuers);
+
+        var token = header["Bearer ".Length..].Trim();
+
+        if (token.StartsWith(LocalDevAuthHandler.TokenPrefix, StringComparison.OrdinalIgnoreCase)
+            && (mode is AuthMode.LocalDev or AuthMode.Hybrid))
+        {
+            return LocalDevAuthHandler.SchemeName;
+        }
+
+        // Three dot-delimited base64url segments → JWT. Forward to the matching issuer's
+        // scheme; if no issuer matches the token's `iss`, forward to the first registered
+        // issuer scheme so JwtBearer surfaces a clean 401.
+        if (LooksLikeJwt(token) && (mode is AuthMode.Oidc or AuthMode.Hybrid) && issuers.Count > 0)
+        {
+            try
+            {
+                var handler = new JsonWebTokenHandler();
+                if (handler.CanReadToken(token))
+                {
+                    var parsed = handler.ReadJsonWebToken(token);
+                    var match = issuers.FirstOrDefault(i =>
+                        string.Equals(i.Issuer, parsed.Issuer, StringComparison.Ordinal));
+                    if (match is not null)
+                        return match.Name;
+                }
+            }
+            catch
+            {
+                // Fall through to first scheme; JwtBearer will reject cleanly.
+            }
+            return issuers[0].Name;
+        }
+
+        if (mode is AuthMode.ApiKey or AuthMode.Hybrid)
+            return ApiKeyAuthHandler.SchemeName;
+
+        return FallbackSchemeForMode(mode, issuers);
+    }
+
+    /// <summary>
+    /// Picks a registered scheme to forward to when the request has no recognizable bearer
+    /// shape. Must never return <see cref="BearerScheme"/> — that's the policy scheme name
+    /// itself, which would create an infinite forward loop.
+    /// </summary>
+    private static string FallbackSchemeForMode(AuthMode mode, IReadOnlyList<OidcIssuerOptions> issuers) => mode switch
+    {
+        AuthMode.ApiKey => ApiKeyAuthHandler.SchemeName,
+        AuthMode.LocalDev => LocalDevAuthHandler.SchemeName,
+        AuthMode.Oidc => issuers.Count > 0
+            ? issuers[0].Name
+            : throw new InvalidOperationException(
+                "Auth:Mode=Oidc requires at least one configured Auth:Oidc:Issuers entry."),
+        AuthMode.Hybrid => issuers.Count > 0 ? issuers[0].Name : ApiKeyAuthHandler.SchemeName,
+        _ => throw new InvalidOperationException($"Unknown Auth:Mode '{mode}'.")
+    };
+
+    private static bool LooksLikeJwt(string token)
+    {
+        var dots = 0;
+        foreach (var c in token)
+        {
+            if (c == '.') dots++;
+            if (dots > 2) return false;
+        }
+        return dots == 2;
     }
 }

--- a/src/ExpertiseApi/Auth/AuthMode.cs
+++ b/src/ExpertiseApi/Auth/AuthMode.cs
@@ -1,0 +1,16 @@
+namespace ExpertiseApi.Auth;
+
+public enum AuthMode
+{
+    /// <summary>OIDC only. Required for non-Development environments.</summary>
+    Oidc,
+
+    /// <summary>Custom dev token format <c>Bearer dev-{tenant}-{scope1}+{scope2}</c>. Development only.</summary>
+    LocalDev,
+
+    /// <summary>Legacy static API key. Development only.</summary>
+    ApiKey,
+
+    /// <summary>Accepts API key, JWT, and LocalDev tokens. Development default.</summary>
+    Hybrid
+}

--- a/src/ExpertiseApi/Auth/AuthMode.cs
+++ b/src/ExpertiseApi/Auth/AuthMode.cs
@@ -5,7 +5,7 @@ public enum AuthMode
     /// <summary>OIDC only. Required for non-Development environments.</summary>
     Oidc,
 
-    /// <summary>Custom dev token format <c>Bearer dev-{tenant}-{scope1}+{scope2}</c>. Development only.</summary>
+    /// <summary>Custom dev token format <c>Bearer dev:{tenant}:{scope1}+{scope2}</c>. Development only.</summary>
     LocalDev,
 
     /// <summary>Legacy static API key. Development only.</summary>

--- a/src/ExpertiseApi/Auth/JwtTenantContextEvents.cs
+++ b/src/ExpertiseApi/Auth/JwtTenantContextEvents.cs
@@ -66,7 +66,7 @@ public static class JwtTenantContextEvents
         }
     }
 
-    private static (string? Tenant, HashSet<string> Scopes) ParseCompoundRoles(
+    internal static (string? Tenant, HashSet<string> Scopes) ParseCompoundRoles(
         IEnumerable<string> rawScopes,
         string separator)
     {

--- a/src/ExpertiseApi/Auth/JwtTenantContextEvents.cs
+++ b/src/ExpertiseApi/Auth/JwtTenantContextEvents.cs
@@ -1,0 +1,146 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+
+namespace ExpertiseApi.Auth;
+
+/// <summary>
+/// Builds <see cref="TenantContext"/> after JWT validation. Shared across all configured
+/// JwtBearer schemes — each scheme is registered with its <see cref="OidcIssuerOptions"/>
+/// in the scheme's <see cref="JwtBearerEvents.OnTokenValidated"/>.
+/// </summary>
+public static class JwtTenantContextEvents
+{
+    public static Task BuildTenantContext(TokenValidatedContext ctx, OidcIssuerOptions issuer)
+    {
+        if (ctx.Principal is null)
+        {
+            ctx.Fail("Principal missing after token validation.");
+            return Task.CompletedTask;
+        }
+
+        var rawScopes = ExtractRawScopes(ctx.Principal, issuer);
+
+        string? tenant;
+        HashSet<string> scopes;
+
+        if (issuer.TenantSource == TenantSource.CompoundRole)
+        {
+            (tenant, scopes) = ParseCompoundRoles(rawScopes, issuer.RoleSeparator);
+        }
+        else
+        {
+            tenant = MapTenantFromGroups(ctx.Principal, issuer);
+            scopes = [.. rawScopes];
+        }
+
+        var expanded = ExpandScopeClosure(scopes);
+
+        var agent = ctx.Principal.FindFirst("appid")?.Value
+                    ?? ctx.Principal.FindFirst("azp")?.Value
+                    ?? ctx.Principal.FindFirst("client_id")?.Value;
+
+        var tenantContext = new TenantContext(
+            Tenant: tenant,
+            Principal: ctx.Principal,
+            Agent: agent,
+            Scopes: expanded);
+
+        ctx.HttpContext.SetTenantContext(tenantContext);
+        return Task.CompletedTask;
+    }
+
+    private static IEnumerable<string> ExtractRawScopes(ClaimsPrincipal principal, OidcIssuerOptions issuer)
+    {
+        foreach (var claim in issuer.ScopeClaims)
+        {
+            foreach (var value in principal.FindAll(claim).Select(c => c.Value))
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                    continue;
+
+                // Entra `scp` is space-separated; Authentik `scope` is space-separated.
+                // Entra `roles` is repeated claim per value (one per array entry).
+                foreach (var scope in value.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                    yield return scope;
+            }
+        }
+    }
+
+    private static (string? Tenant, HashSet<string> Scopes) ParseCompoundRoles(
+        IEnumerable<string> rawScopes,
+        string separator)
+    {
+        string? tenant = null;
+        var scopes = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var raw in rawScopes)
+        {
+            var sepIndex = raw.IndexOf(separator, StringComparison.Ordinal);
+            if (sepIndex < 0)
+            {
+                // No separator — treat as a tenant-less scope. Skip; compound role tokens
+                // must always carry tenant context.
+                continue;
+            }
+
+            var roleTenant = raw[..sepIndex];
+            var roleScope = raw[(sepIndex + separator.Length)..];
+
+            if (string.IsNullOrWhiteSpace(roleTenant) || string.IsNullOrWhiteSpace(roleScope))
+                continue;
+
+            // First role wins on tenant. A token claiming multiple tenants is rejected
+            // (policy decision: machine credentials are scoped to a single tenant).
+            if (tenant is null)
+                tenant = roleTenant;
+            else if (!string.Equals(tenant, roleTenant, StringComparison.Ordinal))
+                continue;
+
+            scopes.Add(roleScope);
+        }
+
+        return (tenant, scopes);
+    }
+
+    private static string? MapTenantFromGroups(ClaimsPrincipal principal, OidcIssuerOptions issuer)
+    {
+        foreach (var group in principal.FindAll(issuer.GroupClaim).Select(c => c.Value))
+        {
+            if (issuer.GroupToTenantMapping.TryGetValue(group, out var tenant))
+                return tenant;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Expands the scope set per the implication hierarchy: admin ⊇ approve ⊇ draft ⊇ read.
+    /// Also normalizes the legacy <see cref="AuthConstants.LegacyWriteScope"/> to
+    /// <see cref="AuthConstants.WriteDraftScope"/>.
+    /// </summary>
+    public static HashSet<string> ExpandScopeClosure(IEnumerable<string> scopes)
+    {
+        var result = new HashSet<string>(scopes, StringComparer.Ordinal);
+
+        if (result.Remove(AuthConstants.LegacyWriteScope))
+            result.Add(AuthConstants.WriteDraftScope);
+
+        if (result.Contains(AuthConstants.AdminScope))
+        {
+            result.Add(AuthConstants.WriteApproveScope);
+            result.Add(AuthConstants.WriteDraftScope);
+            result.Add(AuthConstants.ReadScope);
+        }
+        else if (result.Contains(AuthConstants.WriteApproveScope))
+        {
+            result.Add(AuthConstants.WriteDraftScope);
+            result.Add(AuthConstants.ReadScope);
+        }
+        else if (result.Contains(AuthConstants.WriteDraftScope))
+        {
+            result.Add(AuthConstants.ReadScope);
+        }
+
+        return result;
+    }
+}

--- a/src/ExpertiseApi/Auth/LocalDevAuthHandler.cs
+++ b/src/ExpertiseApi/Auth/LocalDevAuthHandler.cs
@@ -1,0 +1,93 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+
+namespace ExpertiseApi.Auth;
+
+/// <summary>
+/// Accepts an ad-hoc dev token format <c>Bearer dev:{tenant}:{scope1}+{scope2}</c>.
+/// Registered only when <see cref="AuthMode.LocalDev"/> or <see cref="AuthMode.Hybrid"/>
+/// is configured AND <see cref="IHostEnvironment.EnvironmentName"/> is Development.
+/// <para>
+/// The colon separator (rather than hyphen) keeps tenant names containing hyphens safe
+/// (e.g. <c>team-alpha</c>). Scope shorthand (<c>read</c>/<c>draft</c>/<c>approve</c>/
+/// <c>admin</c>) expands to the full <see cref="AuthConstants"/> scope strings; any other
+/// value is passed through verbatim.
+/// </para>
+/// </summary>
+public class LocalDevAuthHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder)
+    : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    public const string SchemeName = "LocalDev";
+    public const string TokenPrefix = "dev:";
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue("Authorization", out var authHeader))
+            return Task.FromResult(AuthenticateResult.NoResult());
+
+        var header = authHeader.ToString();
+        if (!header.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+            return Task.FromResult(AuthenticateResult.NoResult());
+
+        var raw = header["Bearer ".Length..].Trim();
+        if (!raw.StartsWith(TokenPrefix, StringComparison.OrdinalIgnoreCase))
+            return Task.FromResult(AuthenticateResult.NoResult());
+
+        var body = raw[TokenPrefix.Length..];
+        var sepIndex = body.IndexOf(':');
+        if (sepIndex <= 0)
+        {
+            Logger.LogWarning("LocalDev token rejected: malformed format (expected dev:tenant:scopes)");
+            return Task.FromResult(AuthenticateResult.Fail("Malformed LocalDev token"));
+        }
+
+        var tenant = body[..sepIndex];
+        var scopePart = body[(sepIndex + 1)..];
+        if (string.IsNullOrWhiteSpace(tenant) || string.IsNullOrWhiteSpace(scopePart))
+        {
+            Logger.LogWarning("LocalDev token rejected: empty tenant or scope segment");
+            return Task.FromResult(AuthenticateResult.Fail("Malformed LocalDev token"));
+        }
+
+        var scopes = scopePart
+            .Split('+', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(ExpandShorthand);
+
+        var expanded = JwtTenantContextEvents.ExpandScopeClosure(scopes);
+
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.Name, $"localdev:{tenant}"),
+            new("sub", $"localdev:{tenant}")
+        };
+        foreach (var scope in expanded)
+            claims.Add(new Claim(AuthConstants.ScopeClaimType, scope));
+
+        var identity = new ClaimsIdentity(claims, SchemeName);
+        var principal = new ClaimsPrincipal(identity);
+
+        var tenantContext = new TenantContext(
+            Tenant: tenant,
+            Principal: principal,
+            Agent: null,
+            Scopes: expanded);
+        Context.SetTenantContext(tenantContext);
+
+        var ticket = new AuthenticationTicket(principal, SchemeName);
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+
+    private static string ExpandShorthand(string scope) => scope switch
+    {
+        "read" => AuthConstants.ReadScope,
+        "draft" => AuthConstants.WriteDraftScope,
+        "approve" => AuthConstants.WriteApproveScope,
+        "admin" => AuthConstants.AdminScope,
+        _ => scope
+    };
+}

--- a/src/ExpertiseApi/Auth/OidcIssuerOptions.cs
+++ b/src/ExpertiseApi/Auth/OidcIssuerOptions.cs
@@ -1,0 +1,65 @@
+namespace ExpertiseApi.Auth;
+
+public class OidcIssuerOptions
+{
+    /// <summary>
+    /// Logical name for the issuer (e.g. "Entra", "Authentik"). Used as the JwtBearer scheme name.
+    /// </summary>
+    public required string Name { get; set; }
+
+    /// <summary>
+    /// Exact issuer URL as it appears in the discovery document — must byte-match the <c>iss</c>
+    /// claim. Authentik includes a trailing slash; Entra does not. Do not normalize.
+    /// </summary>
+    public required string Issuer { get; set; }
+
+    /// <summary>Primary audience.</summary>
+    public required string Audience { get; set; }
+
+    /// <summary>
+    /// Additional accepted audiences (e.g. v1 App ID URI form alongside v2 GUID for Entra).
+    /// </summary>
+    public List<string> AdditionalAudiences { get; set; } = [];
+
+    /// <summary>
+    /// Claim names to read scope strings from. Microsoft Entra emits <c>scp</c> for delegated
+    /// flows and <c>roles</c> for client_credentials; both should be listed for that issuer.
+    /// Authentik (and RFC 9068 issuers) emit <c>scope</c>.
+    /// </summary>
+    public List<string> ScopeClaims { get; set; } = ["scope"];
+
+    /// <summary>
+    /// How to derive the tenant from the token.
+    /// </summary>
+    public TenantSource TenantSource { get; set; } = TenantSource.Groups;
+
+    /// <summary>
+    /// Separator for compound role names (<c>"team-alpha:expertise.read"</c>) when
+    /// <see cref="TenantSource"/> is <see cref="TenantSource.CompoundRole"/>.
+    /// </summary>
+    public string RoleSeparator { get; set; } = ":";
+
+    /// <summary>
+    /// Group claim → tenant slug mapping. Used when <see cref="TenantSource"/> is
+    /// <see cref="TenantSource.Groups"/>. Keys are group object IDs (Entra) or group slugs
+    /// (Authentik).
+    /// </summary>
+    public Dictionary<string, string> GroupToTenantMapping { get; set; } = [];
+
+    /// <summary>
+    /// Group claim name (defaults to <c>"groups"</c>).
+    /// </summary>
+    public string GroupClaim { get; set; } = "groups";
+}
+
+public enum TenantSource
+{
+    /// <summary>Walk group claims through <see cref="OidcIssuerOptions.GroupToTenantMapping"/>.</summary>
+    Groups,
+
+    /// <summary>
+    /// Parse each scope-claim entry as <c>{tenant}{separator}{scope}</c>. Used for Entra
+    /// <c>client_credentials</c> tokens which do not emit groups for service principals.
+    /// </summary>
+    CompoundRole
+}

--- a/src/ExpertiseApi/Auth/ScopeRequirement.cs
+++ b/src/ExpertiseApi/Auth/ScopeRequirement.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace ExpertiseApi.Auth;
+
+public sealed class ScopeRequirement(string scope) : IAuthorizationRequirement
+{
+    public string Scope { get; } = scope;
+}
+
+public sealed class ScopeAuthorizationHandler : AuthorizationHandler<ScopeRequirement>
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public ScopeAuthorizationHandler(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        ScopeRequirement requirement)
+    {
+        var httpContext = context.Resource as HttpContext ?? _httpContextAccessor.HttpContext;
+        var tenantContext = httpContext?.GetTenantContext();
+
+        // No TenantContext — auth pipeline didn't run or the principal is unmapped.
+        // Leaving the requirement unsatisfied causes the authorization middleware to
+        // return 403 (or 401 if the principal is unauthenticated).
+        if (tenantContext is null || tenantContext.Tenant is null)
+            return Task.CompletedTask;
+
+        if (tenantContext.Scopes.Contains(requirement.Scope))
+            context.Succeed(requirement);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/ExpertiseApi/Auth/TenantContext.cs
+++ b/src/ExpertiseApi/Auth/TenantContext.cs
@@ -1,0 +1,35 @@
+using System.Security.Claims;
+
+namespace ExpertiseApi.Auth;
+
+/// <summary>
+/// Authenticated request context. Populated by the authentication pipeline (JWT, API key,
+/// or LocalDev) and consumed by endpoints, repositories, and the audit log.
+/// <para>
+/// <see cref="Tenant"/> is null when the principal authenticated successfully but did not
+/// map to any configured tenant — the authorization layer turns this into 403.
+/// </para>
+/// <para>
+/// <see cref="Scopes"/> is the expanded closure: a token carrying only <c>expertise.admin</c>
+/// has all four scopes present (admin ⊇ approve ⊇ draft ⊇ read).
+/// </para>
+/// </summary>
+public sealed record TenantContext(
+    string? Tenant,
+    ClaimsPrincipal Principal,
+    string? Agent,
+    IReadOnlySet<string> Scopes);
+
+public static class TenantContextHttpExtensions
+{
+    public static TenantContext? GetTenantContext(this HttpContext ctx) =>
+        ctx.Features.Get<TenantContext>();
+
+    public static TenantContext RequireTenantContext(this HttpContext ctx) =>
+        ctx.GetTenantContext()
+        ?? throw new InvalidOperationException(
+            "TenantContext is not set on HttpContext. Ensure the authentication pipeline ran.");
+
+    public static void SetTenantContext(this HttpContext ctx, TenantContext value) =>
+        ctx.Features.Set(value);
+}

--- a/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
@@ -1,3 +1,4 @@
+using ExpertiseApi.Auth;
 using ExpertiseApi.Data;
 using ExpertiseApi.Models;
 using ExpertiseApi.Services;
@@ -67,6 +68,7 @@ public static class ExpertiseEndpoints
 
     private static async Task<IResult> CreateEntry(
         CreateExpertiseRequest request,
+        HttpContext httpContext,
         IExpertiseRepository repo,
         EmbeddingService embeddingService,
         DeduplicationService dedup,
@@ -75,6 +77,8 @@ public static class ExpertiseEndpoints
         if (!IsRequestValid(request))
             return Results.Problem("Domain, Title, Body, and Source are required.", statusCode: 400);
 
+        var tenantContext = httpContext.RequireTenantContext();
+
         var embedding = await embeddingService.GenerateEmbeddingAsync(
             EmbeddingService.BuildInputText(request.Title, request.Body), ct);
 
@@ -82,7 +86,7 @@ public static class ExpertiseEndpoints
         if (isDuplicate && existing is not null)
             return Results.Conflict(existing);
 
-        var created = await repo.CreateAsync(BuildEntry(request, embedding), ct);
+        var created = await repo.CreateAsync(BuildEntry(request, embedding, tenantContext), ct);
         return Results.Created($"/expertise/{created.Id}", created);
     }
 
@@ -118,6 +122,7 @@ public static class ExpertiseEndpoints
 
     private static async Task<IResult> CreateBatch(
         List<CreateExpertiseRequest> requests,
+        HttpContext httpContext,
         IExpertiseRepository repo,
         EmbeddingService embeddingService,
         DeduplicationService dedup,
@@ -125,6 +130,7 @@ public static class ExpertiseEndpoints
         CancellationToken ct)
     {
         const int MaxBatchSize = 100;
+        var tenantContext = httpContext.RequireTenantContext();
 
         if (requests is null || requests.Count == 0)
             return Results.Problem("Request body must contain at least one entry.", statusCode: 400);
@@ -215,7 +221,7 @@ public static class ExpertiseEndpoints
 
             try
             {
-                var created = await repo.CreateAsync(BuildEntry(request, embedding), ct);
+                var created = await repo.CreateAsync(BuildEntry(request, embedding, tenantContext), ct);
                 results[index] = new BatchEntryResult(index, BatchEntryStatus.Created, created.Id, null);
             }
             catch (OperationCanceledException)
@@ -238,22 +244,26 @@ public static class ExpertiseEndpoints
             : Results.Json(resultList, statusCode: 207);
     }
 
-    private static ExpertiseEntry BuildEntry(CreateExpertiseRequest request, Vector embedding) => new()
-    {
-        Domain = request.Domain,
-        Tags = request.Tags ?? [],
-        Title = request.Title,
-        Body = request.Body,
-        EntryType = request.EntryType,
-        Severity = request.Severity,
-        Source = request.Source,
-        SourceVersion = request.SourceVersion,
-        Embedding = embedding,
-        // Transitional placeholders matching the migration backfill values.
-        // Replaced by TenantContext-derived values once OIDC scaffolding lands.
-        Tenant = "legacy",
-        AuthorPrincipal = "pre-rebuild"
-    };
+    private static ExpertiseEntry BuildEntry(
+        CreateExpertiseRequest request,
+        Vector embedding,
+        TenantContext tenantContext) => new()
+        {
+            Domain = request.Domain,
+            Tags = request.Tags ?? [],
+            Title = request.Title,
+            Body = request.Body,
+            EntryType = request.EntryType,
+            Severity = request.Severity,
+            Source = request.Source,
+            SourceVersion = request.SourceVersion,
+            Embedding = embedding,
+            Tenant = tenantContext.Tenant!,
+            AuthorPrincipal = tenantContext.Principal.FindFirst("sub")?.Value
+                          ?? tenantContext.Principal.Identity?.Name
+                          ?? "unknown",
+            AuthorAgent = tenantContext.Agent
+        };
 
     private static async Task<IResult> DeleteEntry(
         Guid id,

--- a/src/ExpertiseApi/ExpertiseApi.csproj
+++ b/src/ExpertiseApi/ExpertiseApi.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -36,7 +36,7 @@ builder.Services.AddDbContext<ExpertiseDbContext>(options =>
         o => o.UseVector()));
 
 builder.Services.AddScoped<IExpertiseRepository, ExpertiseRepository>();
-builder.Services.AddApiKeyAuth();
+builder.Services.AddExpertiseAuth(builder.Configuration, builder.Environment);
 
 var baseDir = AppContext.BaseDirectory;
 var modelPath = builder.Configuration["Onnx:ModelPath"] ?? Path.Combine(baseDir, "models", "model.onnx");

--- a/src/ExpertiseApi/appsettings.Development.json
+++ b/src/ExpertiseApi/appsettings.Development.json
@@ -8,6 +8,11 @@
     }
   },
   "Auth": {
-    "ApiKey": "dev-api-key-change-me"
+    "Mode": "Hybrid",
+    "ApiKey": "dev-api-key-change-me",
+    "ApiKeyDefaults": {
+      "DefaultTenant": "legacy",
+      "DefaultPrincipal": "api-client"
+    }
   }
 }

--- a/src/ExpertiseApi/appsettings.json
+++ b/src/ExpertiseApi/appsettings.json
@@ -19,8 +19,34 @@
     "DefaultConnection": "Host=localhost;Port=6432;Database=expertise;Username=expertise;Password=;No Reset On Close=true"
   },
   "Auth": {
-    "Mode": "apikey",
-    "ApiKey": ""
+    "Mode": "Oidc",
+    "ApiKey": "",
+    "Oidc": {
+      "Issuers": [
+        {
+          "Name": "Entra",
+          "Issuer": "<TODO_ENTRA_ISSUER>",
+          "Audience": "<TODO_ENTRA_AUDIENCE>",
+          "AdditionalAudiences": [],
+          "ScopeClaims": ["scp", "roles"],
+          "TenantSource": "CompoundRole",
+          "RoleSeparator": ":",
+          "GroupClaim": "groups",
+          "GroupToTenantMapping": {}
+        },
+        {
+          "Name": "Authentik",
+          "Issuer": "<TODO_AUTHENTIK_ISSUER>",
+          "Audience": "<TODO_AUTHENTIK_AUDIENCE>",
+          "AdditionalAudiences": [],
+          "ScopeClaims": ["scope"],
+          "TenantSource": "Groups",
+          "RoleSeparator": ":",
+          "GroupClaim": "groups",
+          "GroupToTenantMapping": {}
+        }
+      ]
+    }
   },
   "Deduplication": {
     "Enabled": true,

--- a/src/ExpertiseApi/wwwroot/query.html
+++ b/src/ExpertiseApi/wwwroot/query.html
@@ -147,8 +147,8 @@
   <p class="subtitle">Browse and search the expertise store. Read-only.</p>
 
   <div class="auth-bar">
-    <label for="apiKey">API Key</label>
-    <input id="apiKey" type="password" placeholder="Bearer token" />
+    <label for="bearerToken">Bearer Token</label>
+    <input id="bearerToken" type="password" placeholder="JWT or API key (no &quot;Bearer&quot; prefix)" />
   </div>
 
   <!-- List / Filter -->
@@ -267,16 +267,30 @@
       document.getElementById(id).classList.toggle('open');
     }
 
+    var TOKEN_STORAGE_KEY = 'expertise-bearer-token';
+
     function getApiKey() {
-      return document.getElementById('apiKey').value.trim();
+      var input = document.getElementById('bearerToken');
+      var value = input.value.trim();
+      if (value) {
+        try { localStorage.setItem(TOKEN_STORAGE_KEY, value); } catch (e) { /* ignore */ }
+      }
+      return value;
     }
+
+    (function restoreToken() {
+      try {
+        var stored = localStorage.getItem(TOKEN_STORAGE_KEY);
+        if (stored) document.getElementById('bearerToken').value = stored;
+      } catch (e) { /* ignore */ }
+    })();
 
     var activeControllers = {};
 
     async function apiCall(path, resultId) {
       var key = getApiKey();
       if (!key) {
-        showResult(resultId, 'Enter an API key above.', true);
+        showResult(resultId, 'Enter a bearer token above.', true);
         return;
       }
 

--- a/tests/ExpertiseApi.Tests/Infrastructure/JwtApiFactory.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/JwtApiFactory.cs
@@ -1,0 +1,107 @@
+#pragma warning disable SKEXP0070
+
+using ExpertiseApi.Data;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using NSubstitute;
+using Pgvector;
+using Serilog;
+
+namespace ExpertiseApi.Tests.Infrastructure;
+
+/// <summary>
+/// API factory configured for OIDC authentication. The JWT path is exercised end-to-end
+/// against an in-memory RSA signing key — no JWKS HTTP fetch is performed because we
+/// preload <see cref="OpenIdConnectConfiguration"/> on the named JwtBearer scheme via
+/// <c>PostConfigure</c>.
+/// </summary>
+public class JwtApiFactory : WebApplicationFactory<Program>
+{
+    private readonly string _connectionString;
+
+    public JwtApiFactory(string connectionString)
+    {
+        _connectionString = connectionString;
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Development");
+        builder.UseSetting("Auth:Mode", "Oidc");
+
+        // Configure a single test issuer mirroring Authentik-style config
+        // (TenantSource = Groups, ScopeClaim = scope).
+        builder.UseSetting("Auth:Oidc:Issuers:0:Name", JwtTokenMinter.TestSchemeName);
+        builder.UseSetting("Auth:Oidc:Issuers:0:Issuer", JwtTokenMinter.TestIssuer);
+        builder.UseSetting("Auth:Oidc:Issuers:0:Audience", JwtTokenMinter.TestAudience);
+        builder.UseSetting("Auth:Oidc:Issuers:0:ScopeClaims:0", "scope");
+        builder.UseSetting("Auth:Oidc:Issuers:0:TenantSource", "Groups");
+        builder.UseSetting("Auth:Oidc:Issuers:0:GroupClaim", "groups");
+        builder.UseSetting("Auth:Oidc:Issuers:0:GroupToTenantMapping:group-test", "test");
+        builder.UseSetting("Auth:Oidc:Issuers:0:GroupToTenantMapping:group-shared", "shared");
+
+        builder.ConfigureLogging(logging =>
+        {
+            logging.ClearProviders();
+            var silentLogger = new LoggerConfiguration().MinimumLevel.Fatal().CreateLogger();
+            logging.AddSerilog(silentLogger, dispose: true);
+        });
+
+        builder.ConfigureServices(services =>
+        {
+            // Inject pre-built OpenIdConnectConfiguration so JwtBearer skips the JWKS HTTP fetch.
+            services.PostConfigure<JwtBearerOptions>(JwtTokenMinter.TestSchemeName, options =>
+            {
+                options.Configuration = new OpenIdConnectConfiguration
+                {
+                    Issuer = JwtTokenMinter.TestIssuer
+                };
+                options.Configuration.SigningKeys.Add(JwtTokenMinter.SigningKey);
+                options.TokenValidationParameters.IssuerSigningKey = JwtTokenMinter.SigningKey;
+                options.MetadataAddress = null!;
+            });
+
+            // Replace DbContext with test container connection.
+            var dbDescriptor = services.SingleOrDefault(
+                d => d.ServiceType == typeof(DbContextOptions<ExpertiseDbContext>));
+            if (dbDescriptor is not null)
+                services.Remove(dbDescriptor);
+
+            services.AddDbContext<ExpertiseDbContext>(options =>
+                options.UseNpgsql(_connectionString, o => o.UseVector()));
+
+            // Replace ONNX embedding generator with a deterministic mock.
+            var embeddingDescriptor = services.SingleOrDefault(
+                d => d.ServiceType == typeof(IEmbeddingGenerator<string, Embedding<float>>));
+            if (embeddingDescriptor is not null)
+                services.Remove(embeddingDescriptor);
+
+            var mockGenerator = Substitute.For<IEmbeddingGenerator<string, Embedding<float>>>();
+            mockGenerator.GenerateAsync(
+                    Arg.Any<IEnumerable<string>>(),
+                    Arg.Any<EmbeddingGenerationOptions?>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(callInfo =>
+                {
+                    var inputs = callInfo.ArgAt<IEnumerable<string>>(0).ToList();
+                    var result = new GeneratedEmbeddings<Embedding<float>>();
+                    foreach (var _ in inputs)
+                    {
+                        var vector = new float[384];
+                        for (var i = 0; i < 384; i++)
+                            vector[i] = (float)(new Random(42 + i).NextDouble() * 2 - 1);
+                        result.Add(new Embedding<float>(vector));
+                    }
+                    return Task.FromResult<GeneratedEmbeddings<Embedding<float>>>(result);
+                });
+
+            services.AddSingleton(mockGenerator);
+        });
+    }
+}

--- a/tests/ExpertiseApi.Tests/Infrastructure/JwtApiFactory.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/JwtApiFactory.cs
@@ -65,6 +65,9 @@ public class JwtApiFactory : WebApplicationFactory<Program>
                 options.Configuration.SigningKeys.Add(JwtTokenMinter.SigningKey);
                 options.TokenValidationParameters.IssuerSigningKey = JwtTokenMinter.SigningKey;
                 options.MetadataAddress = null!;
+                // Suppress the default ConfigurationManager so no code path can trigger
+                // a metadata fetch on https://test-issuer.local/.
+                options.ConfigurationManager = null;
             });
 
             // Replace DbContext with test container connection.

--- a/tests/ExpertiseApi.Tests/Infrastructure/JwtTokenMinter.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/JwtTokenMinter.cs
@@ -1,0 +1,59 @@
+using System.Security.Cryptography;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+namespace ExpertiseApi.Tests.Infrastructure;
+
+/// <summary>
+/// Mints test JWTs signed with an in-memory RSA key. Used by integration tests that exercise
+/// the OIDC path without spinning up a real IdP. The matching public key is registered with
+/// the API via <see cref="JwtApiFactory"/>.
+/// </summary>
+public static class JwtTokenMinter
+{
+    public const string TestIssuer = "https://test-issuer.local/";
+    public const string TestAudience = "test-audience";
+    public const string TestSchemeName = "TestIssuer";
+
+    public static readonly RsaSecurityKey SigningKey = new(RSA.Create(2048))
+    {
+        KeyId = "test-key-1"
+    };
+
+    public static string Mint(
+        string tenant,
+        IEnumerable<string> scopes,
+        string? sub = null,
+        IEnumerable<string>? groups = null,
+        TimeSpan? expiresIn = null,
+        string scopeClaim = "scope",
+        string? issuer = null,
+        string? audience = null)
+    {
+        var handler = new JsonWebTokenHandler();
+
+        var claims = new Dictionary<string, object>
+        {
+            ["sub"] = sub ?? "test-principal",
+            [scopeClaim] = string.Join(' ', scopes)
+        };
+
+        if (groups is not null)
+            claims["groups"] = groups.ToArray();
+
+        // Insert the tenant via group mapping (matches JwtApiFactory's GroupToTenantMapping)
+        if (!claims.ContainsKey("groups"))
+            claims["groups"] = new[] { $"group-{tenant}" };
+
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = issuer ?? TestIssuer,
+            Audience = audience ?? TestAudience,
+            Claims = claims,
+            Expires = DateTime.UtcNow.Add(expiresIn ?? TimeSpan.FromHours(1)),
+            SigningCredentials = new SigningCredentials(SigningKey, SecurityAlgorithms.RsaSha256)
+        };
+
+        return handler.CreateToken(descriptor);
+    }
+}

--- a/tests/ExpertiseApi.Tests/Integration/JwtAuthenticationTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/JwtAuthenticationTests.cs
@@ -1,0 +1,136 @@
+using System.Net;
+using System.Net.Http.Headers;
+using ExpertiseApi.Tests.Infrastructure;
+using FluentAssertions;
+
+namespace ExpertiseApi.Tests.Integration;
+
+[Collection("Postgres")]
+public class JwtAuthenticationTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private JwtApiFactory _factory = null!;
+
+    public JwtAuthenticationTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public Task InitializeAsync()
+    {
+        _factory = new JwtApiFactory(_postgres.ConnectionString);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync() => await _factory.DisposeAsync();
+
+    [Fact]
+    public async Task ValidJwt_WithReadScope_ReturnsOk()
+    {
+        var token = JwtTokenMinter.Mint(
+            tenant: "test",
+            scopes: [ExpertiseApi.Auth.AuthConstants.ReadScope],
+            groups: ["group-test"]);
+
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await client.GetAsync("/expertise");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task NoToken_Returns401()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/expertise");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ExpiredToken_Returns401()
+    {
+        var token = JwtTokenMinter.Mint(
+            tenant: "test",
+            scopes: [ExpertiseApi.Auth.AuthConstants.ReadScope],
+            groups: ["group-test"],
+            expiresIn: TimeSpan.FromMinutes(-5));
+
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await client.GetAsync("/expertise");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task WrongAudience_Returns401()
+    {
+        var token = JwtTokenMinter.Mint(
+            tenant: "test",
+            scopes: [ExpertiseApi.Auth.AuthConstants.ReadScope],
+            groups: ["group-test"],
+            audience: "wrong-audience");
+
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await client.GetAsync("/expertise");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task UnknownIssuer_Returns401()
+    {
+        var token = JwtTokenMinter.Mint(
+            tenant: "test",
+            scopes: [ExpertiseApi.Auth.AuthConstants.ReadScope],
+            groups: ["group-test"],
+            issuer: "https://other-issuer.local/");
+
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await client.GetAsync("/expertise");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ValidToken_NoMappedTenant_Returns403()
+    {
+        // Group "group-unmapped" is not in the JwtApiFactory's GroupToTenantMapping config
+        // (only group-test and group-shared are configured). Token validates but the
+        // ScopeAuthorizationHandler refuses to satisfy the requirement when Tenant is null.
+        var token = JwtTokenMinter.Mint(
+            tenant: "doesnt-matter",
+            scopes: [ExpertiseApi.Auth.AuthConstants.ReadScope],
+            groups: ["group-unmapped"]);
+
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await client.GetAsync("/expertise");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task ValidToken_InsufficientScope_Returns403()
+    {
+        // Mint with no scope at all — token validates but ScopeRequirement fails.
+        var token = JwtTokenMinter.Mint(
+            tenant: "test",
+            scopes: [],
+            groups: ["group-test"]);
+
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await client.GetAsync("/expertise");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+}

--- a/tests/ExpertiseApi.Tests/Unit/AuthModeStartupGuardTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/AuthModeStartupGuardTests.cs
@@ -1,0 +1,104 @@
+using ExpertiseApi.Auth;
+using FluentAssertions;
+using Microsoft.Extensions.Hosting;
+
+namespace ExpertiseApi.Tests.Unit;
+
+public class AuthModeStartupGuardTests
+{
+    [Theory]
+    [InlineData("Production", AuthMode.ApiKey)]
+    [InlineData("Production", AuthMode.LocalDev)]
+    [InlineData("Production", AuthMode.Hybrid)]
+    [InlineData("Staging", AuthMode.ApiKey)]
+    [InlineData("Staging", AuthMode.Hybrid)]
+    public void EnforceModeGuard_NonOidcOutsideDevelopment_Throws(string env, AuthMode mode)
+    {
+        var environment = new HostingEnvironment { EnvironmentName = env };
+
+        var act = () => AuthExtensions.EnforceModeGuard(mode, environment);
+
+        act.Should().Throw<InvalidOperationException>()
+           .WithMessage($"*Auth:Mode '{mode}'*Development*");
+    }
+
+    [Theory]
+    [InlineData(AuthMode.Oidc)]
+    [InlineData(AuthMode.LocalDev)]
+    [InlineData(AuthMode.ApiKey)]
+    [InlineData(AuthMode.Hybrid)]
+    public void EnforceModeGuard_AnyMode_IsPermittedInDevelopment(AuthMode mode)
+    {
+        var environment = new HostingEnvironment { EnvironmentName = Environments.Development };
+
+        var act = () => AuthExtensions.EnforceModeGuard(mode, environment);
+
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [InlineData("Production")]
+    [InlineData("Staging")]
+    public void EnforceModeGuard_OidcMode_BootsInAnyEnvironment(string env)
+    {
+        var environment = new HostingEnvironment { EnvironmentName = env };
+
+        var act = () => AuthExtensions.EnforceModeGuard(AuthMode.Oidc, environment);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ParseAuthMode_DefaultsToHybridInDevelopment()
+    {
+        var environment = new HostingEnvironment { EnvironmentName = Environments.Development };
+
+        var mode = AuthExtensions.ParseAuthMode(null, environment);
+
+        mode.Should().Be(AuthMode.Hybrid);
+    }
+
+    [Fact]
+    public void ParseAuthMode_DefaultsToOidcOutsideDevelopment()
+    {
+        var environment = new HostingEnvironment { EnvironmentName = "Production" };
+
+        var mode = AuthExtensions.ParseAuthMode(null, environment);
+
+        mode.Should().Be(AuthMode.Oidc);
+    }
+
+    [Theory]
+    [InlineData("oidc", AuthMode.Oidc)]
+    [InlineData("OIDC", AuthMode.Oidc)]
+    [InlineData("Hybrid", AuthMode.Hybrid)]
+    [InlineData("apikey", AuthMode.ApiKey)]
+    [InlineData("LocalDev", AuthMode.LocalDev)]
+    public void ParseAuthMode_IsCaseInsensitive(string input, AuthMode expected)
+    {
+        var environment = new HostingEnvironment { EnvironmentName = Environments.Development };
+
+        var mode = AuthExtensions.ParseAuthMode(input, environment);
+
+        mode.Should().Be(expected);
+    }
+
+    [Fact]
+    public void ParseAuthMode_RejectsUnknownValues()
+    {
+        var environment = new HostingEnvironment { EnvironmentName = Environments.Development };
+
+        var act = () => AuthExtensions.ParseAuthMode("garbage", environment);
+
+        act.Should().Throw<InvalidOperationException>()
+           .WithMessage("*not a recognized mode*");
+    }
+
+    private class HostingEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Development;
+        public string ApplicationName { get; set; } = "Test";
+        public string ContentRootPath { get; set; } = "/";
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } = null!;
+    }
+}

--- a/tests/ExpertiseApi.Tests/Unit/JwtTenantContextEventsTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/JwtTenantContextEventsTests.cs
@@ -11,7 +11,11 @@ public class JwtTenantContextEventsTests
         var result = JwtTenantContextEvents.ExpandScopeClosure(new[] { AuthConstants.LegacyWriteScope });
 
         result.Should().Contain(AuthConstants.WriteDraftScope);
+        result.Should().Contain(AuthConstants.ReadScope);
         result.Should().NotContain(AuthConstants.LegacyWriteScope);
+        // Legacy alias must NOT escalate to approve or admin.
+        result.Should().NotContain(AuthConstants.WriteApproveScope);
+        result.Should().NotContain(AuthConstants.AdminScope);
     }
 
     [Fact]
@@ -53,5 +57,84 @@ public class JwtTenantContextEventsTests
         var result = JwtTenantContextEvents.ExpandScopeClosure(new[] { AuthConstants.ReadScope });
 
         result.Should().BeEquivalentTo(new[] { AuthConstants.ReadScope });
+    }
+
+    [Fact]
+    public void ParseCompoundRoles_SingleTenantSingleScope_ExtractsBoth()
+    {
+        var (tenant, scopes) = JwtTenantContextEvents.ParseCompoundRoles(
+            new[] { "team-alpha:expertise.read" }, separator: ":");
+
+        tenant.Should().Be("team-alpha");
+        scopes.Should().BeEquivalentTo(new[] { "expertise.read" });
+    }
+
+    [Fact]
+    public void ParseCompoundRoles_SingleTenantMultipleScopes_AggregatesScopes()
+    {
+        var (tenant, scopes) = JwtTenantContextEvents.ParseCompoundRoles(
+            new[]
+            {
+                "team-alpha:expertise.read",
+                "team-alpha:expertise.write.draft"
+            },
+            separator: ":");
+
+        tenant.Should().Be("team-alpha");
+        scopes.Should().BeEquivalentTo(new[] { "expertise.read", "expertise.write.draft" });
+    }
+
+    [Fact]
+    public void ParseCompoundRoles_MultipleTenants_FirstWinsAndOthersDropped()
+    {
+        // Machine credentials are scoped to a single tenant; a token claiming two tenants
+        // is rejected past the first. team-beta scopes must NOT leak through.
+        var (tenant, scopes) = JwtTenantContextEvents.ParseCompoundRoles(
+            new[]
+            {
+                "team-alpha:expertise.read",
+                "team-beta:expertise.admin"
+            },
+            separator: ":");
+
+        tenant.Should().Be("team-alpha");
+        scopes.Should().BeEquivalentTo(new[] { "expertise.read" });
+        scopes.Should().NotContain("expertise.admin");
+    }
+
+    [Fact]
+    public void ParseCompoundRoles_NoSeparator_YieldsNullTenantAndEmptyScopes()
+    {
+        var (tenant, scopes) = JwtTenantContextEvents.ParseCompoundRoles(
+            new[] { "expertise.read" }, separator: ":");
+
+        tenant.Should().BeNull();
+        scopes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseCompoundRoles_EmptyTenantOrScopeSegment_IsSkipped()
+    {
+        var (tenant, scopes) = JwtTenantContextEvents.ParseCompoundRoles(
+            new[]
+            {
+                ":expertise.read",        // empty tenant
+                "team-alpha:",            // empty scope
+                "team-alpha:expertise.read"
+            },
+            separator: ":");
+
+        tenant.Should().Be("team-alpha");
+        scopes.Should().BeEquivalentTo(new[] { "expertise.read" });
+    }
+
+    [Fact]
+    public void ParseCompoundRoles_EmptyInput_YieldsNullTenant()
+    {
+        var (tenant, scopes) = JwtTenantContextEvents.ParseCompoundRoles(
+            Array.Empty<string>(), separator: ":");
+
+        tenant.Should().BeNull();
+        scopes.Should().BeEmpty();
     }
 }

--- a/tests/ExpertiseApi.Tests/Unit/JwtTenantContextEventsTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/JwtTenantContextEventsTests.cs
@@ -1,0 +1,57 @@
+using ExpertiseApi.Auth;
+using FluentAssertions;
+
+namespace ExpertiseApi.Tests.Unit;
+
+public class JwtTenantContextEventsTests
+{
+    [Fact]
+    public void ExpandScopeClosure_NormalizesLegacyWriteToDraft()
+    {
+        var result = JwtTenantContextEvents.ExpandScopeClosure(new[] { AuthConstants.LegacyWriteScope });
+
+        result.Should().Contain(AuthConstants.WriteDraftScope);
+        result.Should().NotContain(AuthConstants.LegacyWriteScope);
+    }
+
+    [Fact]
+    public void ExpandScopeClosure_AdminImpliesAll()
+    {
+        var result = JwtTenantContextEvents.ExpandScopeClosure(new[] { AuthConstants.AdminScope });
+
+        result.Should().BeEquivalentTo(new[]
+        {
+            AuthConstants.AdminScope,
+            AuthConstants.WriteApproveScope,
+            AuthConstants.WriteDraftScope,
+            AuthConstants.ReadScope
+        });
+    }
+
+    [Fact]
+    public void ExpandScopeClosure_ApproveImpliesDraftAndRead()
+    {
+        var result = JwtTenantContextEvents.ExpandScopeClosure(new[] { AuthConstants.WriteApproveScope });
+
+        result.Should().Contain(AuthConstants.WriteDraftScope);
+        result.Should().Contain(AuthConstants.ReadScope);
+        result.Should().NotContain(AuthConstants.AdminScope);
+    }
+
+    [Fact]
+    public void ExpandScopeClosure_DraftImpliesRead()
+    {
+        var result = JwtTenantContextEvents.ExpandScopeClosure(new[] { AuthConstants.WriteDraftScope });
+
+        result.Should().Contain(AuthConstants.ReadScope);
+        result.Should().NotContain(AuthConstants.WriteApproveScope);
+    }
+
+    [Fact]
+    public void ExpandScopeClosure_ReadStaysRead()
+    {
+        var result = JwtTenantContextEvents.ExpandScopeClosure(new[] { AuthConstants.ReadScope });
+
+        result.Should().BeEquivalentTo(new[] { AuthConstants.ReadScope });
+    }
+}

--- a/tests/ExpertiseApi.Tests/Unit/ScopeAuthorizationHandlerTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/ScopeAuthorizationHandlerTests.cs
@@ -1,0 +1,100 @@
+using System.Security.Claims;
+using ExpertiseApi.Auth;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+
+namespace ExpertiseApi.Tests.Unit;
+
+public class ScopeAuthorizationHandlerTests
+{
+    [Fact]
+    public async Task Succeeds_WhenScopeIsPresent()
+    {
+        var ctx = HttpCtxWithTenant("test", AuthConstants.ReadScope);
+        var (handler, authCtx) = HandlerFor(ctx, AuthConstants.ReadScope);
+
+        await handler.HandleAsync(authCtx);
+
+        authCtx.HasSucceeded.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Fails_WhenScopeIsAbsent()
+    {
+        var ctx = HttpCtxWithTenant("test", AuthConstants.ReadScope);
+        var (handler, authCtx) = HandlerFor(ctx, AuthConstants.AdminScope);
+
+        await handler.HandleAsync(authCtx);
+
+        authCtx.HasSucceeded.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Fails_WhenTenantIsNull()
+    {
+        var ctx = HttpCtxWithTenant(null, AuthConstants.AdminScope);
+        var (handler, authCtx) = HandlerFor(ctx, AuthConstants.ReadScope);
+
+        await handler.HandleAsync(authCtx);
+
+        authCtx.HasSucceeded.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Fails_WhenTenantContextIsAbsent()
+    {
+        var ctx = new DefaultHttpContext();
+        var (handler, authCtx) = HandlerFor(ctx, AuthConstants.ReadScope);
+
+        await handler.HandleAsync(authCtx);
+
+        authCtx.HasSucceeded.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(AuthConstants.AdminScope, AuthConstants.ReadScope)]
+    [InlineData(AuthConstants.AdminScope, AuthConstants.WriteDraftScope)]
+    [InlineData(AuthConstants.AdminScope, AuthConstants.WriteApproveScope)]
+    [InlineData(AuthConstants.AdminScope, AuthConstants.AdminScope)]
+    [InlineData(AuthConstants.WriteApproveScope, AuthConstants.WriteDraftScope)]
+    [InlineData(AuthConstants.WriteApproveScope, AuthConstants.ReadScope)]
+    [InlineData(AuthConstants.WriteDraftScope, AuthConstants.ReadScope)]
+    public async Task ExpandedClosure_SatisfiesImpliedScope(string heldScope, string requirementScope)
+    {
+        // Closure expansion is the responsibility of the issuer (handler/event); these tests
+        // verify that once a token's scopes are expanded by JwtTenantContextEvents, the
+        // ScopeAuthorizationHandler honors the expansion.
+        var expanded = JwtTenantContextEvents.ExpandScopeClosure(new[] { heldScope });
+        var ctx = HttpCtxWithTenant("test", [.. expanded]);
+        var (handler, authCtx) = HandlerFor(ctx, requirementScope);
+
+        await handler.HandleAsync(authCtx);
+
+        authCtx.HasSucceeded.Should().BeTrue();
+    }
+
+    private static HttpContext HttpCtxWithTenant(string? tenant, params string[] scopes)
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.SetTenantContext(new TenantContext(
+            Tenant: tenant,
+            Principal: new ClaimsPrincipal(new ClaimsIdentity("Test")),
+            Agent: null,
+            Scopes: scopes.ToHashSet()));
+        return ctx;
+    }
+
+    private static (ScopeAuthorizationHandler handler, AuthorizationHandlerContext ctx) HandlerFor(
+        HttpContext httpContext,
+        string requirementScope)
+    {
+        var requirement = new ScopeRequirement(requirementScope);
+        var authCtx = new AuthorizationHandlerContext(
+            [requirement],
+            new ClaimsPrincipal(new ClaimsIdentity()),
+            httpContext);
+        var accessor = new HttpContextAccessor { HttpContext = httpContext };
+        return (new ScopeAuthorizationHandler(accessor), authCtx);
+    }
+}


### PR DESCRIPTION
Closes #47. Part of #45.

## Summary

PR 2 of the secure rebuild. Replaces the static API key handler with multi-issuer JWT validation, builds `TenantContext` per request, registers four scope-bound authorization policies, and adds the `Auth:Mode` startup guard. Existing endpoints continue to work under `Hybrid` mode (default in Development) — no breaking change in this PR.

## Type of Change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [ ] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change (add `!` to PR title)

## Test Plan

- [x] `dotnet test ExpertiseApi.slnx` — 109/109 passing locally (44 new tests; existing 65 from PR 1 still green)
- [x] New tests:
  - **Unit** — `ScopeAuthorizationHandlerTests` (closure expansion, missing TenantContext, scope-implication matrix), `JwtTenantContextEventsTests` (legacy → draft normalization, full implication closure), `AuthModeStartupGuardTests` (every Auth:Mode × environment combination)
  - **Integration** — `JwtAuthenticationTests` via new `JwtApiFactory` (valid token → 200, no token → 401, expired/wrong-audience/unknown-issuer → 401, valid + no tenant mapping → 403, valid + insufficient scope → 403)
- [x] Existing API key tests (`AuthEndpointTests`, `ApiKeyAuthHandlerTests`) continue to pass under `Hybrid` mode
- [x] `dotnet format` clean; `markdownlint` clean
- [x] No Helm chart change in this PR

## Checklist

- [x] No secrets or credentials committed (Issuer/Audience are `<TODO_*>` placeholders in `appsettings.json`)
- [x] Linter clean on changed files
- [ ] Database migrations are reversible — N/A (no schema change)
- [x] API changes are backward-compatible — existing API key flow continues to work under Development `Hybrid` mode
- [x] CLAUDE.md, README.md, and SKILL.md updated with the new auth model

## Architecture decisions (resolved during planning)

1. **`roles` vs `scp` for Entra**: read both — Entra emits `roles` for `client_credentials` (no `scp`), `scp` for delegated. Per-issuer `ScopeClaims[]` config supports either or both.
2. **Tenant from compound roles** (`team-alpha:expertise.read`) for Entra `client_credentials` since groups aren't emitted for service principals. `TenantSource` per-issuer config selects between `Groups` (delegated, Authentik) and `CompoundRole` (Entra `client_credentials`).
3. **One JwtBearer scheme per issuer** behind a `Bearer` policy scheme — avoids the silent audience cross-contamination that a flat `ValidIssuers`/`ValidAudiences` list would create.
4. **`appsettings.Development.json`** confirmed well-formed. No structural fix needed.
5. **`BuildEntry` updated to read `TenantContext`** in this PR — the PR 1 placeholders (`Tenant = "legacy"`, `AuthorPrincipal = "pre-rebuild"`) would have made every entry created post-PR-2 ignored by PR 3's tenant filter.

## Minor deviation from the plan

`LocalDevAuthHandler` token format uses **colons** (`Bearer dev:{tenant}:{scope1}+{scope2}`) rather than the original brief's hyphens (`Bearer dev-{tenant}-{scopes}`). Reason: tenant names with hyphens (e.g. `team-alpha`) would break the parse with the hyphen separator. Documented in `CLAUDE.md`.

## What is NOT in this PR

- Tenant filtering in repository methods → PR 3 (#48)
- `IExpertiseRepository` signature changes to take `TenantContext` → PR 3 (#48)
- EF global query filter on `ExpertiseEntry.Tenant` → PR 3 (#48)
- `/approve`, `/reject`, `/drafts`, `/audit` endpoints + audit write path → PR 4 (#49)
- Rate limiting → PR 5 (#50)
- Production cutover (`Auth:Mode = Oidc` in production config + `appsettings.Production.json` overrides) → PR 6 (#51)

## Follow-up

ADR-002 (multi-IdP OIDC) should get a small clarification PR documenting the `roles`-vs-`scp` claim distinction for Entra `client_credentials` and the `TenantSource: CompoundRole` design that follows from it. Not blocking PR 2.

## Cross-repo coordination

This PR adds OIDC scaffolding but does not require any IdP to be live. PR 6 (production cutover) is when Authentik must be deployed (`agent-expertise-vps` IaC repo) and Entra app registrations configured.