### PR TITLE
feat(reads): tenant filtering on read endpoints

### DIFF
--- a/.claude/skills/expertise-api-design/SKILL.md
+++ b/.claude/skills/expertise-api-design/SKILL.md
@@ -161,9 +161,19 @@ Four scopes with hierarchical implication (`admin ⊇ approve ⊇ draft ⊇ read
 
 ### TenantContext
 
-A `TenantContext { Tenant, Principal, Agent?, Scopes[] }` is built per request and stashed on `HttpContext.Features`. All authentication paths (JWT, ApiKey, LocalDev) populate it. Endpoints read it via `HttpContext.RequireTenantContext()`. Repository methods (PR 3) will require it as an argument.
+A `TenantContext { Tenant, Principal, Agent?, Scopes[] }` is built per request and stashed on `HttpContext.Features`. All authentication paths (JWT, ApiKey, LocalDev) populate it. Endpoints read it via `HttpContext.RequireTenantContext()`. Per ADR-001 every `IExpertiseRepository` method takes a `TenantContext` argument and constructs explicit `WHERE Tenant IN (ctx.Tenant, "shared") AND ReviewState = Approved` predicates. The default review state filter is lifted by `?includeDrafts=true` only when the caller carries `expertise.write.approve` (otherwise the endpoint returns 403); the tenant filter is unconditional.
 
 When the principal authenticates successfully but no tenant maps (e.g. group not in `GroupToTenantMapping`), `TenantContext.Tenant` is `null` and the authorization handler returns 403.
+
+### Tenant filtering — defense layers
+
+1. **Endpoint** — every protected endpoint reads `httpContext.RequireTenantContext()` and threads it to the repository.
+2. **Repository** — primary safeguard. Each method applies an explicit `WHERE Tenant IN (ctx.Tenant, "shared")`; `GetByIdAsync`, `UpdateAsync`, and `SoftDeleteAsync` use `Where(id) + FirstOrDefaultAsync` rather than `FindAsync` so the filter cannot be bypassed via the EF identity map.
+3. **EF global query filter** — `HasQueryFilter` on `ExpertiseEntry` reads `ITenantContextAccessor.Tenant` (HTTP-backed). Defense-in-depth: when a future query forgets the explicit `WHERE`, this still applies. Short-circuits to no filter when the accessor returns null (CLI / design-time / direct test seeding) — those paths rely on the explicit repository `WHERE` for correctness.
+4. **CLI bypass** — `reembed` and `rehash` commands call `IgnoreQueryFilters()` explicitly so they process every tenant.
+5. **Dedup tenant scoping** — `FindExactMatchAsync`, `FindExactMatchesAsync`, `FindNearestInDomainAsync`, and `FindAllEmbeddingsInDomainAsync` are tenant-scoped so a `409 Conflict` on `POST /expertise` cannot leak another tenant's entry contents in the response body.
+
+Cross-tenant operations return **404, not 403**, on `GET`, `PATCH`, and `DELETE` so existence is not disclosed.
 
 ## Embedding Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,19 @@ Four scopes drive the four authorization policies. The hierarchy is `admin ⊇ a
 
 The legacy `expertise.write` scope is normalized to `expertise.write.draft` during one transition cycle.
 
+### Tenant filtering on reads
+
+Every read path is scoped to `Tenant IN (caller_tenant, "shared") AND ReviewState = Approved`. Cross-tenant reads return 404, never 403, so existence is not disclosed. The filter is layered:
+
+1. **Endpoint** — every read endpoint reads `httpContext.RequireTenantContext()` and passes it to the repository.
+2. **Repository** — every `IExpertiseRepository` method takes a `TenantContext` and applies an explicit `WHERE` clause (primary safeguard per ADR-001).
+3. **EF global query filter** — `HasQueryFilter` on `ExpertiseEntry` reads from `ITenantContextAccessor` as defense-in-depth. When the accessor returns null (CLI / design-time / direct DbContext access in tests) the filter short-circuits and the explicit repository `WHERE` drives correctness.
+4. **CLI bypass** — `reembed` and `rehash` call `IgnoreQueryFilters()` explicitly to operate across all tenants.
+
+`?includeDrafts=true` lifts the `ReviewState = Approved` filter on `GET /expertise`, `GET /expertise/search`, and `GET /expertise/search/semantic` — but requires `expertise.write.approve`. A `read`-only caller passing `includeDrafts=true` gets 403. Tenant scoping always applies regardless of `includeDrafts`.
+
+`?includeDeprecated=true` lifts the `DeprecatedAt IS NULL` filter; tenant scoping still applies.
+
 ### OIDC issuers
 
 `Auth:Oidc:Issuers[]` is an array of per-issuer configs. Each entry:

--- a/src/ExpertiseApi/Auth/HttpTenantContextAccessor.cs
+++ b/src/ExpertiseApi/Auth/HttpTenantContextAccessor.cs
@@ -1,0 +1,24 @@
+namespace ExpertiseApi.Auth;
+
+/// <summary>
+/// Resolves <see cref="ITenantContextAccessor.Tenant"/> from the current
+/// <see cref="HttpContext"/>'s <see cref="TenantContext"/>. Returns <c>null</c>
+/// when no <see cref="HttpContext"/> is available — the EF global query filter
+/// treats that as "no filter" (CLI / design-time) and falls back to the explicit
+/// repository <c>Where</c> clauses for safety.
+/// </summary>
+public sealed class HttpTenantContextAccessor(IHttpContextAccessor httpContextAccessor)
+    : ITenantContextAccessor
+{
+    public string? Tenant =>
+        httpContextAccessor.HttpContext?.GetTenantContext()?.Tenant;
+}
+
+/// <summary>
+/// Always returns <c>null</c>. Used by <see cref="Data.DesignTimeDbContextFactory"/>
+/// so <c>dotnet ef</c> tooling can construct a DbContext without an HTTP scope.
+/// </summary>
+public sealed class NoOpTenantContextAccessor : ITenantContextAccessor
+{
+    public string? Tenant => null;
+}

--- a/src/ExpertiseApi/Auth/ITenantContextAccessor.cs
+++ b/src/ExpertiseApi/Auth/ITenantContextAccessor.cs
@@ -1,0 +1,18 @@
+namespace ExpertiseApi.Auth;
+
+/// <summary>
+/// Provides the tenant identifier for the current execution scope. Drives the
+/// <c>HasQueryFilter</c> on <see cref="Data.ExpertiseDbContext"/> as defense-in-depth
+/// against accidental cross-tenant reads.
+/// <para>
+/// Returns <c>null</c> when no HTTP request scope is active (CLI commands,
+/// design-time DbContext factory, repository calls outside the request pipeline).
+/// In that case the global query filter short-circuits and applies no tenant
+/// predicate — the explicit <c>Where</c> clauses constructed inside
+/// <see cref="Data.IExpertiseRepository"/> remain the primary safeguard.
+/// </para>
+/// </summary>
+public interface ITenantContextAccessor
+{
+    string? Tenant { get; }
+}

--- a/src/ExpertiseApi/Cli/ReembedCommand.cs
+++ b/src/ExpertiseApi/Cli/ReembedCommand.cs
@@ -25,7 +25,11 @@ public static class ReembedCommand
 
         while (true)
         {
-            var query = db.ExpertiseEntries.OrderBy(e => e.Id).AsQueryable();
+            // CLI must process every tenant — bypass the EF tenant query filter explicitly.
+            // The accessor returns null in CLI scope so the filter would short-circuit anyway,
+            // but the explicit call documents intent and is robust against future changes to
+            // the null-handling semantics in HasQueryFilter.
+            var query = db.ExpertiseEntries.IgnoreQueryFilters().OrderBy(e => e.Id).AsQueryable();
             if (lastId is not null)
                 query = query.Where(e => e.Id > lastId.Value);
 

--- a/src/ExpertiseApi/Cli/RehashCommand.cs
+++ b/src/ExpertiseApi/Cli/RehashCommand.cs
@@ -23,7 +23,10 @@ public static class RehashCommand
 
         while (true)
         {
+            // CLI must process every tenant — bypass the EF tenant query filter explicitly.
+            // See ReembedCommand for rationale.
             var query = db.ExpertiseEntries
+                .IgnoreQueryFilters()
                 .Where(e => e.IntegrityHash == null)
                 .OrderBy(e => e.Id)
                 .AsQueryable();

--- a/src/ExpertiseApi/Data/DesignTimeDbContextFactory.cs
+++ b/src/ExpertiseApi/Data/DesignTimeDbContextFactory.cs
@@ -1,3 +1,4 @@
+using ExpertiseApi.Auth;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 
@@ -10,6 +11,6 @@ public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<ExpertiseD
         var optionsBuilder = new DbContextOptionsBuilder<ExpertiseDbContext>();
         optionsBuilder.UseNpgsql("Host=localhost;Database=expertise", o => o.UseVector());
 
-        return new ExpertiseDbContext(optionsBuilder.Options);
+        return new ExpertiseDbContext(optionsBuilder.Options, new NoOpTenantContextAccessor());
     }
 }

--- a/src/ExpertiseApi/Data/ExpertiseDbContext.cs
+++ b/src/ExpertiseApi/Data/ExpertiseDbContext.cs
@@ -1,9 +1,12 @@
+using ExpertiseApi.Auth;
 using ExpertiseApi.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace ExpertiseApi.Data;
 
-public class ExpertiseDbContext(DbContextOptions<ExpertiseDbContext> options) : DbContext(options)
+public class ExpertiseDbContext(
+    DbContextOptions<ExpertiseDbContext> options,
+    ITenantContextAccessor tenantAccessor) : DbContext(options)
 {
     public DbSet<ExpertiseEntry> ExpertiseEntries => Set<ExpertiseEntry>();
     public DbSet<EmbeddingMetadata> EmbeddingMetadata => Set<EmbeddingMetadata>();
@@ -66,6 +69,17 @@ public class ExpertiseDbContext(DbContextOptions<ExpertiseDbContext> options) : 
 
             entity.HasIndex(e => e.SearchVector)
                 .HasMethod("gin");
+
+            // Defense-in-depth tenant filter. Primary defense lives in IExpertiseRepository
+            // (per ADR-001) — every read method constructs an explicit WHERE from its
+            // TenantContext argument. This filter is the safety net for any future query
+            // that forgets that explicit clause. When the accessor returns null (CLI,
+            // design-time, test direct-context access) the predicate short-circuits and
+            // no filter applies; the explicit repository WHERE then drives correctness.
+            entity.HasQueryFilter(e =>
+                tenantAccessor.Tenant == null ||
+                e.Tenant == tenantAccessor.Tenant ||
+                e.Tenant == "shared");
         });
 
         modelBuilder.Entity<EmbeddingMetadata>(entity =>

--- a/src/ExpertiseApi/Data/ExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/ExpertiseRepository.cs
@@ -1,3 +1,4 @@
+using ExpertiseApi.Auth;
 using ExpertiseApi.Models;
 using Microsoft.EntityFrameworkCore;
 using Pgvector;
@@ -7,20 +8,63 @@ namespace ExpertiseApi.Data;
 
 public class ExpertiseRepository(ExpertiseDbContext db, ILogger<ExpertiseRepository> logger) : IExpertiseRepository
 {
-    public async Task<ExpertiseEntry?> GetByIdAsync(Guid id, CancellationToken ct)
+    /// <summary>
+    /// Builds the tenant predicate per ADR-001: a row is visible if its <c>Tenant</c>
+    /// matches the caller's, or if it is in the cross-tenant <c>shared</c> namespace.
+    /// </summary>
+    private static IQueryable<ExpertiseEntry> ApplyTenantFilter(
+        IQueryable<ExpertiseEntry> query, TenantContext ctx)
     {
-        return await db.ExpertiseEntries.FindAsync([id], ct);
+        var tenant = RequireTenant(ctx);
+        return query.Where(e => e.Tenant == tenant || e.Tenant == "shared");
+    }
+
+    /// <summary>
+    /// Read filter that gates draft visibility. By default reads are restricted to
+    /// <see cref="ReviewState.Approved"/> entries. <paramref name="includeDrafts"/> is
+    /// only honored at the endpoint layer when the caller carries
+    /// <see cref="AuthConstants.WriteApproveScope"/>.
+    /// </summary>
+    private static IQueryable<ExpertiseEntry> ApplyReviewStateFilter(
+        IQueryable<ExpertiseEntry> query, bool includeDrafts)
+    {
+        return includeDrafts
+            ? query
+            : query.Where(e => e.ReviewState == ReviewState.Approved);
+    }
+
+    /// <summary>
+    /// Defensive guard. If the auth pipeline produced a <see cref="TenantContext"/> with a
+    /// null <c>Tenant</c> (unmapped principal), the authorization handler should have
+    /// returned 403 before we reached the repository — but if anything slips through, fail
+    /// loud rather than running an unbounded query against the full table.
+    /// </summary>
+    private static string RequireTenant(TenantContext ctx) =>
+        ctx.Tenant ?? throw new InvalidOperationException(
+            "Repository invoked with TenantContext.Tenant=null. The authorization pipeline " +
+            "must reject unmapped principals before any repository call.");
+
+    public async Task<ExpertiseEntry?> GetByIdAsync(Guid id, TenantContext ctx, CancellationToken ct)
+    {
+        // FindAsync would short-circuit through the identity map and bypass the tenant
+        // filter; explicit Where + FirstOrDefaultAsync keeps every read tenant-scoped.
+        return await ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx)
+            .Where(e => e.Id == id)
+            .FirstOrDefaultAsync(ct);
     }
 
     public async Task<List<ExpertiseEntry>> ListAsync(
+        TenantContext ctx,
         string? domain,
         List<string>? tags,
         EntryType? entryType,
         Severity? severity,
+        bool includeDrafts,
         bool includeDeprecated,
         CancellationToken ct)
     {
-        var query = db.ExpertiseEntries.AsQueryable();
+        var query = ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx);
+        query = ApplyReviewStateFilter(query, includeDrafts);
 
         if (!includeDeprecated)
             query = query.Where(e => e.DeprecatedAt == null);
@@ -40,8 +84,16 @@ public class ExpertiseRepository(ExpertiseDbContext db, ILogger<ExpertiseReposit
         return await query.OrderByDescending(e => e.UpdatedAt).ToListAsync(ct);
     }
 
-    public async Task<ExpertiseEntry> CreateAsync(ExpertiseEntry entry, CancellationToken ct)
+    public async Task<ExpertiseEntry> CreateAsync(ExpertiseEntry entry, TenantContext ctx, CancellationToken ct)
     {
+        // Defensive: ensure the entry's Tenant matches the caller's. BuildEntry wires this
+        // from the same TenantContext, but verifying here closes the loop against any
+        // future code path that constructs an entry with a request-supplied tenant.
+        var callerTenant = RequireTenant(ctx);
+        if (!string.Equals(entry.Tenant, callerTenant, StringComparison.Ordinal))
+            throw new InvalidOperationException(
+                $"Entry tenant '{entry.Tenant}' does not match caller tenant '{callerTenant}'.");
+
         entry.CreatedAt = DateTime.UtcNow;
         entry.UpdatedAt = DateTime.UtcNow;
 
@@ -51,9 +103,11 @@ public class ExpertiseRepository(ExpertiseDbContext db, ILogger<ExpertiseReposit
         return entry;
     }
 
-    public async Task<ExpertiseEntry?> UpdateAsync(Guid id, Func<ExpertiseEntry, Task> applyUpdates, CancellationToken ct)
+    public async Task<ExpertiseEntry?> UpdateAsync(Guid id, TenantContext ctx, Func<ExpertiseEntry, Task> applyUpdates, CancellationToken ct)
     {
-        var entry = await db.ExpertiseEntries.FindAsync([id], ct);
+        var entry = await ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx)
+            .Where(e => e.Id == id)
+            .FirstOrDefaultAsync(ct);
         if (entry is null)
             return null;
 
@@ -64,9 +118,11 @@ public class ExpertiseRepository(ExpertiseDbContext db, ILogger<ExpertiseReposit
         return entry;
     }
 
-    public async Task<bool> SoftDeleteAsync(Guid id, CancellationToken ct)
+    public async Task<bool> SoftDeleteAsync(Guid id, TenantContext ctx, CancellationToken ct)
     {
-        var entry = await db.ExpertiseEntries.FindAsync([id], ct);
+        var entry = await ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx)
+            .Where(e => e.Id == id)
+            .FirstOrDefaultAsync(ct);
         if (entry is null)
             return false;
 
@@ -77,33 +133,58 @@ public class ExpertiseRepository(ExpertiseDbContext db, ILogger<ExpertiseReposit
         return true;
     }
 
-    public async Task<List<ExpertiseEntry>> KeywordSearchAsync(string query, bool includeDeprecated, CancellationToken ct)
+    public async Task<List<ExpertiseEntry>> KeywordSearchAsync(string query, TenantContext ctx, bool includeDrafts, bool includeDeprecated, CancellationToken ct)
     {
-        if (includeDeprecated)
-        {
-            return await db.ExpertiseEntries
-                .FromSqlInterpolated($"""
-                    SELECT * FROM "ExpertiseEntries"
-                    WHERE "SearchVector" @@ plainto_tsquery('english', {query})
-                    ORDER BY ts_rank("SearchVector", plainto_tsquery('english', {query})) DESC
-                    """)
-                .ToListAsync(ct);
-        }
+        // Tenant + ReviewState + DeprecatedAt filters live inside the raw SQL alongside
+        // ORDER BY ts_rank because composing LINQ Where on top of FromSqlInterpolated
+        // wraps the original query in a subquery — the planner may then drop the inner
+        // ORDER BY since the subquery has no LIMIT, leaving result order undefined.
+        // Branching keeps each SQL string fully parameterized via FromSqlInterpolated.
+        var tenant = RequireTenant(ctx);
+        var approvedState = nameof(ReviewState.Approved);
 
-        return await db.ExpertiseEntries
-            .FromSqlInterpolated($"""
+        if (includeDrafts && includeDeprecated)
+            return await db.ExpertiseEntries.FromSqlInterpolated($"""
                 SELECT * FROM "ExpertiseEntries"
                 WHERE "SearchVector" @@ plainto_tsquery('english', {query})
+                  AND ("Tenant" = {tenant} OR "Tenant" = 'shared')
+                ORDER BY ts_rank("SearchVector", plainto_tsquery('english', {query})) DESC
+                """).ToListAsync(ct);
+
+        if (includeDrafts)
+            return await db.ExpertiseEntries.FromSqlInterpolated($"""
+                SELECT * FROM "ExpertiseEntries"
+                WHERE "SearchVector" @@ plainto_tsquery('english', {query})
+                  AND ("Tenant" = {tenant} OR "Tenant" = 'shared')
                   AND "DeprecatedAt" IS NULL
                 ORDER BY ts_rank("SearchVector", plainto_tsquery('english', {query})) DESC
-                """)
-            .ToListAsync(ct);
+                """).ToListAsync(ct);
+
+        if (includeDeprecated)
+            return await db.ExpertiseEntries.FromSqlInterpolated($"""
+                SELECT * FROM "ExpertiseEntries"
+                WHERE "SearchVector" @@ plainto_tsquery('english', {query})
+                  AND ("Tenant" = {tenant} OR "Tenant" = 'shared')
+                  AND "ReviewState" = {approvedState}
+                ORDER BY ts_rank("SearchVector", plainto_tsquery('english', {query})) DESC
+                """).ToListAsync(ct);
+
+        return await db.ExpertiseEntries.FromSqlInterpolated($"""
+            SELECT * FROM "ExpertiseEntries"
+            WHERE "SearchVector" @@ plainto_tsquery('english', {query})
+              AND ("Tenant" = {tenant} OR "Tenant" = 'shared')
+              AND "ReviewState" = {approvedState}
+              AND "DeprecatedAt" IS NULL
+            ORDER BY ts_rank("SearchVector", plainto_tsquery('english', {query})) DESC
+            """).ToListAsync(ct);
     }
 
-    public async Task<List<ExpertiseEntry>> SemanticSearchAsync(Vector queryVector, int limit, bool includeDeprecated, CancellationToken ct)
+    public async Task<List<ExpertiseEntry>> SemanticSearchAsync(Vector queryVector, TenantContext ctx, int limit, bool includeDrafts, bool includeDeprecated, CancellationToken ct)
     {
-        var query = db.ExpertiseEntries
+        var query = ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx)
             .Where(e => e.Embedding != null);
+
+        query = ApplyReviewStateFilter(query, includeDrafts);
 
         if (!includeDeprecated)
             query = query.Where(e => e.DeprecatedAt == null);
@@ -114,28 +195,28 @@ public class ExpertiseRepository(ExpertiseDbContext db, ILogger<ExpertiseReposit
             .ToListAsync(ct);
     }
 
-    public async Task<ExpertiseEntry?> FindExactMatchAsync(string domain, string title, CancellationToken ct)
+    public async Task<ExpertiseEntry?> FindExactMatchAsync(string domain, string title, TenantContext ctx, CancellationToken ct)
     {
-        return await db.ExpertiseEntries
+        return await ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx)
             .Where(e => e.DeprecatedAt == null)
             .Where(e => e.Domain == domain)
             .Where(e => e.Title.ToLower() == title.ToLower())
             .FirstOrDefaultAsync(ct);
     }
 
-    public async Task<List<ExpertiseEntry>> FindExactMatchesAsync(string domain, IReadOnlyList<string> titles, CancellationToken ct)
+    public async Task<List<ExpertiseEntry>> FindExactMatchesAsync(string domain, IReadOnlyList<string> titles, TenantContext ctx, CancellationToken ct)
     {
         var lowerTitles = titles.Select(t => t.ToLowerInvariant()).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
-        return await db.ExpertiseEntries
+        return await ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx)
             .Where(e => e.DeprecatedAt == null)
             .Where(e => e.Domain == domain)
             .Where(e => lowerTitles.Contains(e.Title.ToLowerInvariant()))
             .ToListAsync(ct);
     }
 
-    public async Task<ExpertiseEntry?> FindNearestInDomainAsync(string domain, Vector queryVector, double maxDistance, CancellationToken ct)
+    public async Task<ExpertiseEntry?> FindNearestInDomainAsync(string domain, Vector queryVector, double maxDistance, TenantContext ctx, CancellationToken ct)
     {
-        var candidate = await db.ExpertiseEntries
+        var candidate = await ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx)
             .Where(e => e.DeprecatedAt == null)
             .Where(e => e.Domain == domain)
             .Where(e => e.Embedding != null)
@@ -161,9 +242,9 @@ public class ExpertiseRepository(ExpertiseDbContext db, ILogger<ExpertiseReposit
         return distance.Value <= maxDistance ? candidate : null;
     }
 
-    public async Task<List<ExpertiseEntry>> FindAllEmbeddingsInDomainAsync(string domain, CancellationToken ct)
+    public async Task<List<ExpertiseEntry>> FindAllEmbeddingsInDomainAsync(string domain, TenantContext ctx, CancellationToken ct)
     {
-        return await db.ExpertiseEntries
+        return await ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx)
             .Where(e => e.DeprecatedAt == null)
             .Where(e => e.Domain == domain)
             .Where(e => e.Embedding != null)

--- a/src/ExpertiseApi/Data/IExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/IExpertiseRepository.cs
@@ -1,35 +1,44 @@
+using ExpertiseApi.Auth;
 using ExpertiseApi.Models;
 using Pgvector;
 
 namespace ExpertiseApi.Data;
 
+/// <summary>
+/// Per ADR-001: every method takes a <see cref="TenantContext"/>. Reads are filtered to
+/// <c>Tenant IN (ctx.Tenant, "shared")</c>. Writes scope tenant ownership at the repository
+/// layer so a caller in tenant A cannot mutate or soft-delete an entry in tenant B
+/// (cross-tenant resolves to 404 via <c>FirstOrDefaultAsync</c> returning null).
+/// </summary>
 public interface IExpertiseRepository
 {
-    Task<ExpertiseEntry?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task<ExpertiseEntry?> GetByIdAsync(Guid id, TenantContext ctx, CancellationToken ct = default);
 
     Task<List<ExpertiseEntry>> ListAsync(
+        TenantContext ctx,
         string? domain = null,
         List<string>? tags = null,
         EntryType? entryType = null,
         Severity? severity = null,
+        bool includeDrafts = false,
         bool includeDeprecated = false,
         CancellationToken ct = default);
 
-    Task<ExpertiseEntry> CreateAsync(ExpertiseEntry entry, CancellationToken ct = default);
+    Task<ExpertiseEntry> CreateAsync(ExpertiseEntry entry, TenantContext ctx, CancellationToken ct = default);
 
-    Task<ExpertiseEntry?> UpdateAsync(Guid id, Func<ExpertiseEntry, Task> applyUpdates, CancellationToken ct = default);
+    Task<ExpertiseEntry?> UpdateAsync(Guid id, TenantContext ctx, Func<ExpertiseEntry, Task> applyUpdates, CancellationToken ct = default);
 
-    Task<bool> SoftDeleteAsync(Guid id, CancellationToken ct = default);
+    Task<bool> SoftDeleteAsync(Guid id, TenantContext ctx, CancellationToken ct = default);
 
-    Task<List<ExpertiseEntry>> KeywordSearchAsync(string query, bool includeDeprecated = false, CancellationToken ct = default);
+    Task<List<ExpertiseEntry>> KeywordSearchAsync(string query, TenantContext ctx, bool includeDrafts = false, bool includeDeprecated = false, CancellationToken ct = default);
 
-    Task<List<ExpertiseEntry>> SemanticSearchAsync(Vector queryVector, int limit = 10, bool includeDeprecated = false, CancellationToken ct = default);
+    Task<List<ExpertiseEntry>> SemanticSearchAsync(Vector queryVector, TenantContext ctx, int limit = 10, bool includeDrafts = false, bool includeDeprecated = false, CancellationToken ct = default);
 
-    Task<ExpertiseEntry?> FindExactMatchAsync(string domain, string title, CancellationToken ct = default);
+    Task<ExpertiseEntry?> FindExactMatchAsync(string domain, string title, TenantContext ctx, CancellationToken ct = default);
 
-    Task<List<ExpertiseEntry>> FindExactMatchesAsync(string domain, IReadOnlyList<string> titles, CancellationToken ct = default);
+    Task<List<ExpertiseEntry>> FindExactMatchesAsync(string domain, IReadOnlyList<string> titles, TenantContext ctx, CancellationToken ct = default);
 
-    Task<ExpertiseEntry?> FindNearestInDomainAsync(string domain, Vector queryVector, double maxDistance, CancellationToken ct = default);
+    Task<ExpertiseEntry?> FindNearestInDomainAsync(string domain, Vector queryVector, double maxDistance, TenantContext ctx, CancellationToken ct = default);
 
-    Task<List<ExpertiseEntry>> FindAllEmbeddingsInDomainAsync(string domain, CancellationToken ct = default);
+    Task<List<ExpertiseEntry>> FindAllEmbeddingsInDomainAsync(string domain, TenantContext ctx, CancellationToken ct = default);
 }

--- a/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
@@ -37,26 +37,37 @@ public static class ExpertiseEndpoints
     }
 
     private static async Task<IResult> ListEntries(
+        HttpContext httpContext,
         IExpertiseRepository repo,
         [FromQuery] string? domain,
         [FromQuery] string? tags,
         [FromQuery] EntryType? entryType,
         [FromQuery] Severity? severity,
+        [FromQuery] bool includeDrafts = false,
         [FromQuery] bool includeDeprecated = false,
         CancellationToken ct = default)
     {
+        var tenantContext = httpContext.RequireTenantContext();
+
+        if (includeDrafts && !tenantContext.Scopes.Contains(AuthConstants.WriteApproveScope))
+            return Results.Problem(
+                "?includeDrafts=true requires the expertise.write.approve scope.",
+                statusCode: 403);
+
         var tagList = tags?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
 
-        var entries = await repo.ListAsync(domain, tagList, entryType, severity, includeDeprecated, ct);
+        var entries = await repo.ListAsync(tenantContext, domain, tagList, entryType, severity, includeDrafts, includeDeprecated, ct);
         return Results.Ok(entries);
     }
 
     private static async Task<IResult> GetEntry(
         Guid id,
+        HttpContext httpContext,
         IExpertiseRepository repo,
         CancellationToken ct)
     {
-        var entry = await repo.GetByIdAsync(id, ct);
+        var tenantContext = httpContext.RequireTenantContext();
+        var entry = await repo.GetByIdAsync(id, tenantContext, ct);
         return entry is null ? Results.NotFound() : Results.Ok(entry);
     }
 
@@ -82,24 +93,26 @@ public static class ExpertiseEndpoints
         var embedding = await embeddingService.GenerateEmbeddingAsync(
             EmbeddingService.BuildInputText(request.Title, request.Body), ct);
 
-        var (isDuplicate, existing) = await dedup.CheckAsync(request, embedding, ct);
+        var (isDuplicate, existing) = await dedup.CheckAsync(request, embedding, tenantContext, ct);
         if (isDuplicate && existing is not null)
             return Results.Conflict(existing);
 
-        var created = await repo.CreateAsync(BuildEntry(request, embedding, tenantContext), ct);
+        var created = await repo.CreateAsync(BuildEntry(request, embedding, tenantContext), tenantContext, ct);
         return Results.Created($"/expertise/{created.Id}", created);
     }
 
     private static async Task<IResult> UpdateEntry(
         Guid id,
         UpdateExpertiseRequest request,
+        HttpContext httpContext,
         IExpertiseRepository repo,
         EmbeddingService embeddingService,
         CancellationToken ct)
     {
+        var tenantContext = httpContext.RequireTenantContext();
         var needsReembed = request.Title is not null || request.Body is not null;
 
-        var updated = await repo.UpdateAsync(id, async entry =>
+        var updated = await repo.UpdateAsync(id, tenantContext, async entry =>
         {
             if (request.Domain is not null) entry.Domain = request.Domain;
             if (request.Tags is not null) entry.Tags = request.Tags;
@@ -187,7 +200,7 @@ public static class ExpertiseEndpoints
         try
         {
             var validRequests = validItems.Select(v => v.Request).ToList();
-            dedupResults = await dedup.CheckBatchAsync(validRequests, embeddings, ct);
+            dedupResults = await dedup.CheckBatchAsync(validRequests, embeddings, tenantContext, ct);
         }
         catch (OperationCanceledException)
         {
@@ -221,7 +234,7 @@ public static class ExpertiseEndpoints
 
             try
             {
-                var created = await repo.CreateAsync(BuildEntry(request, embedding, tenantContext), ct);
+                var created = await repo.CreateAsync(BuildEntry(request, embedding, tenantContext), tenantContext, ct);
                 results[index] = new BatchEntryResult(index, BatchEntryStatus.Created, created.Id, null);
             }
             catch (OperationCanceledException)
@@ -267,10 +280,12 @@ public static class ExpertiseEndpoints
 
     private static async Task<IResult> DeleteEntry(
         Guid id,
+        HttpContext httpContext,
         IExpertiseRepository repo,
         CancellationToken ct)
     {
-        var deleted = await repo.SoftDeleteAsync(id, ct);
+        var tenantContext = httpContext.RequireTenantContext();
+        var deleted = await repo.SoftDeleteAsync(id, tenantContext, ct);
         return deleted ? Results.NoContent() : Results.NotFound();
     }
 }

--- a/src/ExpertiseApi/Endpoints/SearchEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/SearchEndpoints.cs
@@ -1,3 +1,4 @@
+using ExpertiseApi.Auth;
 using ExpertiseApi.Data;
 using Microsoft.AspNetCore.Mvc;
 
@@ -17,15 +18,24 @@ public static class SearchEndpoints
     }
 
     private static async Task<IResult> KeywordSearch(
+        HttpContext httpContext,
         IExpertiseRepository repo,
         [FromQuery] string q,
+        [FromQuery] bool includeDrafts = false,
         [FromQuery] bool includeDeprecated = false,
         CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(q))
             return Results.Problem("Query parameter 'q' is required.", statusCode: 400);
 
-        var results = await repo.KeywordSearchAsync(q, includeDeprecated, ct);
+        var tenantContext = httpContext.RequireTenantContext();
+
+        if (includeDrafts && !tenantContext.Scopes.Contains(AuthConstants.WriteApproveScope))
+            return Results.Problem(
+                "?includeDrafts=true requires the expertise.write.approve scope.",
+                statusCode: 403);
+
+        var results = await repo.KeywordSearchAsync(q, tenantContext, includeDrafts, includeDeprecated, ct);
         return Results.Ok(results);
     }
 }

--- a/src/ExpertiseApi/Endpoints/SemanticSearchEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/SemanticSearchEndpoints.cs
@@ -1,3 +1,4 @@
+using ExpertiseApi.Auth;
 using ExpertiseApi.Data;
 using ExpertiseApi.Services;
 using Microsoft.AspNetCore.Mvc;
@@ -18,19 +19,28 @@ public static class SemanticSearchEndpoints
     }
 
     private static async Task<IResult> SemanticSearch(
+        HttpContext httpContext,
         IExpertiseRepository repo,
         EmbeddingService embeddingService,
         [FromQuery] string q,
         [FromQuery] int limit = 10,
+        [FromQuery] bool includeDrafts = false,
         [FromQuery] bool includeDeprecated = false,
         CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(q))
             return Results.Problem("Query parameter 'q' is required.", statusCode: 400);
 
+        var tenantContext = httpContext.RequireTenantContext();
+
+        if (includeDrafts && !tenantContext.Scopes.Contains(AuthConstants.WriteApproveScope))
+            return Results.Problem(
+                "?includeDrafts=true requires the expertise.write.approve scope.",
+                statusCode: 403);
+
         var clampedLimit = Math.Clamp(limit, 1, 100);
         var queryVector = await embeddingService.GenerateEmbeddingAsync(q, ct);
-        var results = await repo.SemanticSearchAsync(queryVector, clampedLimit, includeDeprecated, ct);
+        var results = await repo.SemanticSearchAsync(queryVector, tenantContext, clampedLimit, includeDrafts, includeDeprecated, ct);
         return Results.Ok(results);
     }
 }

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -36,6 +36,7 @@ builder.Services.AddDbContext<ExpertiseDbContext>(options =>
         o => o.UseVector()));
 
 builder.Services.AddScoped<IExpertiseRepository, ExpertiseRepository>();
+builder.Services.AddScoped<ITenantContextAccessor, HttpTenantContextAccessor>();
 builder.Services.AddExpertiseAuth(builder.Configuration, builder.Environment);
 
 var baseDir = AppContext.BaseDirectory;

--- a/src/ExpertiseApi/Services/DeduplicationService.cs
+++ b/src/ExpertiseApi/Services/DeduplicationService.cs
@@ -1,3 +1,4 @@
+using ExpertiseApi.Auth;
 using ExpertiseApi.Data;
 using ExpertiseApi.Endpoints;
 using ExpertiseApi.Models;
@@ -15,18 +16,21 @@ public class DeduplicationOptions
 public class DeduplicationService(IExpertiseRepository repo, IOptions<DeduplicationOptions> options)
 {
     public async Task<(bool IsDuplicate, ExpertiseEntry? Existing)> CheckAsync(
-        CreateExpertiseRequest request, Vector embedding, CancellationToken ct = default)
+        CreateExpertiseRequest request, Vector embedding, TenantContext ctx, CancellationToken ct = default)
     {
         var opts = options.Value;
 
         if (!opts.Enabled)
             return (false, null);
 
-        var exact = await repo.FindExactMatchAsync(request.Domain, request.Title, ct);
+        // Tenant-scoped dedup: an entry in tenant A must NEVER be reported as a duplicate
+        // of a tenant B entry — that would leak the B entry's full content via the 409
+        // Conflict response body. The repository already filters by ctx.Tenant.
+        var exact = await repo.FindExactMatchAsync(request.Domain, request.Title, ctx, ct);
         if (exact is not null && exact.Body == request.Body)
             return (true, exact);
 
-        var nearest = await repo.FindNearestInDomainAsync(request.Domain, embedding, opts.SemanticThreshold, ct);
+        var nearest = await repo.FindNearestInDomainAsync(request.Domain, embedding, opts.SemanticThreshold, ctx, ct);
         if (nearest is not null)
             return (true, nearest);
 
@@ -36,6 +40,7 @@ public class DeduplicationService(IExpertiseRepository repo, IOptions<Deduplicat
     public async Task<IReadOnlyList<(bool IsDuplicate, ExpertiseEntry? Existing)>> CheckBatchAsync(
         IReadOnlyList<CreateExpertiseRequest> requests,
         IReadOnlyList<Vector> embeddings,
+        TenantContext ctx,
         CancellationToken ct = default)
     {
         if (embeddings.Count != requests.Count)
@@ -61,7 +66,7 @@ public class DeduplicationService(IExpertiseRepository repo, IOptions<Deduplicat
 
             // Bulk exact-match: one query per domain instead of N
             var titles = items.Select(x => x.Request.Title).ToList();
-            var exactMatches = await repo.FindExactMatchesAsync(domain, titles, ct);
+            var exactMatches = await repo.FindExactMatchesAsync(domain, titles, ctx, ct);
 
             // Map title -> list of candidates (OrdinalIgnoreCase) to handle multiple entries sharing the same title
             var matchesByTitle = exactMatches
@@ -86,7 +91,7 @@ public class DeduplicationService(IExpertiseRepository repo, IOptions<Deduplicat
                 }
 
                 // Check semantic match in memory
-                domainEntries ??= await repo.FindAllEmbeddingsInDomainAsync(domain, ct);
+                domainEntries ??= await repo.FindAllEmbeddingsInDomainAsync(domain, ctx, ct);
 
                 // Precompute domain entry arrays once per domain group, skipping null embeddings
                 if (domainEntryArrays is null)

--- a/tests/ExpertiseApi.Tests/Infrastructure/ApiFactory.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/ApiFactory.cs
@@ -76,5 +76,9 @@ public class ApiFactory : WebApplicationFactory<Program>
         });
 
         builder.UseSetting("Auth:ApiKey", TestHelpers.TestApiKey);
+        // The API key handler defaults Tenant to "legacy"; align the test client with the
+        // SeedEntry helper's default tenant ("test") so existing tests don't all fail under
+        // the new tenant filter.
+        builder.UseSetting("Auth:ApiKeyDefaults:DefaultTenant", TestHelpers.TestTenant);
     }
 }

--- a/tests/ExpertiseApi.Tests/Infrastructure/JwtApiFactory.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/JwtApiFactory.cs
@@ -45,6 +45,8 @@ public class JwtApiFactory : WebApplicationFactory<Program>
         builder.UseSetting("Auth:Oidc:Issuers:0:GroupClaim", "groups");
         builder.UseSetting("Auth:Oidc:Issuers:0:GroupToTenantMapping:group-test", "test");
         builder.UseSetting("Auth:Oidc:Issuers:0:GroupToTenantMapping:group-shared", "shared");
+        // Second tenant for cross-tenant isolation tests.
+        builder.UseSetting("Auth:Oidc:Issuers:0:GroupToTenantMapping:group-other", "other-team");
 
         builder.ConfigureLogging(logging =>
         {

--- a/tests/ExpertiseApi.Tests/Infrastructure/PostgresFixture.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/PostgresFixture.cs
@@ -1,3 +1,4 @@
+using ExpertiseApi.Auth;
 using ExpertiseApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Testcontainers.PostgreSql;
@@ -21,7 +22,7 @@ public sealed class PostgresFixture : IAsyncLifetime
         var optionsBuilder = new DbContextOptionsBuilder<ExpertiseDbContext>()
             .UseNpgsql(ConnectionString, o => o.UseVector());
 
-        await using var db = new ExpertiseDbContext(optionsBuilder.Options);
+        await using var db = new ExpertiseDbContext(optionsBuilder.Options, new NoOpTenantContextAccessor());
         await db.Database.MigrateAsync();
     }
 

--- a/tests/ExpertiseApi.Tests/Infrastructure/TestHelpers.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/TestHelpers.cs
@@ -1,7 +1,9 @@
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Security.Claims;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using ExpertiseApi.Auth;
 using ExpertiseApi.Models;
 using Pgvector;
 
@@ -10,6 +12,33 @@ namespace ExpertiseApi.Tests.Infrastructure;
 public static class TestHelpers
 {
     public const string TestApiKey = "test-api-key-12345";
+    public const string TestTenant = "test";
+
+    /// <summary>
+    /// Builds a <see cref="TenantContext"/> for direct repository calls in tests
+    /// (i.e., outside the HTTP request pipeline). Defaults to read+draft scopes;
+    /// callers that need approve/admin can pass them explicitly.
+    /// </summary>
+    public static TenantContext CreateTenantContext(
+        string tenant = TestTenant,
+        params string[] scopes)
+    {
+        var scopeSet = scopes.Length == 0
+            ? new HashSet<string>(StringComparer.Ordinal)
+            {
+                AuthConstants.ReadScope,
+                AuthConstants.WriteDraftScope
+            }
+            : new HashSet<string>(scopes, StringComparer.Ordinal);
+
+        var identity = new ClaimsIdentity(
+            new[] { new Claim("sub", $"test-{tenant}") }, "Test");
+        return new TenantContext(
+            Tenant: tenant,
+            Principal: new ClaimsPrincipal(identity),
+            Agent: null,
+            Scopes: scopeSet);
+    }
 
     public static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -45,8 +74,9 @@ public static class TestHelpers
         EntryType entryType = EntryType.Pattern,
         Severity severity = Severity.Info,
         string source = "test",
-        string tenant = "test",
-        string authorPrincipal = "test-principal")
+        string tenant = TestTenant,
+        string authorPrincipal = "test-principal",
+        ReviewState reviewState = ReviewState.Approved)
     {
         return new ExpertiseEntry
         {
@@ -59,7 +89,8 @@ public static class TestHelpers
             Tags = ["test"],
             Embedding = CreateTestVector(),
             Tenant = tenant,
-            AuthorPrincipal = authorPrincipal
+            AuthorPrincipal = authorPrincipal,
+            ReviewState = reviewState
         };
     }
 

--- a/tests/ExpertiseApi.Tests/Integration/ExpertiseEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/ExpertiseEndpointTests.cs
@@ -101,7 +101,8 @@ public class ExpertiseEndpointTests : IAsyncLifetime
 
         using var scope = _factory.Services.CreateScope();
         var repo = scope.ServiceProvider.GetRequiredService<IExpertiseRepository>();
-        await repo.SoftDeleteAsync(deprecated.Id);
+        // Soft-deleted entry was seeded with tenant "test" — match it on the call.
+        await repo.SoftDeleteAsync(deprecated.Id, TestHelpers.CreateTenantContext(deprecated.Tenant));
 
         var response = await _client.GetAsync("/expertise");
 
@@ -118,7 +119,7 @@ public class ExpertiseEndpointTests : IAsyncLifetime
 
         using var scope = _factory.Services.CreateScope();
         var repo = scope.ServiceProvider.GetRequiredService<IExpertiseRepository>();
-        await repo.SoftDeleteAsync(deprecated.Id);
+        await repo.SoftDeleteAsync(deprecated.Id, TestHelpers.CreateTenantContext(deprecated.Tenant));
 
         var response = await _client.GetAsync("/expertise?includeDeprecated=true");
 
@@ -165,11 +166,13 @@ public class ExpertiseEndpointTests : IAsyncLifetime
     private async Task<ExpertiseEntry> SeedEntryViaRepo(
         string domain = "shared",
         string title = "Test",
-        EntryType entryType = EntryType.Pattern)
+        EntryType entryType = EntryType.Pattern,
+        string tenant = TestHelpers.TestTenant)
     {
         using var scope = _factory.Services.CreateScope();
         var repo = scope.ServiceProvider.GetRequiredService<IExpertiseRepository>();
         return await repo.CreateAsync(
-            TestHelpers.SeedEntry(domain: domain, title: title, entryType: entryType));
+            TestHelpers.SeedEntry(domain: domain, title: title, entryType: entryType, tenant: tenant),
+            TestHelpers.CreateTenantContext(tenant));
     }
 }

--- a/tests/ExpertiseApi.Tests/Integration/MigrationReversibilityTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/MigrationReversibilityTests.cs
@@ -1,3 +1,4 @@
+using ExpertiseApi.Auth;
 using ExpertiseApi.Data;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
@@ -62,7 +63,7 @@ public class MigrationReversibilityTests : IAsyncLifetime
         var options = new DbContextOptionsBuilder<ExpertiseDbContext>()
             .UseNpgsql(_container.GetConnectionString(), o => o.UseVector())
             .Options;
-        return new ExpertiseDbContext(options);
+        return new ExpertiseDbContext(options, new NoOpTenantContextAccessor());
     }
 
     private static async Task AssertColumnsExist(ExpertiseDbContext db, bool expected)

--- a/tests/ExpertiseApi.Tests/Integration/SearchEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/SearchEndpointTests.cs
@@ -77,7 +77,7 @@ public class SearchEndpointTests : IAsyncLifetime
 
         using var scope = _factory.Services.CreateScope();
         var repo = scope.ServiceProvider.GetRequiredService<IExpertiseRepository>();
-        await repo.SoftDeleteAsync(deprecated.Id);
+        await repo.SoftDeleteAsync(deprecated.Id, TestHelpers.CreateTenantContext(deprecated.Tenant));
 
         var response = await _client.GetAsync("/expertise/search?q=migration");
 
@@ -96,7 +96,7 @@ public class SearchEndpointTests : IAsyncLifetime
 
         using var scope = _factory.Services.CreateScope();
         var repo = scope.ServiceProvider.GetRequiredService<IExpertiseRepository>();
-        await repo.SoftDeleteAsync(deprecated.Id);
+        await repo.SoftDeleteAsync(deprecated.Id, TestHelpers.CreateTenantContext(deprecated.Tenant));
 
         var response = await _client.GetAsync("/expertise/search?q=migration&includeDeprecated=true");
 
@@ -119,10 +119,13 @@ public class SearchEndpointTests : IAsyncLifetime
     private async Task<ExpertiseEntry> SeedEntryViaRepo(
         string domain,
         string title,
-        string body = "Default test body content")
+        string body = "Default test body content",
+        string tenant = TestHelpers.TestTenant)
     {
         using var scope = _factory.Services.CreateScope();
         var repo = scope.ServiceProvider.GetRequiredService<IExpertiseRepository>();
-        return await repo.CreateAsync(TestHelpers.SeedEntry(domain: domain, title: title, body: body));
+        return await repo.CreateAsync(
+            TestHelpers.SeedEntry(domain: domain, title: title, body: body, tenant: tenant),
+            TestHelpers.CreateTenantContext(tenant));
     }
 }

--- a/tests/ExpertiseApi.Tests/Integration/TenantIsolationTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/TenantIsolationTests.cs
@@ -1,0 +1,216 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using ExpertiseApi.Auth;
+using ExpertiseApi.Data;
+using ExpertiseApi.Models;
+using ExpertiseApi.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ExpertiseApi.Tests.Integration;
+
+/// <summary>
+/// Cross-tenant isolation tests. Each scenario seeds entries in two different tenants
+/// (and one in <c>shared</c>) then asserts the caller in tenant <c>test</c> sees only
+/// their own and the shared rows. These guard the failure mode PR 3 was built to close:
+/// a caller in tenant A reading or mutating an entry in tenant B.
+/// </summary>
+[Collection("Postgres")]
+public class TenantIsolationTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private JwtApiFactory _factory = null!;
+    private HttpClient _testClient = null!;
+
+    public TenantIsolationTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public async Task InitializeAsync()
+    {
+        _factory = new JwtApiFactory(_postgres.ConnectionString);
+
+        // Caller is tenant "test" with read + draft scopes (no approve scope, no admin).
+        var token = JwtTokenMinter.Mint(
+            tenant: "test",
+            scopes: [AuthConstants.ReadScope, AuthConstants.WriteDraftScope],
+            groups: ["group-test"]);
+        _testClient = _factory.CreateClient();
+        _testClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+        await db.ExpertiseEntries.IgnoreQueryFilters()
+            .ExecuteDeleteAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        _testClient.Dispose();
+        await _factory.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task GetById_CrossTenantEntry_Returns404()
+    {
+        var other = await SeedEntry(tenant: "other-team");
+
+        var response = await _testClient.GetAsync($"/expertise/{other.Id}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task List_OnlyReturnsCallerTenantAndShared()
+    {
+        var ownEntry = await SeedEntry(tenant: "test", title: "own-entry");
+        var sharedEntry = await SeedEntry(tenant: "shared", title: "shared-entry");
+        var otherEntry = await SeedEntry(tenant: "other-team", title: "other-entry");
+
+        var response = await _testClient.GetAsync("/expertise");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetArrayLength().Should().Be(2);
+        var titles = new[] { json[0].GetProperty("title").GetString(), json[1].GetProperty("title").GetString() };
+        titles.Should().Contain("own-entry");
+        titles.Should().Contain("shared-entry");
+        titles.Should().NotContain("other-entry");
+    }
+
+    [Fact]
+    public async Task List_DefaultExcludesDrafts()
+    {
+        await SeedEntry(tenant: "test", title: "approved", reviewState: ReviewState.Approved);
+        await SeedEntry(tenant: "test", title: "draft", reviewState: ReviewState.Draft);
+
+        var response = await _testClient.GetAsync("/expertise");
+
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetArrayLength().Should().Be(1);
+        json[0].GetProperty("title").GetString().Should().Be("approved");
+    }
+
+    [Fact]
+    public async Task List_IncludeDraftsWithoutApproveScope_Returns403()
+    {
+        // _testClient carries read + draft scopes but NOT approve.
+        await SeedEntry(tenant: "test", reviewState: ReviewState.Draft);
+
+        var response = await _testClient.GetAsync("/expertise?includeDrafts=true");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task List_IncludeDraftsWithApproveScope_ReturnsDrafts()
+    {
+        var approved = await SeedEntry(tenant: "test", title: "approved", reviewState: ReviewState.Approved);
+        var draft = await SeedEntry(tenant: "test", title: "draft", reviewState: ReviewState.Draft);
+
+        var approveToken = JwtTokenMinter.Mint(
+            tenant: "test",
+            scopes: [AuthConstants.ReadScope, AuthConstants.WriteApproveScope],
+            groups: ["group-test"]);
+        using var approveClient = _factory.CreateClient();
+        approveClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", approveToken);
+
+        var response = await approveClient.GetAsync("/expertise?includeDrafts=true");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetArrayLength().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task KeywordSearch_CrossTenantEntry_NotIncluded()
+    {
+        // Same matchable text in two tenants — only the caller's match should be returned.
+        await SeedEntry(tenant: "test", title: "Database migration guide for own tenant",
+            body: "Database migration best practices for our team.");
+        await SeedEntry(tenant: "other-team", title: "Database migration guide for other team",
+            body: "Database migration practices for the other team.");
+
+        var response = await _testClient.GetAsync("/expertise/search?q=migration");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetArrayLength().Should().Be(1);
+        json[0].GetProperty("tenant").GetString().Should().Be("test");
+    }
+
+    [Fact]
+    public async Task SemanticSearch_CrossTenantEntry_NotIncluded()
+    {
+        await SeedEntry(tenant: "test", title: "own");
+        await SeedEntry(tenant: "other-team", title: "other");
+
+        var response = await _testClient.GetAsync("/expertise/search/semantic?q=test&limit=10");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await response.Content.ReadJsonElementAsync();
+        for (var i = 0; i < json.GetArrayLength(); i++)
+            json[i].GetProperty("tenant").GetString().Should().NotBe("other-team");
+    }
+
+    [Fact]
+    public async Task Update_CrossTenantEntry_Returns404()
+    {
+        var other = await SeedEntry(tenant: "other-team");
+
+        var payload = new { title = "hijacked" };
+        var response = await _testClient.PatchAsJsonAsync($"/expertise/{other.Id}", payload);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Delete_CrossTenantEntry_Returns404()
+    {
+        var other = await SeedEntry(tenant: "other-team");
+
+        var response = await _testClient.DeleteAsync($"/expertise/{other.Id}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Create_TitleCollidesWithCrossTenantEntry_CreatesAsNonDuplicate()
+    {
+        // The dedup leak: before PR 3, a POST in tenant A whose title collided with a
+        // tenant B entry would 409 with the B entry's full body. Now: dedup is tenant-
+        // scoped, so the collision is invisible and the POST succeeds.
+        await SeedEntry(tenant: "other-team", domain: "shared",
+            title: "Cross-tenant collision title", body: "Other team's secret body");
+
+        var payload = new
+        {
+            domain = "shared",
+            title = "Cross-tenant collision title",
+            body = "Test team's body",
+            entryType = "Pattern",
+            severity = "Info",
+            source = "test"
+        };
+        var response = await _testClient.PostAsJsonAsync("/expertise", payload);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    private async Task<ExpertiseEntry> SeedEntry(
+        string tenant,
+        string domain = "shared",
+        string title = "isolation-seed",
+        string body = "isolation seed body for keyword search indexing",
+        ReviewState reviewState = ReviewState.Approved)
+    {
+        // Seed directly via DbContext + IgnoreQueryFilters so we can plant rows in any
+        // tenant without going through the per-request tenant accessor.
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+        var entry = TestHelpers.SeedEntry(
+            domain: domain, title: title, body: body, tenant: tenant, reviewState: reviewState);
+        db.ExpertiseEntries.Add(entry);
+        await db.SaveChangesAsync();
+        return entry;
+    }
+}

--- a/tests/ExpertiseApi.Tests/Unit/DeduplicationServiceTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/DeduplicationServiceTests.cs
@@ -1,3 +1,4 @@
+using ExpertiseApi.Auth;
 using ExpertiseApi.Data;
 using ExpertiseApi.Endpoints;
 using ExpertiseApi.Models;
@@ -14,6 +15,7 @@ public class DeduplicationServiceTests
 {
     private readonly IExpertiseRepository _repo = Substitute.For<IExpertiseRepository>();
     private readonly Vector _testVector = TestHelpers.CreateTestVector();
+    private readonly TenantContext _ctx = TestHelpers.CreateTenantContext();
 
     private DeduplicationService CreateService(bool enabled = true, double threshold = 0.10)
     {
@@ -37,11 +39,11 @@ public class DeduplicationServiceTests
         var service = CreateService(enabled: false);
         var request = CreateRequest();
 
-        var (isDuplicate, existing) = await service.CheckAsync(request, _testVector);
+        var (isDuplicate, existing) = await service.CheckAsync(request, _testVector, _ctx);
 
         isDuplicate.Should().BeFalse();
         existing.Should().BeNull();
-        await _repo.DidNotReceive().FindExactMatchAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _repo.DidNotReceive().FindExactMatchAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -51,10 +53,10 @@ public class DeduplicationServiceTests
         var request = CreateRequest(body: "Exact body");
         var existingEntry = TestHelpers.SeedEntry(body: "Exact body");
 
-        _repo.FindExactMatchAsync("shared", "Test", Arg.Any<CancellationToken>())
+        _repo.FindExactMatchAsync("shared", "Test", Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns(existingEntry);
 
-        var (isDuplicate, existing) = await service.CheckAsync(request, _testVector);
+        var (isDuplicate, existing) = await service.CheckAsync(request, _testVector, _ctx);
 
         isDuplicate.Should().BeTrue();
         existing.Should().Be(existingEntry);
@@ -67,15 +69,15 @@ public class DeduplicationServiceTests
         var request = CreateRequest(body: "New body");
         var existingEntry = TestHelpers.SeedEntry(body: "Different body");
 
-        _repo.FindExactMatchAsync("shared", "Test", Arg.Any<CancellationToken>())
+        _repo.FindExactMatchAsync("shared", "Test", Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns(existingEntry);
-        _repo.FindNearestInDomainAsync("shared", _testVector, 0.10, Arg.Any<CancellationToken>())
+        _repo.FindNearestInDomainAsync("shared", _testVector, 0.10, Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns((ExpertiseEntry?)null);
 
-        var (isDuplicate, _) = await service.CheckAsync(request, _testVector);
+        var (isDuplicate, _) = await service.CheckAsync(request, _testVector, _ctx);
 
         isDuplicate.Should().BeFalse();
-        await _repo.Received(1).FindNearestInDomainAsync("shared", _testVector, 0.10, Arg.Any<CancellationToken>());
+        await _repo.Received(1).FindNearestInDomainAsync("shared", _testVector, 0.10, Arg.Any<TenantContext>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -85,12 +87,12 @@ public class DeduplicationServiceTests
         var request = CreateRequest();
         var nearEntry = TestHelpers.SeedEntry(title: "Similar entry");
 
-        _repo.FindExactMatchAsync("shared", "Test", Arg.Any<CancellationToken>())
+        _repo.FindExactMatchAsync("shared", "Test", Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns((ExpertiseEntry?)null);
-        _repo.FindNearestInDomainAsync("shared", _testVector, 0.10, Arg.Any<CancellationToken>())
+        _repo.FindNearestInDomainAsync("shared", _testVector, 0.10, Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns(nearEntry);
 
-        var (isDuplicate, existing) = await service.CheckAsync(request, _testVector);
+        var (isDuplicate, existing) = await service.CheckAsync(request, _testVector, _ctx);
 
         isDuplicate.Should().BeTrue();
         existing.Should().Be(nearEntry);
@@ -102,12 +104,12 @@ public class DeduplicationServiceTests
         var service = CreateService();
         var request = CreateRequest();
 
-        _repo.FindExactMatchAsync("shared", "Test", Arg.Any<CancellationToken>())
+        _repo.FindExactMatchAsync("shared", "Test", Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns((ExpertiseEntry?)null);
-        _repo.FindNearestInDomainAsync("shared", _testVector, 0.10, Arg.Any<CancellationToken>())
+        _repo.FindNearestInDomainAsync("shared", _testVector, 0.10, Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns((ExpertiseEntry?)null);
 
-        var (isDuplicate, existing) = await service.CheckAsync(request, _testVector);
+        var (isDuplicate, existing) = await service.CheckAsync(request, _testVector, _ctx);
 
         isDuplicate.Should().BeFalse();
         existing.Should().BeNull();
@@ -120,7 +122,7 @@ public class DeduplicationServiceTests
         var requests = new List<CreateExpertiseRequest> { CreateRequest(), CreateRequest(title: "Other") };
         var vectors = new List<Vector> { _testVector }; // one fewer embedding than requests
 
-        await service.Invoking(s => s.CheckBatchAsync(requests, vectors))
+        await service.Invoking(s => s.CheckBatchAsync(requests, vectors, _ctx))
             .Should().ThrowAsync<ArgumentException>()
             .WithParameterName("embeddings");
     }
@@ -132,7 +134,7 @@ public class DeduplicationServiceTests
         var requests = new List<CreateExpertiseRequest> { CreateRequest(), CreateRequest(title: "Other") };
         var vectors = new List<Vector> { _testVector, _testVector };
 
-        var results = await service.CheckBatchAsync(requests, vectors);
+        var results = await service.CheckBatchAsync(requests, vectors, _ctx);
 
         results.Should().HaveCount(2);
         results.Should().AllSatisfy(r => r.IsDuplicate.Should().BeFalse());
@@ -146,10 +148,10 @@ public class DeduplicationServiceTests
         var vectors = new List<Vector> { _testVector };
         var existingEntry = TestHelpers.SeedEntry(title: "Test", body: "Exact body");
 
-        _repo.FindExactMatchesAsync("shared", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+        _repo.FindExactMatchesAsync("shared", Arg.Any<IReadOnlyList<string>>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns([existingEntry]);
 
-        var results = await service.CheckBatchAsync(requests, vectors);
+        var results = await service.CheckBatchAsync(requests, vectors, _ctx);
 
         results.Should().HaveCount(1);
         results[0].IsDuplicate.Should().BeTrue();
@@ -163,12 +165,12 @@ public class DeduplicationServiceTests
         var requests = new List<CreateExpertiseRequest> { CreateRequest(), CreateRequest(title: "Other") };
         var vectors = new List<Vector> { _testVector, _testVector };
 
-        _repo.FindExactMatchesAsync("shared", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+        _repo.FindExactMatchesAsync("shared", Arg.Any<IReadOnlyList<string>>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns(new List<ExpertiseEntry>());
-        _repo.FindAllEmbeddingsInDomainAsync("shared", Arg.Any<CancellationToken>())
+        _repo.FindAllEmbeddingsInDomainAsync("shared", Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns(new List<ExpertiseEntry>());
 
-        var results = await service.CheckBatchAsync(requests, vectors);
+        var results = await service.CheckBatchAsync(requests, vectors, _ctx);
 
         results.Should().HaveCount(2);
         results.Should().AllSatisfy(r => r.IsDuplicate.Should().BeFalse());
@@ -186,12 +188,12 @@ public class DeduplicationServiceTests
         // Use the same vector so cosine distance == 0, well below the 0.10 threshold
         domainEntry.Embedding = _testVector;
 
-        _repo.FindExactMatchesAsync("shared", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+        _repo.FindExactMatchesAsync("shared", Arg.Any<IReadOnlyList<string>>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns(new List<ExpertiseEntry>());
-        _repo.FindAllEmbeddingsInDomainAsync("shared", Arg.Any<CancellationToken>())
+        _repo.FindAllEmbeddingsInDomainAsync("shared", Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns([domainEntry]);
 
-        var results = await service.CheckBatchAsync(requests, vectors);
+        var results = await service.CheckBatchAsync(requests, vectors, _ctx);
 
         results.Should().HaveCount(1);
         results[0].IsDuplicate.Should().BeTrue();
@@ -214,12 +216,12 @@ public class DeduplicationServiceTests
         var domainEntry = TestHelpers.SeedEntry(title: "Similar But Different Title");
         domainEntry.Embedding = _testVector; // very different direction
 
-        _repo.FindExactMatchesAsync("shared", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+        _repo.FindExactMatchesAsync("shared", Arg.Any<IReadOnlyList<string>>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns(new List<ExpertiseEntry>());
-        _repo.FindAllEmbeddingsInDomainAsync("shared", Arg.Any<CancellationToken>())
+        _repo.FindAllEmbeddingsInDomainAsync("shared", Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns([domainEntry]);
 
-        var results = await service.CheckBatchAsync(requests, vectors);
+        var results = await service.CheckBatchAsync(requests, vectors, _ctx);
 
         results.Should().HaveCount(1);
         results[0].IsDuplicate.Should().BeFalse();
@@ -237,12 +239,12 @@ public class DeduplicationServiceTests
         var vectors = new List<Vector> { _testVector, _testVector };
 
         var existingEntry = TestHelpers.SeedEntry(title: "Duplicate", body: "Same body");
-        _repo.FindExactMatchesAsync("shared", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+        _repo.FindExactMatchesAsync("shared", Arg.Any<IReadOnlyList<string>>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns([existingEntry]);
-        _repo.FindAllEmbeddingsInDomainAsync("shared", Arg.Any<CancellationToken>())
+        _repo.FindAllEmbeddingsInDomainAsync("shared", Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns(new List<ExpertiseEntry>());
 
-        var results = await service.CheckBatchAsync(requests, vectors);
+        var results = await service.CheckBatchAsync(requests, vectors, _ctx);
 
         results.Should().HaveCount(2);
         results[0].IsDuplicate.Should().BeTrue();


### PR DESCRIPTION
Closes #48. Part of #45.

## Summary

PR 3 of the secure rebuild. Closes three failure modes:

1. **Cross-tenant read leak** — every read path is now scoped to `Tenant IN (ctx.Tenant, "shared") AND ReviewState = Approved`.
2. **Dedup 409-body leak** — `POST /expertise` no longer returns another tenant's entry contents in the conflict response when titles or embeddings collide.
3. **Cross-tenant PATCH/DELETE** — write mutation paths now resolve to 404 (not 403, so existence is not disclosed) when the entry belongs to a different tenant. This addresses the gap flagged on the PR 2 review.

## Type of Change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [ ] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change (add `!` to PR title)

## Defense layers (ADR-001 belt-and-braces)

1. **Endpoint** — every read endpoint reads `httpContext.RequireTenantContext()` and threads it to the repository.
2. **Repository (primary safeguard)** — every `IExpertiseRepository` method takes a `TenantContext` parameter and applies an explicit `WHERE Tenant IN (ctx.Tenant, "shared")`. `GetByIdAsync`, `UpdateAsync`, `SoftDeleteAsync` replaced `FindAsync` with `Where(id) + FirstOrDefaultAsync` so the filter cannot be bypassed via the EF identity map.
3. **EF global query filter** — `HasQueryFilter` on `ExpertiseEntry` reads from a new `ITenantContextAccessor` (HTTP-backed). Defense-in-depth: catches any future query that forgets the explicit `WHERE`. Short-circuits to no-filter when the accessor returns null (CLI, design-time, direct test seeding).
4. **CLI bypass** — `reembed` and `rehash` call `IgnoreQueryFilters()` explicitly so they process every tenant.
5. **Dedup tenant scoping** — `FindExactMatchAsync` / `FindExactMatchesAsync` / `FindNearestInDomainAsync` / `FindAllEmbeddingsInDomainAsync` filter by tenant. `DeduplicationService` takes a `TenantContext` and threads it through.

## `?includeDrafts=true` semantics

| Caller scope | `?includeDrafts=true` | Visible ReviewStates |
|---|---|---|
| `read` only | false | `Approved` only |
| `read` only | true | **403** (insufficient scope) |
| `write.approve` or `admin` | false | `Approved` only |
| `write.approve` or `admin` | true | All (`Draft`, `Approved`, `Rejected`) within `(ctx.Tenant, "shared")` |

Tenant scoping is unconditional regardless of `includeDrafts` or `includeDeprecated`.

## Plan-before-code decisions (approved)

- **A3** — repository signature pattern: every method takes `TenantContext` (per ADR-001) AND `ITenantContextAccessor` drives the global query filter.
- **B1** — dedup scoping folded into PR 3 (closes the 409-body leak in the same PR as the read filter).
- **C1** — `UpdateEntry`/`DeleteEntry` tenant scoping in PR 3 (no asymmetry between reads and writes).
- **D** — `?includeDrafts=true` requires `write.approve`; `read`-only callers get 403.
- **E** — `ReviewState = Approved` default filter included in PR 3.

## Test Plan

- [x] `dotnet test ExpertiseApi.slnx` — 125/125 passing (was 109 on PR 2 merge; +6 ParseCompoundRoles tests in the PR 2 fix-up commit and +10 new cross-tenant isolation tests in PR 3)
- [x] New `TenantIsolationTests` covers:
  - `GetById_CrossTenantEntry_Returns404`
  - `List_OnlyReturnsCallerTenantAndShared` (caller's tenant + shared, never another tenant's)
  - `List_DefaultExcludesDrafts`
  - `List_IncludeDraftsWithoutApproveScope_Returns403`
  - `List_IncludeDraftsWithApproveScope_ReturnsDrafts`
  - `KeywordSearch_CrossTenantEntry_NotIncluded`
  - `SemanticSearch_CrossTenantEntry_NotIncluded`
  - `Update_CrossTenantEntry_Returns404`
  - `Delete_CrossTenantEntry_Returns404`
  - `Create_TitleCollidesWithCrossTenantEntry_CreatesAsNonDuplicate` (proves the 409-body leak is closed)
- [x] Existing 35 integration tests still pass (updated where they called repo methods directly to thread `TenantContext`)
- [x] Architecture test (`DbContextEncapsulationTests`) still enforces `ExpertiseDbContext` is only injected into `Data/`
- [x] `dotnet format --verify-no-changes` clean
- [x] `markdownlint-cli2` clean on `CLAUDE.md`, `README.md`, `SKILL.md`
- [x] No DB migration required — `HasQueryFilter` is runtime-only

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files
- [x] Database migrations are reversible — N/A (no schema change in this PR)
- [x] API changes are backward-compatible — same routes, same response shapes; `?includeDrafts=true` is new and opt-in
- [x] CLAUDE.md and SKILL.md updated with the tenant filter semantics

## API Changes

- `GET /expertise`, `GET /expertise/search`, `GET /expertise/search/semantic` — all gain optional `?includeDrafts` (default false). Lifts the `ReviewState = Approved` default filter; requires `expertise.write.approve`.
- `GET /expertise/{id}`, `PATCH /expertise/{id}`, `DELETE /expertise/{id}` — return 404 (was: 200/204) when the entry belongs to a different tenant. This is intentional information-disclosure protection per ADR-003.
- `POST /expertise` and `POST /expertise/batch` — dedup is now tenant-scoped. A title or embedding collision with another tenant's entry no longer triggers 409 with a foreign body; the create succeeds normally.

## What is NOT in this PR

- `/approve`, `/reject`, `/drafts`, `/audit` endpoints → PR 4 (#49)
- `expertise.admin` cross-tenant repository methods → PR 4 (#49)
- Audit log writes on state-change operations → PR 4 (#49)
- Rate limiting → PR 5 (#50)
- Production OIDC cutover → PR 6 (#51)

## Architecture decision (no new ADR)

ADR-001 already documents the four-layer defense (per-method tenant filter + global query filter + endpoint check + database). This PR is the implementation; no new architectural decision was made.

## Cross-repo coordination

None. PR 3 is API-internal.