### PR TITLE
feat(approval): approve and reject endpoints with audit log writes

### DIFF
--- a/.claude/skills/expertise-api-design/SKILL.md
+++ b/.claude/skills/expertise-api-design/SKILL.md
@@ -175,6 +175,33 @@ When the principal authenticates successfully but no tenant maps (e.g. group not
 
 Cross-tenant operations return **404, not 403**, on `GET`, `PATCH`, and `DELETE` so existence is not disclosed.
 
+### Approval workflow (PR 4)
+
+Reads default to `ReviewState = Approved`. The previous `?includeDrafts=true` query parameter on `/expertise` and `/expertise/search*` was replaced by a dedicated `GET /expertise/drafts` endpoint that returns `Draft` and `Rejected` entries in the caller's tenant only (no `shared` for the draft queue). Requires `expertise.write.approve`.
+
+`POST /expertise/{id}/approve` and `POST /expertise/{id}/reject` move entries between states. Both:
+
+- Require `expertise.write.approve`.
+- Are tenant-scoped — cross-tenant returns 404, even for admins.
+- Validate the source state is `Draft`; otherwise 409.
+- Use a Postgres `xmin` system column as an EF Core RowVersion concurrency token. Concurrent approve+reject races resolve to one 200 + one 409 (no schema migration; `xmin` already exists on every Postgres table).
+- Write an `ExpertiseAuditLog` row in the same `SaveChangesAsync` as the state mutation — atomic by construction.
+- `/reject` requires a non-empty `RejectionReason` body field, max 2000 chars.
+
+PATCH state regression (ADR-003): a `write.draft`-only caller editing an `Approved` entry resets it to `Draft` so it requires re-approval. A `write.approve` caller preserves `Approved`. Without this rule the approval workflow does not actually mitigate ASI06 — content can change post-approval.
+
+Soft-deleting a `Tenant = "shared"` entry requires `expertise.write.approve` (returns 403 otherwise — 404 would mislead since the caller can read the entry).
+
+### Audit log
+
+Every write path writes one `ExpertiseAuditLog` row in the same transaction as the entry mutation. The repository owns this — `ExpertiseRepository.BuildAuditRow` constructs the row using `IHttpContextAccessor` for `IpAddress`, falling back to `null` when no `HttpContext` (CLI). `BeforeHash` / `AfterHash` are SHA-256 over the canonical content fields (`IntegrityHashService`); approve/reject leave content unchanged so before == after, but the `Action` discriminates the transition.
+
+`GET /audit` is `expertise.admin`-only and cross-tenant. Query parameters: `entryId`, `principal`, `action`, `from`, `to`, `limit` (1-200, default 50), plus cursor pagination via `afterTimestamp` + `afterId`.
+
+### ForwardedHeaders middleware
+
+`Program.cs` registers `UseForwardedHeaders()` before `UseAuthentication()`. Configure `ForwardedHeaders:KnownNetworks` (CIDR list) so the middleware trusts only the actual proxy network — without an allowlist the middleware trusts only loopback and audit `IpAddress` records the ingress pod IP. In k8s the value is typically the cluster pod CIDR. Helm values should expose this as `ingress.trustedCidr` or equivalent.
+
 ## Embedding Architecture
 
 In-process ONNX using `BertOnnxTextEmbeddingGenerationService` behind `IEmbeddingGenerator<string, Embedding<float>>`. Registered with `AddBertOnnxEmbeddingGenerator`. Requires `#pragma warning disable SKEXP0070`. Model/vocab paths configurable via `Onnx:ModelPath` and `Onnx:VocabPath` config keys (default: `models/model.onnx`, `models/vocab.txt`). The abstraction allows future substitution with Ollama or Azure OpenAI without changing application code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,9 +170,32 @@ Every read path is scoped to `Tenant IN (caller_tenant, "shared") AND ReviewStat
 3. **EF global query filter** — `HasQueryFilter` on `ExpertiseEntry` reads from `ITenantContextAccessor` as defense-in-depth. When the accessor returns null (CLI / design-time / direct DbContext access in tests) the filter short-circuits and the explicit repository `WHERE` drives correctness.
 4. **CLI bypass** — `reembed` and `rehash` call `IgnoreQueryFilters()` explicitly to operate across all tenants.
 
-`?includeDrafts=true` lifts the `ReviewState = Approved` filter on `GET /expertise`, `GET /expertise/search`, and `GET /expertise/search/semantic` — but requires `expertise.write.approve`. A `read`-only caller passing `includeDrafts=true` gets 403. Tenant scoping always applies regardless of `includeDrafts`.
-
 `?includeDeprecated=true` lifts the `DeprecatedAt IS NULL` filter; tenant scoping still applies.
+
+### Approval workflow
+
+Reads default to `ReviewState = Approved`. Reviewers see `Draft` and `Rejected` entries via `GET /expertise/drafts` (requires `expertise.write.approve`, caller's tenant only — no cross-tenant or shared draft visibility). The previous `?includeDrafts=true` query parameter on `/expertise` and `/expertise/search*` was replaced by `/expertise/drafts` in PR 4.
+
+Approval transitions:
+
+- `POST /expertise/{id}/approve` — `Draft → Approved`. Sets `ReviewedBy`, `ReviewedAt`, applies optional `Visibility` from request body (default `Private`), clears `RejectionReason`.
+- `POST /expertise/{id}/reject` — `Draft → Rejected`. Body `{ "rejectionReason": "..." }` is required, max 2000 characters.
+- Both require `expertise.write.approve`. Both return 409 if the entry is not in `Draft` state.
+- Both use a Postgres `xmin` row-version concurrency token: a concurrent approve+reject race resolves to one 200 + one 409 instead of last-write-wins.
+
+PATCH state regression (per ADR-003): when a `write.draft`-only caller PATCHes an `Approved` entry, the entry regresses to `Draft` (forces re-approval). A caller carrying `write.approve` preserves the `Approved` state. This closes the ASI06 path where post-approval content edits would otherwise bypass review.
+
+Soft-deleting a `Tenant = "shared"` entry requires `expertise.write.approve`. A `write.draft` caller attempting to delete a shared entry receives 403.
+
+### Audit log
+
+Every state-changing operation (`POST`, `PATCH`, `DELETE`, `/approve`, `/reject`) writes a row to `ExpertiseAuditLog` in the same database transaction as the entry mutation — atomic by construction. Hashes (`BeforeHash`, `AfterHash`) are SHA-256 over the canonical content fields per `IntegrityHashService`; equal hashes mean content was not modified (e.g., approve/reject change `ReviewState` only, not content).
+
+`GET /audit` is admin-only (`expertise.admin`), cross-tenant, cursor-paginated on `(Timestamp DESC, Id)`. Query parameters: `entryId`, `principal`, `action`, `from`, `to`, `limit` (1-200, default 50), `afterTimestamp` + `afterId` (cursor).
+
+### ForwardedHeaders for IpAddress capture
+
+The audit log records the client IP address. To get the real client IP behind an ingress controller, configure `ForwardedHeaders:KnownNetworks` (CIDR list) so the `UseForwardedHeaders` middleware trusts only the proxy network. Without explicit allowlist the middleware trusts only loopback and audit IpAddress will record the ingress pod IP. In Kubernetes the value is typically the cluster pod CIDR.
 
 ### OIDC issuers
 

--- a/README.md
+++ b/README.md
@@ -38,14 +38,18 @@ flowchart LR
 
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
-| GET | `/expertise` | List/filter entries by domain, tags, type, severity |
-| GET | `/expertise/{id}` | Get single entry |
-| POST | `/expertise` | Create entry (generates embedding) |
+| GET | `/expertise` | List/filter entries by domain, tags, type, severity (Approved only) |
+| GET | `/expertise/{id}` | Get single entry (Approved only) |
+| GET | `/expertise/drafts` | List Draft + Rejected entries in caller's tenant (requires `expertise.write.approve`) |
+| POST | `/expertise` | Create entry (generates embedding, writes audit row) |
 | POST | `/expertise/batch` | Create up to 100 entries (generates embeddings, deduplicates) |
-| PATCH | `/expertise/{id}` | Update entry (regenerates embedding if title/body changed) |
-| DELETE | `/expertise/{id}` | Soft delete (sets DeprecatedAt) |
-| GET | `/expertise/search?q=` | Keyword full-text search (tsvector) |
-| GET | `/expertise/search/semantic?q=` | Semantic vector search (pgvector) |
+| PATCH | `/expertise/{id}` | Update entry. Approved entries regress to Draft if caller lacks `write.approve` |
+| DELETE | `/expertise/{id}` | Soft delete (sets DeprecatedAt). Shared entries require `expertise.write.approve` |
+| POST | `/expertise/{id}/approve` | Transition Draft → Approved (requires `expertise.write.approve`) |
+| POST | `/expertise/{id}/reject` | Transition Draft → Rejected with required reason (requires `expertise.write.approve`) |
+| GET | `/expertise/search?q=` | Keyword full-text search (tsvector, Approved only) |
+| GET | `/expertise/search/semantic?q=` | Semantic vector search (pgvector, Approved only) |
+| GET | `/audit` | Cross-tenant audit log (cursor-paginated, requires `expertise.admin`) |
 | GET | `/health` | Liveness probe (no auth required) |
 | GET | `/metrics` | Prometheus scrape endpoint (no auth required) |
 | GET | `/query` | Interactive query page (read-only, no auth to load) |

--- a/src/ExpertiseApi/Data/ExpertiseDbContext.cs
+++ b/src/ExpertiseApi/Data/ExpertiseDbContext.cs
@@ -80,6 +80,16 @@ public class ExpertiseDbContext(
                 tenantAccessor.Tenant == null ||
                 e.Tenant == tenantAccessor.Tenant ||
                 e.Tenant == "shared");
+
+            // PostgreSQL xmin system column as the EF Core concurrency token. The column
+            // already exists on every Postgres table (it's a system column); this
+            // configuration just teaches EF to read it and emit `WHERE xmin = @original`
+            // on UPDATE/DELETE. No schema migration is required for the column itself.
+            entity.Property(e => e.Version)
+                .HasColumnName("xmin")
+                .HasColumnType("xid")
+                .IsRowVersion()
+                .ValueGeneratedOnAddOrUpdate();
         });
 
         modelBuilder.Entity<EmbeddingMetadata>(entity =>

--- a/src/ExpertiseApi/Data/ExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/ExpertiseRepository.cs
@@ -1,12 +1,16 @@
 using ExpertiseApi.Auth;
 using ExpertiseApi.Models;
+using ExpertiseApi.Services;
 using Microsoft.EntityFrameworkCore;
 using Pgvector;
 using Pgvector.EntityFrameworkCore;
 
 namespace ExpertiseApi.Data;
 
-public class ExpertiseRepository(ExpertiseDbContext db, ILogger<ExpertiseRepository> logger) : IExpertiseRepository
+public class ExpertiseRepository(
+    ExpertiseDbContext db,
+    IHttpContextAccessor httpContextAccessor,
+    ILogger<ExpertiseRepository> logger) : IExpertiseRepository
 {
     /// <summary>
     /// Builds the tenant predicate per ADR-001: a row is visible if its <c>Tenant</c>
@@ -20,18 +24,12 @@ public class ExpertiseRepository(ExpertiseDbContext db, ILogger<ExpertiseReposit
     }
 
     /// <summary>
-    /// Read filter that gates draft visibility. By default reads are restricted to
-    /// <see cref="ReviewState.Approved"/> entries. <paramref name="includeDrafts"/> is
-    /// only honored at the endpoint layer when the caller carries
-    /// <see cref="AuthConstants.WriteApproveScope"/>.
+    /// Reads default to <see cref="ReviewState.Approved"/>. Drafts and Rejected entries
+    /// are exposed only via the dedicated <c>/drafts</c> endpoint.
     /// </summary>
-    private static IQueryable<ExpertiseEntry> ApplyReviewStateFilter(
-        IQueryable<ExpertiseEntry> query, bool includeDrafts)
-    {
-        return includeDrafts
-            ? query
-            : query.Where(e => e.ReviewState == ReviewState.Approved);
-    }
+    private static IQueryable<ExpertiseEntry> ApplyApprovedReviewFilter(
+        IQueryable<ExpertiseEntry> query) =>
+            query.Where(e => e.ReviewState == ReviewState.Approved);
 
     /// <summary>
     /// Defensive guard. If the auth pipeline produced a <see cref="TenantContext"/> with a
@@ -44,10 +42,48 @@ public class ExpertiseRepository(ExpertiseDbContext db, ILogger<ExpertiseReposit
             "Repository invoked with TenantContext.Tenant=null. The authorization pipeline " +
             "must reject unmapped principals before any repository call.");
 
+    /// <summary>
+    /// Builds an audit log row for a state-changing operation. Caller is responsible for
+    /// adding the row to the DbContext alongside its mutation in a single SaveChangesAsync.
+    /// </summary>
+    private ExpertiseAuditLog BuildAuditRow(
+        AuditAction action,
+        ExpertiseEntry entry,
+        TenantContext ctx,
+        string? beforeHash,
+        string? afterHash)
+    {
+        var principal = ctx.Principal.FindFirst("sub")?.Value
+                     ?? ctx.Principal.Identity?.Name
+                     ?? "system";
+
+        return new ExpertiseAuditLog
+        {
+            Timestamp = DateTime.UtcNow,
+            Action = action,
+            EntryId = entry.Id,
+            Tenant = entry.Tenant,
+            Principal = principal,
+            Agent = ctx.Agent,
+            BeforeHash = beforeHash,
+            AfterHash = afterHash,
+            IpAddress = httpContextAccessor.HttpContext?.Connection.RemoteIpAddress?.ToString()
+        };
+    }
+
     public async Task<ExpertiseEntry?> GetByIdAsync(Guid id, TenantContext ctx, CancellationToken ct)
     {
         // FindAsync would short-circuit through the identity map and bypass the tenant
         // filter; explicit Where + FirstOrDefaultAsync keeps every read tenant-scoped.
+        return await ApplyApprovedReviewFilter(ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx))
+            .Where(e => e.Id == id)
+            .FirstOrDefaultAsync(ct);
+    }
+
+    public async Task<ExpertiseEntry?> GetByIdIncludingDraftsAsync(Guid id, TenantContext ctx, CancellationToken ct)
+    {
+        // Approve/reject paths must be able to load Draft entries; the default
+        // ApplyApprovedReviewFilter would exclude them.
         return await ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx)
             .Where(e => e.Id == id)
             .FirstOrDefaultAsync(ct);
@@ -59,12 +95,10 @@ public class ExpertiseRepository(ExpertiseDbContext db, ILogger<ExpertiseReposit
         List<string>? tags,
         EntryType? entryType,
         Severity? severity,
-        bool includeDrafts,
         bool includeDeprecated,
         CancellationToken ct)
     {
-        var query = ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx);
-        query = ApplyReviewStateFilter(query, includeDrafts);
+        var query = ApplyApprovedReviewFilter(ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx));
 
         if (!includeDeprecated)
             query = query.Where(e => e.DeprecatedAt == null);
@@ -84,6 +118,18 @@ public class ExpertiseRepository(ExpertiseDbContext db, ILogger<ExpertiseReposit
         return await query.OrderByDescending(e => e.UpdatedAt).ToListAsync(ct);
     }
 
+    public async Task<List<ExpertiseEntry>> ListDraftsAsync(TenantContext ctx, CancellationToken ct)
+    {
+        // Drafts are owned by the writing tenant — no `shared` visibility for the queue.
+        var tenant = RequireTenant(ctx);
+        return await db.ExpertiseEntries
+            .Where(e => e.Tenant == tenant)
+            .Where(e => e.ReviewState == ReviewState.Draft || e.ReviewState == ReviewState.Rejected)
+            .Where(e => e.DeprecatedAt == null)
+            .OrderByDescending(e => e.UpdatedAt)
+            .ToListAsync(ct);
+    }
+
     public async Task<ExpertiseEntry> CreateAsync(ExpertiseEntry entry, TenantContext ctx, CancellationToken ct)
     {
         // Defensive: ensure the entry's Tenant matches the caller's. BuildEntry wires this
@@ -94,10 +140,19 @@ public class ExpertiseRepository(ExpertiseDbContext db, ILogger<ExpertiseReposit
             throw new InvalidOperationException(
                 $"Entry tenant '{entry.Tenant}' does not match caller tenant '{callerTenant}'.");
 
+        // Generate the Id client-side so the audit row's EntryId points at a real GUID.
+        // The DB-level gen_random_uuid() default still applies if Id is left empty by other
+        // callers, but EF cannot wire the audit FK across two pending inserts in the same
+        // SaveChanges without a navigation property — so we assign here to be explicit.
+        if (entry.Id == Guid.Empty)
+            entry.Id = Guid.NewGuid();
+
         entry.CreatedAt = DateTime.UtcNow;
         entry.UpdatedAt = DateTime.UtcNow;
+        entry.IntegrityHash = IntegrityHashService.Compute(entry);
 
         db.ExpertiseEntries.Add(entry);
+        db.ExpertiseAuditLogs.Add(BuildAuditRow(AuditAction.Created, entry, ctx, beforeHash: null, afterHash: entry.IntegrityHash));
         await db.SaveChangesAsync(ct);
 
         return entry;
@@ -107,62 +162,177 @@ public class ExpertiseRepository(ExpertiseDbContext db, ILogger<ExpertiseReposit
     {
         var entry = await ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx)
             .Where(e => e.Id == id)
+            .Where(e => e.DeprecatedAt == null)
             .FirstOrDefaultAsync(ct);
         if (entry is null)
             return null;
 
+        var beforeHash = entry.IntegrityHash ?? IntegrityHashService.Compute(entry);
+
         await applyUpdates(entry);
         entry.UpdatedAt = DateTime.UtcNow;
+        entry.IntegrityHash = IntegrityHashService.Compute(entry);
 
+        // ADR-003 state-regression rule: a write.draft-only caller editing an Approved
+        // entry resets it to Draft (forces re-approval); write.approve callers preserve
+        // the Approved state. Without this, the approval workflow does not actually
+        // mitigate ASI06 — content can change post-approval without re-review.
+        if (entry.ReviewState == ReviewState.Approved
+            && !ctx.Scopes.Contains(AuthConstants.WriteApproveScope))
+        {
+            entry.ReviewState = ReviewState.Draft;
+            entry.ReviewedBy = null;
+            entry.ReviewedAt = null;
+        }
+
+        db.ExpertiseAuditLogs.Add(BuildAuditRow(AuditAction.Updated, entry, ctx, beforeHash, entry.IntegrityHash));
         await db.SaveChangesAsync(ct);
         return entry;
     }
 
-    public async Task<bool> SoftDeleteAsync(Guid id, TenantContext ctx, CancellationToken ct)
+    public async Task<WriteOutcome> SoftDeleteAsync(Guid id, TenantContext ctx, CancellationToken ct)
     {
         var entry = await ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx)
             .Where(e => e.Id == id)
+            .Where(e => e.DeprecatedAt == null)
             .FirstOrDefaultAsync(ct);
         if (entry is null)
-            return false;
+            return WriteOutcome.NotFound;
 
+        // ADR-003: soft-delete on shared entries requires expertise.write.approve.
+        // 403 (not 404) is correct here because the caller already knows the entry exists
+        // — they could read it under the same TenantContext.
+        if (entry.Tenant == "shared" && !ctx.Scopes.Contains(AuthConstants.WriteApproveScope))
+            return WriteOutcome.InsufficientScope;
+
+        var hash = entry.IntegrityHash ?? IntegrityHashService.Compute(entry);
         entry.DeprecatedAt = DateTime.UtcNow;
         entry.UpdatedAt = DateTime.UtcNow;
 
+        db.ExpertiseAuditLogs.Add(BuildAuditRow(AuditAction.Deleted, entry, ctx, hash, hash));
         await db.SaveChangesAsync(ct);
-        return true;
+        return WriteOutcome.Success;
     }
 
-    public async Task<List<ExpertiseEntry>> KeywordSearchAsync(string query, TenantContext ctx, bool includeDrafts, bool includeDeprecated, CancellationToken ct)
+    public async Task<(WriteOutcome Outcome, ExpertiseEntry? Entry)> ApproveAsync(
+        Guid id, TenantContext ctx, Visibility visibility, CancellationToken ct)
+    {
+        var entry = await ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx)
+            .Where(e => e.Id == id)
+            .Where(e => e.DeprecatedAt == null)
+            .FirstOrDefaultAsync(ct);
+        if (entry is null)
+            return (WriteOutcome.NotFound, null);
+
+        if (entry.ReviewState != ReviewState.Draft)
+            return (WriteOutcome.InvalidState, null);
+
+        var reviewer = ctx.Principal.FindFirst("sub")?.Value
+                    ?? ctx.Principal.Identity?.Name
+                    ?? "system";
+
+        var hash = entry.IntegrityHash ?? IntegrityHashService.Compute(entry);
+        entry.ReviewState = ReviewState.Approved;
+        entry.Visibility = visibility;
+        entry.ReviewedBy = reviewer;
+        entry.ReviewedAt = DateTime.UtcNow;
+        entry.RejectionReason = null;
+        entry.UpdatedAt = DateTime.UtcNow;
+
+        db.ExpertiseAuditLogs.Add(BuildAuditRow(AuditAction.Approved, entry, ctx, hash, hash));
+
+        try
+        {
+            await db.SaveChangesAsync(ct);
+            return (WriteOutcome.Success, entry);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            return (WriteOutcome.ConcurrentConflict, null);
+        }
+    }
+
+    public async Task<(WriteOutcome Outcome, ExpertiseEntry? Entry)> RejectAsync(
+        Guid id, TenantContext ctx, string rejectionReason, CancellationToken ct)
+    {
+        var entry = await ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx)
+            .Where(e => e.Id == id)
+            .Where(e => e.DeprecatedAt == null)
+            .FirstOrDefaultAsync(ct);
+        if (entry is null)
+            return (WriteOutcome.NotFound, null);
+
+        if (entry.ReviewState != ReviewState.Draft)
+            return (WriteOutcome.InvalidState, null);
+
+        var reviewer = ctx.Principal.FindFirst("sub")?.Value
+                    ?? ctx.Principal.Identity?.Name
+                    ?? "system";
+
+        var hash = entry.IntegrityHash ?? IntegrityHashService.Compute(entry);
+        entry.ReviewState = ReviewState.Rejected;
+        entry.ReviewedBy = reviewer;
+        entry.ReviewedAt = DateTime.UtcNow;
+        entry.RejectionReason = rejectionReason;
+        entry.UpdatedAt = DateTime.UtcNow;
+
+        db.ExpertiseAuditLogs.Add(BuildAuditRow(AuditAction.Rejected, entry, ctx, hash, hash));
+
+        try
+        {
+            await db.SaveChangesAsync(ct);
+            return (WriteOutcome.Success, entry);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            return (WriteOutcome.ConcurrentConflict, null);
+        }
+    }
+
+    public async Task<List<ExpertiseAuditLog>> ListAuditAsync(AuditLogFilter filter, CancellationToken ct)
+    {
+        var query = db.ExpertiseAuditLogs.AsQueryable();
+
+        if (filter.EntryId is { } entryId)
+            query = query.Where(a => a.EntryId == entryId);
+        if (filter.Principal is { Length: > 0 } principal)
+            query = query.Where(a => a.Principal == principal);
+        if (filter.Action is { } action)
+            query = query.Where(a => a.Action == action);
+        if (filter.From is { } from)
+            query = query.Where(a => a.Timestamp >= from);
+        if (filter.To is { } to)
+            query = query.Where(a => a.Timestamp <= to);
+
+        // Cursor: keyset pagination over (Timestamp DESC, Id) — strictly less than the
+        // cursor row keeps result pages deterministic across inserts.
+        if (filter.AfterTimestamp is { } cursorTs && filter.AfterId is { } cursorId)
+        {
+            query = query.Where(a =>
+                a.Timestamp < cursorTs ||
+                (a.Timestamp == cursorTs && a.Id.CompareTo(cursorId) < 0));
+        }
+
+        var limit = Math.Clamp(filter.Limit, 1, 200);
+        return await query
+            .OrderByDescending(a => a.Timestamp)
+            .ThenByDescending(a => a.Id)
+            .Take(limit)
+            .ToListAsync(ct);
+    }
+
+    public async Task<List<ExpertiseEntry>> KeywordSearchAsync(string query, TenantContext ctx, bool includeDeprecated, CancellationToken ct)
     {
         // Tenant + ReviewState + DeprecatedAt filters live inside the raw SQL alongside
         // ORDER BY ts_rank because composing LINQ Where on top of FromSqlInterpolated
         // wraps the original query in a subquery — the planner may then drop the inner
         // ORDER BY since the subquery has no LIMIT, leaving result order undefined.
-        // Branching keeps each SQL string fully parameterized via FromSqlInterpolated.
         var tenant = RequireTenant(ctx);
         var approvedState = nameof(ReviewState.Approved);
 
-        if (includeDrafts && includeDeprecated)
-            return await db.ExpertiseEntries.FromSqlInterpolated($"""
-                SELECT * FROM "ExpertiseEntries"
-                WHERE "SearchVector" @@ plainto_tsquery('english', {query})
-                  AND ("Tenant" = {tenant} OR "Tenant" = 'shared')
-                ORDER BY ts_rank("SearchVector", plainto_tsquery('english', {query})) DESC
-                """).ToListAsync(ct);
-
-        if (includeDrafts)
-            return await db.ExpertiseEntries.FromSqlInterpolated($"""
-                SELECT * FROM "ExpertiseEntries"
-                WHERE "SearchVector" @@ plainto_tsquery('english', {query})
-                  AND ("Tenant" = {tenant} OR "Tenant" = 'shared')
-                  AND "DeprecatedAt" IS NULL
-                ORDER BY ts_rank("SearchVector", plainto_tsquery('english', {query})) DESC
-                """).ToListAsync(ct);
-
         if (includeDeprecated)
             return await db.ExpertiseEntries.FromSqlInterpolated($"""
-                SELECT * FROM "ExpertiseEntries"
+                SELECT *, xmin FROM "ExpertiseEntries"
                 WHERE "SearchVector" @@ plainto_tsquery('english', {query})
                   AND ("Tenant" = {tenant} OR "Tenant" = 'shared')
                   AND "ReviewState" = {approvedState}
@@ -170,7 +340,7 @@ public class ExpertiseRepository(ExpertiseDbContext db, ILogger<ExpertiseReposit
                 """).ToListAsync(ct);
 
         return await db.ExpertiseEntries.FromSqlInterpolated($"""
-            SELECT * FROM "ExpertiseEntries"
+            SELECT *, xmin FROM "ExpertiseEntries"
             WHERE "SearchVector" @@ plainto_tsquery('english', {query})
               AND ("Tenant" = {tenant} OR "Tenant" = 'shared')
               AND "ReviewState" = {approvedState}
@@ -179,12 +349,10 @@ public class ExpertiseRepository(ExpertiseDbContext db, ILogger<ExpertiseReposit
             """).ToListAsync(ct);
     }
 
-    public async Task<List<ExpertiseEntry>> SemanticSearchAsync(Vector queryVector, TenantContext ctx, int limit, bool includeDrafts, bool includeDeprecated, CancellationToken ct)
+    public async Task<List<ExpertiseEntry>> SemanticSearchAsync(Vector queryVector, TenantContext ctx, int limit, bool includeDeprecated, CancellationToken ct)
     {
-        var query = ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx)
+        var query = ApplyApprovedReviewFilter(ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx))
             .Where(e => e.Embedding != null);
-
-        query = ApplyReviewStateFilter(query, includeDrafts);
 
         if (!includeDeprecated)
             query = query.Where(e => e.DeprecatedAt == null);

--- a/src/ExpertiseApi/Data/ExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/ExpertiseRepository.cs
@@ -132,19 +132,16 @@ public class ExpertiseRepository(
 
     public async Task<ExpertiseEntry> CreateAsync(ExpertiseEntry entry, TenantContext ctx, CancellationToken ct)
     {
-        // Defensive invariant: entry.Tenant must match the caller's token-asserted tenant.
-        // BuildEntry always derives Tenant from TenantContext, so this guard cannot trip under
-        // normal operation. It exists to catch any future code path that constructs an
-        // ExpertiseEntry with a caller-supplied tenant bypassing that assertion.
-        //
-        // NOTE: Creating entries with Tenant="shared" via POST /expertise is intentionally
-        // not supported in this design. Cross-tenant sharing is achieved by approving an
-        // entry with Visibility=Shared (POST /expertise/{id}/approve). Allowing write.approve
-        // callers to POST Tenant="shared" directly would produce unapprove-able drafts because
-        // ListDraftsAsync scopes its draft queue to the caller's own tenant and never surfaces
-        // shared entries; those drafts would be permanently stranded.
+        // Defensive invariant: entry.Tenant must match the caller's token-asserted tenant,
+        // with one explicit exception: write.approve callers may create Tenant="shared" entries
+        // (which are created directly as Approved — see BuildEntry). BuildEntry always derives
+        // Tenant from TenantContext or a validated request.Tenant, so this guard cannot trip
+        // under normal operation. It exists to catch any future code path that constructs an
+        // ExpertiseEntry with an unvalidated tenant bypassing that assertion.
         var callerTenant = RequireTenant(ctx);
-        if (!string.Equals(entry.Tenant, callerTenant, StringComparison.Ordinal))
+        var isSharedByApprover = string.Equals(entry.Tenant, "shared", StringComparison.Ordinal)
+                              && ctx.Scopes.Contains(AuthConstants.WriteApproveScope);
+        if (!string.Equals(entry.Tenant, callerTenant, StringComparison.Ordinal) && !isSharedByApprover)
             throw new InvalidOperationException(
                 $"Entry tenant '{entry.Tenant}' does not match caller tenant '{callerTenant}'.");
 

--- a/src/ExpertiseApi/Data/ExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/ExpertiseRepository.cs
@@ -132,9 +132,17 @@ public class ExpertiseRepository(
 
     public async Task<ExpertiseEntry> CreateAsync(ExpertiseEntry entry, TenantContext ctx, CancellationToken ct)
     {
-        // Defensive: ensure the entry's Tenant matches the caller's. BuildEntry wires this
-        // from the same TenantContext, but verifying here closes the loop against any
-        // future code path that constructs an entry with a request-supplied tenant.
+        // Defensive invariant: entry.Tenant must match the caller's token-asserted tenant.
+        // BuildEntry always derives Tenant from TenantContext, so this guard cannot trip under
+        // normal operation. It exists to catch any future code path that constructs an
+        // ExpertiseEntry with a caller-supplied tenant bypassing that assertion.
+        //
+        // NOTE: Creating entries with Tenant="shared" via POST /expertise is intentionally
+        // not supported in this design. Cross-tenant sharing is achieved by approving an
+        // entry with Visibility=Shared (POST /expertise/{id}/approve). Allowing write.approve
+        // callers to POST Tenant="shared" directly would produce unapprove-able drafts because
+        // ListDraftsAsync scopes its draft queue to the caller's own tenant and never surfaces
+        // shared entries; those drafts would be permanently stranded.
         var callerTenant = RequireTenant(ctx);
         if (!string.Equals(entry.Tenant, callerTenant, StringComparison.Ordinal))
             throw new InvalidOperationException(

--- a/src/ExpertiseApi/Data/IExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/IExpertiseRepository.cs
@@ -9,10 +9,22 @@ namespace ExpertiseApi.Data;
 /// <c>Tenant IN (ctx.Tenant, "shared")</c>. Writes scope tenant ownership at the repository
 /// layer so a caller in tenant A cannot mutate or soft-delete an entry in tenant B
 /// (cross-tenant resolves to 404 via <c>FirstOrDefaultAsync</c> returning null).
+/// <para>
+/// State-changing methods write a row to <c>ExpertiseAuditLog</c> in the same
+/// <c>SaveChangesAsync</c> call as the entry mutation — atomicity is the safeguard
+/// against the entry-mutated-but-no-audit-row failure mode.
+/// </para>
 /// </summary>
 public interface IExpertiseRepository
 {
     Task<ExpertiseEntry?> GetByIdAsync(Guid id, TenantContext ctx, CancellationToken ct = default);
+
+    /// <summary>
+    /// Reads an entry without filtering on <c>ReviewState</c>. Used by approve/reject paths
+    /// that must load <see cref="ReviewState.Draft"/> entries the default <see cref="GetByIdAsync"/>
+    /// would exclude. Tenant filter is still applied — cross-tenant returns null.
+    /// </summary>
+    Task<ExpertiseEntry?> GetByIdIncludingDraftsAsync(Guid id, TenantContext ctx, CancellationToken ct = default);
 
     Task<List<ExpertiseEntry>> ListAsync(
         TenantContext ctx,
@@ -20,19 +32,53 @@ public interface IExpertiseRepository
         List<string>? tags = null,
         EntryType? entryType = null,
         Severity? severity = null,
-        bool includeDrafts = false,
         bool includeDeprecated = false,
         CancellationToken ct = default);
 
+    /// <summary>
+    /// Lists <c>Draft</c> and <c>Rejected</c> entries in the caller's tenant only — drafts
+    /// are owned by the writing tenant and are not cross-tenant visible (no <c>shared</c>).
+    /// Caller authorization (<c>WriteApproveAccess</c>) is enforced at the endpoint layer.
+    /// </summary>
+    Task<List<ExpertiseEntry>> ListDraftsAsync(TenantContext ctx, CancellationToken ct = default);
+
     Task<ExpertiseEntry> CreateAsync(ExpertiseEntry entry, TenantContext ctx, CancellationToken ct = default);
 
+    /// <summary>
+    /// Applies the caller-supplied delegate to the entry, then commits. State-regression
+    /// rule (ADR-003): when a <c>write.draft</c>-only caller mutates an <c>Approved</c>
+    /// entry, the entry is reset to <c>Draft</c>; <c>write.approve</c> callers preserve
+    /// <c>Approved</c> state. The state regression and audit row are written atomically.
+    /// </summary>
     Task<ExpertiseEntry?> UpdateAsync(Guid id, TenantContext ctx, Func<ExpertiseEntry, Task> applyUpdates, CancellationToken ct = default);
 
-    Task<bool> SoftDeleteAsync(Guid id, TenantContext ctx, CancellationToken ct = default);
+    /// <summary>
+    /// Soft-deletes by setting <see cref="ExpertiseEntry.DeprecatedAt"/>. Soft-deleting a
+    /// <c>Tenant = "shared"</c> entry requires <c>expertise.write.approve</c> per ADR-003;
+    /// without that scope returns <see cref="WriteOutcome.InsufficientScope"/>.
+    /// </summary>
+    Task<WriteOutcome> SoftDeleteAsync(Guid id, TenantContext ctx, CancellationToken ct = default);
 
-    Task<List<ExpertiseEntry>> KeywordSearchAsync(string query, TenantContext ctx, bool includeDrafts = false, bool includeDeprecated = false, CancellationToken ct = default);
+    /// <summary>
+    /// Transitions <c>Draft</c> → <c>Approved</c>. Sets <c>ReviewedBy</c>/<c>ReviewedAt</c>,
+    /// applies <paramref name="visibility"/> (default <c>Private</c>), clears
+    /// <c>RejectionReason</c>. Returns <see cref="WriteOutcome.InvalidState"/> when the
+    /// entry is not in <c>Draft</c>; <see cref="WriteOutcome.ConcurrentConflict"/> when an
+    /// <c>xmin</c> race is lost.
+    /// </summary>
+    Task<(WriteOutcome Outcome, ExpertiseEntry? Entry)> ApproveAsync(
+        Guid id, TenantContext ctx, Visibility visibility, CancellationToken ct = default);
 
-    Task<List<ExpertiseEntry>> SemanticSearchAsync(Vector queryVector, TenantContext ctx, int limit = 10, bool includeDrafts = false, bool includeDeprecated = false, CancellationToken ct = default);
+    Task<(WriteOutcome Outcome, ExpertiseEntry? Entry)> RejectAsync(
+        Guid id, TenantContext ctx, string rejectionReason, CancellationToken ct = default);
+
+    Task<List<ExpertiseAuditLog>> ListAuditAsync(
+        AuditLogFilter filter,
+        CancellationToken ct = default);
+
+    Task<List<ExpertiseEntry>> KeywordSearchAsync(string query, TenantContext ctx, bool includeDeprecated = false, CancellationToken ct = default);
+
+    Task<List<ExpertiseEntry>> SemanticSearchAsync(Vector queryVector, TenantContext ctx, int limit = 10, bool includeDeprecated = false, CancellationToken ct = default);
 
     Task<ExpertiseEntry?> FindExactMatchAsync(string domain, string title, TenantContext ctx, CancellationToken ct = default);
 
@@ -42,3 +88,32 @@ public interface IExpertiseRepository
 
     Task<List<ExpertiseEntry>> FindAllEmbeddingsInDomainAsync(string domain, TenantContext ctx, CancellationToken ct = default);
 }
+
+/// <summary>
+/// Outcome of a write operation that can fail for reasons other than "not found."
+/// </summary>
+public enum WriteOutcome
+{
+    Success,
+    NotFound,
+    /// <summary>State machine rejected the transition (e.g., approve on already-approved).</summary>
+    InvalidState,
+    /// <summary>Caller is missing a scope required for this specific entry (e.g., shared-entry mutation).</summary>
+    InsufficientScope,
+    /// <summary>Optimistic concurrency conflict on <c>xmin</c>.</summary>
+    ConcurrentConflict
+}
+
+/// <summary>
+/// Cursor-paginated audit log query. Cursor is <c>(AfterTimestamp, AfterId)</c> for
+/// keyset pagination ordered by <c>(Timestamp DESC, Id)</c>.
+/// </summary>
+public record AuditLogFilter(
+    Guid? EntryId = null,
+    string? Principal = null,
+    AuditAction? Action = null,
+    DateTime? From = null,
+    DateTime? To = null,
+    int Limit = 50,
+    DateTime? AfterTimestamp = null,
+    Guid? AfterId = null);

--- a/src/ExpertiseApi/Endpoints/AuditEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/AuditEndpoints.cs
@@ -1,0 +1,53 @@
+using ExpertiseApi.Auth;
+using ExpertiseApi.Data;
+using ExpertiseApi.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ExpertiseApi.Endpoints;
+
+/// <summary>
+/// Cross-tenant audit log queries. Admin-only per ADR-003 line 32. Tenant-scoped audit
+/// reads for non-admin reviewers are deferred (tracked separately).
+/// </summary>
+public static class AuditEndpoints
+{
+    public static RouteGroupBuilder MapAuditEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/audit")
+            .WithTags("Audit")
+            .RequireAuthorization(AuthConstants.Policies.AdminAccess);
+
+        group.MapGet("/", ListAudit);
+
+        return group;
+    }
+
+    private static async Task<IResult> ListAudit(
+        IExpertiseRepository repo,
+        [FromQuery] Guid? entryId,
+        [FromQuery] string? principal,
+        [FromQuery] AuditAction? action,
+        [FromQuery] DateTime? from,
+        [FromQuery] DateTime? to,
+        [FromQuery] int limit = 50,
+        [FromQuery(Name = "afterTimestamp")] DateTime? afterTimestamp = null,
+        [FromQuery(Name = "afterId")] Guid? afterId = null,
+        CancellationToken ct = default)
+    {
+        // Cursor pagination requires both halves of the keyset; if only one is provided
+        // we treat the cursor as absent rather than producing surprising results.
+        var hasCursor = afterTimestamp is not null && afterId is not null;
+        var filter = new AuditLogFilter(
+            EntryId: entryId,
+            Principal: principal,
+            Action: action,
+            From: from,
+            To: to,
+            Limit: limit,
+            AfterTimestamp: hasCursor ? afterTimestamp : null,
+            AfterId: hasCursor ? afterId : null);
+
+        var rows = await repo.ListAuditAsync(filter, ct);
+        return Results.Ok(rows);
+    }
+}

--- a/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
@@ -18,6 +18,9 @@ public static class ExpertiseEndpoints
         group.MapGet("/", ListEntries)
             .RequireAuthorization("ReadAccess");
 
+        group.MapGet("/drafts", ListDrafts)
+            .RequireAuthorization(AuthConstants.Policies.WriteApproveAccess);
+
         group.MapGet("/{id:guid}", GetEntry)
             .RequireAuthorization("ReadAccess");
 
@@ -33,6 +36,12 @@ public static class ExpertiseEndpoints
         group.MapPost("/batch", CreateBatch)
             .RequireAuthorization("WriteAccess");
 
+        group.MapPost("/{id:guid}/approve", ApproveEntry)
+            .RequireAuthorization(AuthConstants.Policies.WriteApproveAccess);
+
+        group.MapPost("/{id:guid}/reject", RejectEntry)
+            .RequireAuthorization(AuthConstants.Policies.WriteApproveAccess);
+
         return group;
     }
 
@@ -43,20 +52,25 @@ public static class ExpertiseEndpoints
         [FromQuery] string? tags,
         [FromQuery] EntryType? entryType,
         [FromQuery] Severity? severity,
-        [FromQuery] bool includeDrafts = false,
         [FromQuery] bool includeDeprecated = false,
         CancellationToken ct = default)
     {
+        // Reads always default to ReviewState = Approved. Reviewers see drafts and rejected
+        // entries via GET /expertise/drafts (which requires write.approve).
         var tenantContext = httpContext.RequireTenantContext();
-
-        if (includeDrafts && !tenantContext.Scopes.Contains(AuthConstants.WriteApproveScope))
-            return Results.Problem(
-                "?includeDrafts=true requires the expertise.write.approve scope.",
-                statusCode: 403);
-
         var tagList = tags?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
 
-        var entries = await repo.ListAsync(tenantContext, domain, tagList, entryType, severity, includeDrafts, includeDeprecated, ct);
+        var entries = await repo.ListAsync(tenantContext, domain, tagList, entryType, severity, includeDeprecated, ct);
+        return Results.Ok(entries);
+    }
+
+    private static async Task<IResult> ListDrafts(
+        HttpContext httpContext,
+        IExpertiseRepository repo,
+        CancellationToken ct)
+    {
+        var tenantContext = httpContext.RequireTenantContext();
+        var entries = await repo.ListDraftsAsync(tenantContext, ct);
         return Results.Ok(entries);
     }
 
@@ -285,9 +299,74 @@ public static class ExpertiseEndpoints
         CancellationToken ct)
     {
         var tenantContext = httpContext.RequireTenantContext();
-        var deleted = await repo.SoftDeleteAsync(id, tenantContext, ct);
-        return deleted ? Results.NoContent() : Results.NotFound();
+        var outcome = await repo.SoftDeleteAsync(id, tenantContext, ct);
+        return outcome switch
+        {
+            WriteOutcome.Success => Results.NoContent(),
+            WriteOutcome.NotFound => Results.NotFound(),
+            WriteOutcome.InsufficientScope => Results.Problem(
+                "Soft-deleting a shared entry requires the expertise.write.approve scope.",
+                statusCode: 403),
+            _ => Results.Problem("Unexpected outcome from soft-delete.", statusCode: 500)
+        };
     }
+
+    private static async Task<IResult> ApproveEntry(
+        Guid id,
+        HttpContext httpContext,
+        IExpertiseRepository repo,
+        ApproveExpertiseRequest? request,
+        CancellationToken ct)
+    {
+        var tenantContext = httpContext.RequireTenantContext();
+        var visibility = request?.Visibility ?? Visibility.Private;
+
+        var (outcome, entry) = await repo.ApproveAsync(id, tenantContext, visibility, ct);
+        return outcome switch
+        {
+            WriteOutcome.Success => Results.Ok(entry),
+            WriteOutcome.NotFound => Results.NotFound(),
+            WriteOutcome.InvalidState => Results.Problem(
+                "Entry is not in Draft state and cannot be approved.",
+                statusCode: 409),
+            WriteOutcome.ConcurrentConflict => Results.Problem(
+                "Entry was modified concurrently. Retry.",
+                statusCode: 409),
+            _ => Results.Problem("Unexpected outcome from approve.", statusCode: 500)
+        };
+    }
+
+    private static async Task<IResult> RejectEntry(
+        Guid id,
+        RejectExpertiseRequest request,
+        HttpContext httpContext,
+        IExpertiseRepository repo,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(request.RejectionReason))
+            return Results.Problem("rejectionReason is required.", statusCode: 400);
+        if (request.RejectionReason.Length > MaxRejectionReasonLength)
+            return Results.Problem(
+                $"rejectionReason exceeds maximum length of {MaxRejectionReasonLength} characters.",
+                statusCode: 400);
+
+        var tenantContext = httpContext.RequireTenantContext();
+        var (outcome, entry) = await repo.RejectAsync(id, tenantContext, request.RejectionReason, ct);
+        return outcome switch
+        {
+            WriteOutcome.Success => Results.Ok(entry),
+            WriteOutcome.NotFound => Results.NotFound(),
+            WriteOutcome.InvalidState => Results.Problem(
+                "Entry is not in Draft state and cannot be rejected.",
+                statusCode: 409),
+            WriteOutcome.ConcurrentConflict => Results.Problem(
+                "Entry was modified concurrently. Retry.",
+                statusCode: 409),
+            _ => Results.Problem("Unexpected outcome from reject.", statusCode: 500)
+        };
+    }
+
+    private const int MaxRejectionReasonLength = 2000;
 }
 
 public enum BatchEntryStatus { Created, Duplicate, Rejected, Failed }
@@ -317,3 +396,7 @@ public record UpdateExpertiseRequest(
     string? Source = null,
     List<string>? Tags = null,
     string? SourceVersion = null);
+
+public record ApproveExpertiseRequest(Visibility? Visibility = null);
+
+public record RejectExpertiseRequest(string RejectionReason);

--- a/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
@@ -104,6 +104,20 @@ public static class ExpertiseEndpoints
 
         var tenantContext = httpContext.RequireTenantContext();
 
+        // Validate optional Tenant override: only "shared" is permitted, and only for write.approve callers.
+        if (request.Tenant is not null)
+        {
+            if (!string.Equals(request.Tenant, "shared", StringComparison.OrdinalIgnoreCase))
+                return Results.Problem(
+                    "Only Tenant=\"shared\" may be specified; all other tenants are server-assigned.",
+                    statusCode: 400);
+
+            if (!tenantContext.Scopes.Contains(AuthConstants.WriteApproveScope))
+                return Results.Problem(
+                    "Creating shared entries requires expertise.write.approve.",
+                    statusCode: 403);
+        }
+
         var embedding = await embeddingService.GenerateEmbeddingAsync(
             EmbeddingService.BuildInputText(request.Title, request.Body), ct);
 
@@ -178,6 +192,25 @@ public static class ExpertiseEndpoints
                     "Domain, Title, Body, and Source are required.");
                 continue;
             }
+
+            // Validate optional Tenant override per item.
+            if (requests[i].Tenant is not null)
+            {
+                if (!string.Equals(requests[i].Tenant, "shared", StringComparison.OrdinalIgnoreCase))
+                {
+                    results[i] = new BatchEntryResult(i, BatchEntryStatus.Rejected, null,
+                        "Only Tenant=\"shared\" may be specified; all other tenants are server-assigned.");
+                    continue;
+                }
+
+                if (!tenantContext.Scopes.Contains(AuthConstants.WriteApproveScope))
+                {
+                    results[i] = new BatchEntryResult(i, BatchEntryStatus.Rejected, null,
+                        "Creating shared entries requires expertise.write.approve.");
+                    continue;
+                }
+            }
+
             validItems.Add((i, requests[i]));
         }
 
@@ -274,7 +307,13 @@ public static class ExpertiseEndpoints
     private static ExpertiseEntry BuildEntry(
         CreateExpertiseRequest request,
         Vector embedding,
-        TenantContext tenantContext) => new()
+        TenantContext tenantContext)
+    {
+        var authorPrincipal = tenantContext.Principal.FindFirst("sub")?.Value
+                          ?? tenantContext.Principal.Identity?.Name
+                          ?? "unknown";
+        var isShared = string.Equals(request.Tenant, "shared", StringComparison.OrdinalIgnoreCase);
+        return new ExpertiseEntry
         {
             Domain = request.Domain,
             Tags = request.Tags ?? [],
@@ -285,12 +324,17 @@ public static class ExpertiseEndpoints
             Source = request.Source,
             SourceVersion = request.SourceVersion,
             Embedding = embedding,
-            Tenant = tenantContext.Tenant!,
-            AuthorPrincipal = tenantContext.Principal.FindFirst("sub")?.Value
-                          ?? tenantContext.Principal.Identity?.Name
-                          ?? "unknown",
-            AuthorAgent = tenantContext.Agent
+            Tenant = request.Tenant ?? tenantContext.Tenant!,
+            AuthorPrincipal = authorPrincipal,
+            AuthorAgent = tenantContext.Agent,
+            // Shared entries bypass the draft queue (which is scoped to the writing tenant
+            // and never surfaces shared drafts). Create them directly as Approved to avoid
+            // a permanently unapprovable stranded draft.
+            ReviewState = isShared ? ReviewState.Approved : ReviewState.Draft,
+            ReviewedBy = isShared ? authorPrincipal : null,
+            ReviewedAt = isShared ? DateTime.UtcNow : null,
         };
+    }
 
     private static async Task<IResult> DeleteEntry(
         Guid id,
@@ -385,7 +429,15 @@ public record CreateExpertiseRequest(
     Severity Severity,
     string Source,
     List<string>? Tags = null,
-    string? SourceVersion = null);
+    string? SourceVersion = null,
+    /// <summary>
+    /// Optional tenant override. Only <c>"shared"</c> is accepted; all other tenants are
+    /// server-assigned from the caller's token. Requires <c>expertise.write.approve</c>.
+    /// Shared entries are created directly as <see cref="ReviewState.Approved"/> to avoid
+    /// stranded drafts (the draft queue is scoped to the writing tenant and never surfaces
+    /// shared entries).
+    /// </summary>
+    string? Tenant = null);
 
 public record UpdateExpertiseRequest(
     string? Domain = null,

--- a/src/ExpertiseApi/Endpoints/SearchEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/SearchEndpoints.cs
@@ -21,7 +21,6 @@ public static class SearchEndpoints
         HttpContext httpContext,
         IExpertiseRepository repo,
         [FromQuery] string q,
-        [FromQuery] bool includeDrafts = false,
         [FromQuery] bool includeDeprecated = false,
         CancellationToken ct = default)
     {
@@ -29,13 +28,7 @@ public static class SearchEndpoints
             return Results.Problem("Query parameter 'q' is required.", statusCode: 400);
 
         var tenantContext = httpContext.RequireTenantContext();
-
-        if (includeDrafts && !tenantContext.Scopes.Contains(AuthConstants.WriteApproveScope))
-            return Results.Problem(
-                "?includeDrafts=true requires the expertise.write.approve scope.",
-                statusCode: 403);
-
-        var results = await repo.KeywordSearchAsync(q, tenantContext, includeDrafts, includeDeprecated, ct);
+        var results = await repo.KeywordSearchAsync(q, tenantContext, includeDeprecated, ct);
         return Results.Ok(results);
     }
 }

--- a/src/ExpertiseApi/Endpoints/SemanticSearchEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/SemanticSearchEndpoints.cs
@@ -24,7 +24,6 @@ public static class SemanticSearchEndpoints
         EmbeddingService embeddingService,
         [FromQuery] string q,
         [FromQuery] int limit = 10,
-        [FromQuery] bool includeDrafts = false,
         [FromQuery] bool includeDeprecated = false,
         CancellationToken ct = default)
     {
@@ -32,15 +31,9 @@ public static class SemanticSearchEndpoints
             return Results.Problem("Query parameter 'q' is required.", statusCode: 400);
 
         var tenantContext = httpContext.RequireTenantContext();
-
-        if (includeDrafts && !tenantContext.Scopes.Contains(AuthConstants.WriteApproveScope))
-            return Results.Problem(
-                "?includeDrafts=true requires the expertise.write.approve scope.",
-                statusCode: 403);
-
         var clampedLimit = Math.Clamp(limit, 1, 100);
         var queryVector = await embeddingService.GenerateEmbeddingAsync(q, ct);
-        var results = await repo.SemanticSearchAsync(queryVector, tenantContext, clampedLimit, includeDrafts, includeDeprecated, ct);
+        var results = await repo.SemanticSearchAsync(queryVector, tenantContext, clampedLimit, includeDeprecated, ct);
         return Results.Ok(results);
     }
 }

--- a/src/ExpertiseApi/Migrations/20260429122919_AddXminRowVersion.Designer.cs
+++ b/src/ExpertiseApi/Migrations/20260429122919_AddXminRowVersion.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using ExpertiseApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -14,9 +15,11 @@ using Pgvector;
 namespace ExpertiseApi.Migrations
 {
     [DbContext(typeof(ExpertiseDbContext))]
-    partial class ExpertiseDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260429122919_AddXminRowVersion")]
+    partial class AddXminRowVersion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ExpertiseApi/Migrations/20260429122919_AddXminRowVersion.cs
+++ b/src/ExpertiseApi/Migrations/20260429122919_AddXminRowVersion.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ExpertiseApi.Migrations
+{
+    /// <summary>
+    /// Registers the PostgreSQL <c>xmin</c> system column as the EF Core concurrency token
+    /// on <c>ExpertiseEntries</c>. <c>xmin</c> is a system column that already exists on
+    /// every Postgres table, so this migration is intentionally a no-op at the schema level
+    /// — the migration exists so the model snapshot tracks the EF-side mapping. Generated
+    /// AddColumn / DropColumn calls were removed because they would attempt to create a
+    /// duplicate user-defined column or drop a system column.
+    /// </summary>
+    public partial class AddXminRowVersion : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // No-op — xmin already exists as a Postgres system column.
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // No-op — xmin cannot be dropped (it's a system column).
+        }
+    }
+}

--- a/src/ExpertiseApi/Models/ExpertiseEntry.cs
+++ b/src/ExpertiseApi/Models/ExpertiseEntry.cs
@@ -52,4 +52,13 @@ public class ExpertiseEntry
     public DateTime? ReviewedAt { get; set; }
 
     public string? RejectionReason { get; set; }
+
+    /// <summary>
+    /// PostgreSQL <c>xmin</c> system column used as an EF Core optimistic concurrency token.
+    /// Two reviewers racing on <c>POST /approve</c> + <c>POST /reject</c> against the same draft
+    /// would both observe <c>ReviewState = Draft</c>; the second <c>SaveChangesAsync</c> throws
+    /// <see cref="Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException"/> and the endpoint
+    /// returns 409 Conflict instead of silently last-write-wins.
+    /// </summary>
+    public uint Version { get; set; }
 }

--- a/src/ExpertiseApi/Models/ExpertiseEntry.cs
+++ b/src/ExpertiseApi/Models/ExpertiseEntry.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
 using NpgsqlTypes;
 using Pgvector;
 
@@ -59,6 +60,8 @@ public class ExpertiseEntry
     /// would both observe <c>ReviewState = Draft</c>; the second <c>SaveChangesAsync</c> throws
     /// <see cref="Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException"/> and the endpoint
     /// returns 409 Conflict instead of silently last-write-wins.
+    /// Not included in API responses — it is an internal EF concurrency mechanism.
     /// </summary>
+    [JsonIgnore]
     public uint Version { get; set; }
 }

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -62,14 +62,32 @@ builder.Services.AddScoped<DeduplicationService>();
 builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
     options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+
+    var configuredCidrs = builder.Configuration
+        .GetSection("ForwardedHeaders:KnownNetworks")
+        .Get<string[]>()?
+        .Where(static cidr => !string.IsNullOrWhiteSpace(cidr))
+        .ToArray();
+
+    // Preserve the framework defaults when no allowlist is configured so only loopback is trusted.
+    if (configuredCidrs is null || configuredCidrs.Length == 0)
+        return;
+
+    var parsedNetworks = new List<System.Net.IPNetwork>(configuredCidrs.Length);
+    foreach (var cidr in configuredCidrs)
+    {
+        if (!System.Net.IPNetwork.TryParse(cidr, out var network))
+            throw new InvalidOperationException(
+                $"Invalid ForwardedHeaders:KnownNetworks CIDR entry '{cidr}'.");
+
+        parsedNetworks.Add(network);
+    }
+
     options.KnownIPNetworks.Clear();
     options.KnownProxies.Clear();
 
-    foreach (var cidr in builder.Configuration.GetSection("ForwardedHeaders:KnownNetworks").Get<string[]>() ?? [])
-    {
-        if (System.Net.IPNetwork.TryParse(cidr, out var network))
-            options.KnownIPNetworks.Add(network);
-    }
+    foreach (var network in parsedNetworks)
+        options.KnownIPNetworks.Add(network);
 });
 
 var app = builder.Build();

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -5,10 +5,12 @@ using ExpertiseApi.Cli;
 using ExpertiseApi.Data;
 using ExpertiseApi.Endpoints;
 using ExpertiseApi.Services;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.SemanticKernel;
 using Prometheus;
 using Serilog;
+using System.Net;
 using System.Text.Json.Serialization;
 using Scalar.AspNetCore;
 
@@ -53,6 +55,23 @@ builder.Services.Configure<DeduplicationOptions>(
     builder.Configuration.GetSection("Deduplication"));
 builder.Services.AddScoped<DeduplicationService>();
 
+// X-Forwarded-For support for accurate audit IpAddress capture behind ingress / reverse proxy.
+// KnownNetworks must be configured via ForwardedHeaders:KnownNetworks (CIDR list) in
+// production — without explicit allowlist the middleware trusts only loopback, which means
+// audit IpAddress will record the ingress pod IP rather than the real client.
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+    options.KnownIPNetworks.Clear();
+    options.KnownProxies.Clear();
+
+    foreach (var cidr in builder.Configuration.GetSection("ForwardedHeaders:KnownNetworks").Get<string[]>() ?? [])
+    {
+        if (System.Net.IPNetwork.TryParse(cidr, out var network))
+            options.KnownIPNetworks.Add(network);
+    }
+});
+
 var app = builder.Build();
 
 if (ReembedCommand.IsReembedRequested(args))
@@ -66,6 +85,10 @@ if (RehashCommand.IsRehashRequested(args))
     await RehashCommand.RunAsync(app, args);
     return;
 }
+
+// ForwardedHeaders must run before authentication so HttpContext.Connection.RemoteIpAddress
+// reflects the real client IP when the audit pipeline reads it.
+app.UseForwardedHeaders();
 
 app.UseExceptionHandler();
 app.UseStatusCodePages();
@@ -94,6 +117,7 @@ app.MapHealthEndpoints();
 app.MapExpertiseEndpoints();
 app.MapSearchEndpoints();
 app.MapSemanticSearchEndpoints();
+app.MapAuditEndpoints();
 if (metricsEnabled)
     app.MapMetrics().AllowAnonymous();
 

--- a/tests/ExpertiseApi.Tests/Integration/ApprovalWorkflowTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/ApprovalWorkflowTests.cs
@@ -1,0 +1,504 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using ExpertiseApi.Auth;
+using ExpertiseApi.Data;
+using ExpertiseApi.Models;
+using ExpertiseApi.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ExpertiseApi.Tests.Integration;
+
+/// <summary>
+/// Approval workflow: <c>/approve</c>, <c>/reject</c>, state-machine guards, audit row
+/// atomicity, optimistic concurrency, PATCH state regression, shared-entry soft-delete
+/// scope, and rejection-reason validation.
+/// </summary>
+[Collection("Postgres")]
+public class ApprovalWorkflowTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private JwtApiFactory _factory = null!;
+
+    public ApprovalWorkflowTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public async Task InitializeAsync()
+    {
+        _factory = new JwtApiFactory(_postgres.ConnectionString);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+        await db.ExpertiseAuditLogs.IgnoreQueryFilters().ExecuteDeleteAsync();
+        await db.ExpertiseEntries.IgnoreQueryFilters().ExecuteDeleteAsync();
+    }
+
+    public async Task DisposeAsync() => await _factory.DisposeAsync();
+
+    private HttpClient ClientWithScopes(params string[] scopes)
+    {
+        var token = JwtTokenMinter.Mint(
+            tenant: "test",
+            scopes: scopes,
+            groups: ["group-test"]);
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
+    }
+
+    private async Task<ExpertiseEntry> SeedDraft(
+        string tenant = "test",
+        string title = "needs review",
+        string body = "draft body content")
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+        var entry = TestHelpers.SeedEntry(
+            tenant: tenant, title: title, body: body, reviewState: ReviewState.Draft);
+        db.ExpertiseEntries.Add(entry);
+        await db.SaveChangesAsync();
+        return entry;
+    }
+
+    private async Task<int> CountAuditRows(Guid entryId)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+        return await db.ExpertiseAuditLogs.CountAsync(a => a.EntryId == entryId);
+    }
+
+    private async Task<ExpertiseAuditLog?> LatestAudit(Guid entryId)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+        return await db.ExpertiseAuditLogs
+            .Where(a => a.EntryId == entryId)
+            .OrderByDescending(a => a.Timestamp)
+            .ThenByDescending(a => a.Id)
+            .FirstOrDefaultAsync();
+    }
+
+    [Fact]
+    public async Task Approve_DraftWithApproveScope_TransitionsToApproved()
+    {
+        var draft = await SeedDraft();
+        using var approver = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteApproveScope);
+
+        var response = await approver.PostAsJsonAsync($"/expertise/{draft.Id}/approve", new { });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetProperty("reviewState").GetString().Should().Be("Approved");
+        json.GetProperty("reviewedBy").GetString().Should().NotBeNullOrEmpty();
+        json.GetProperty("reviewedAt").GetString().Should().NotBeNullOrEmpty();
+
+        var audit = await LatestAudit(draft.Id);
+        audit.Should().NotBeNull();
+        audit!.Action.Should().Be(AuditAction.Approved);
+    }
+
+    [Fact]
+    public async Task Approve_WithoutApproveScope_Returns403()
+    {
+        var draft = await SeedDraft();
+        using var writer = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);
+
+        var response = await writer.PostAsJsonAsync($"/expertise/{draft.Id}/approve", new { });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Approve_AlreadyApprovedEntry_Returns409()
+    {
+        var draft = await SeedDraft();
+        using var approver = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteApproveScope);
+
+        var first = await approver.PostAsJsonAsync($"/expertise/{draft.Id}/approve", new { });
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var second = await approver.PostAsJsonAsync($"/expertise/{draft.Id}/approve", new { });
+        second.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task Approve_CrossTenantEntry_Returns404()
+    {
+        // Caller is in tenant "test"; entry is in tenant "other-team".
+        using var approver = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteApproveScope);
+        var draft = await SeedDraft(tenant: "other-team");
+
+        var response = await approver.PostAsJsonAsync($"/expertise/{draft.Id}/approve", new { });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Approve_WithVisibilityShared_SetsVisibility()
+    {
+        var draft = await SeedDraft();
+        using var approver = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteApproveScope);
+
+        var response = await approver.PostAsJsonAsync($"/expertise/{draft.Id}/approve",
+            new { visibility = "Shared" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetProperty("visibility").GetString().Should().Be("Shared");
+    }
+
+    [Fact]
+    public async Task Reject_DraftWithReason_TransitionsToRejected()
+    {
+        var draft = await SeedDraft();
+        using var approver = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteApproveScope);
+
+        var response = await approver.PostAsJsonAsync(
+            $"/expertise/{draft.Id}/reject",
+            new { rejectionReason = "Lacks supporting context." });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetProperty("reviewState").GetString().Should().Be("Rejected");
+        json.GetProperty("rejectionReason").GetString().Should().Be("Lacks supporting context.");
+
+        var audit = await LatestAudit(draft.Id);
+        audit!.Action.Should().Be(AuditAction.Rejected);
+    }
+
+    [Fact]
+    public async Task Reject_WithoutReason_Returns400()
+    {
+        var draft = await SeedDraft();
+        using var approver = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteApproveScope);
+
+        var response = await approver.PostAsJsonAsync(
+            $"/expertise/{draft.Id}/reject",
+            new { rejectionReason = "" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Reject_OverlongReason_Returns400()
+    {
+        var draft = await SeedDraft();
+        using var approver = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteApproveScope);
+
+        var response = await approver.PostAsJsonAsync(
+            $"/expertise/{draft.Id}/reject",
+            new { rejectionReason = new string('x', 2001) });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Approve_WritesIntegrityHashAndAuditChain()
+    {
+        var draft = await SeedDraft();
+        using var approver = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteApproveScope);
+
+        await approver.PostAsJsonAsync($"/expertise/{draft.Id}/approve", new { });
+
+        var audit = await LatestAudit(draft.Id);
+        audit!.BeforeHash.Should().NotBeNullOrEmpty();
+        audit.AfterHash.Should().NotBeNullOrEmpty();
+        // ReviewState is excluded from the canonical hash, so before == after on approve.
+        audit.BeforeHash.Should().Be(audit.AfterHash);
+    }
+
+    [Fact]
+    public async Task ConcurrentApproveAndReject_OneSucceedsOneConflicts()
+    {
+        var draft = await SeedDraft();
+        using var c1 = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteApproveScope);
+        using var c2 = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteApproveScope);
+
+        var t1 = c1.PostAsJsonAsync($"/expertise/{draft.Id}/approve", new { });
+        var t2 = c2.PostAsJsonAsync(
+            $"/expertise/{draft.Id}/reject",
+            new { rejectionReason = "racey" });
+
+        var results = await Task.WhenAll(t1, t2);
+        var statuses = results.Select(r => (int)r.StatusCode).OrderBy(s => s).ToArray();
+
+        // One must succeed (200), one must fail with 409 (either invalid-state or
+        // concurrency token mismatch — both are 409).
+        statuses.Should().BeEquivalentTo(new[] { 200, 409 });
+    }
+
+    [Fact]
+    public async Task Patch_OnApprovedByDraftCaller_RegressesToDraft()
+    {
+        // Seed an Approved entry, then PATCH it as a write.draft caller. Per ADR-003 the
+        // entry should regress to Draft so it requires re-approval.
+        ExpertiseEntry seeded;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+            seeded = TestHelpers.SeedEntry(
+                tenant: "test", title: "approved-content", reviewState: ReviewState.Approved);
+            seeded.ReviewedBy = "previous-approver";
+            seeded.ReviewedAt = DateTime.UtcNow;
+            db.ExpertiseEntries.Add(seeded);
+            await db.SaveChangesAsync();
+        }
+
+        using var writer = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);
+        var response = await writer.PatchAsJsonAsync(
+            $"/expertise/{seeded.Id}",
+            new { body = "edited body — should regress to draft" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetProperty("reviewState").GetString().Should().Be("Draft");
+    }
+
+    [Fact]
+    public async Task Patch_OnApprovedByApproveCaller_PreservesApproved()
+    {
+        ExpertiseEntry seeded;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+            seeded = TestHelpers.SeedEntry(
+                tenant: "test", title: "approved-content", reviewState: ReviewState.Approved);
+            db.ExpertiseEntries.Add(seeded);
+            await db.SaveChangesAsync();
+        }
+
+        using var approver = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope, AuthConstants.WriteApproveScope);
+        var response = await approver.PatchAsJsonAsync(
+            $"/expertise/{seeded.Id}",
+            new { body = "edited by approver — stays Approved" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetProperty("reviewState").GetString().Should().Be("Approved");
+    }
+
+    [Fact]
+    public async Task Delete_SharedEntryByWriteDraftCaller_Returns403()
+    {
+        // Soft-delete on shared entries requires write.approve per ADR-003.
+        ExpertiseEntry seeded;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+            seeded = TestHelpers.SeedEntry(
+                tenant: "shared", title: "shared-knowledge", reviewState: ReviewState.Approved);
+            db.ExpertiseEntries.Add(seeded);
+            await db.SaveChangesAsync();
+        }
+
+        using var writer = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);
+        var response = await writer.DeleteAsync($"/expertise/{seeded.Id}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Delete_SharedEntryByApproveCaller_Succeeds()
+    {
+        ExpertiseEntry seeded;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+            seeded = TestHelpers.SeedEntry(
+                tenant: "shared", title: "shared-knowledge", reviewState: ReviewState.Approved);
+            db.ExpertiseEntries.Add(seeded);
+            await db.SaveChangesAsync();
+        }
+
+        using var approver = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope, AuthConstants.WriteApproveScope);
+        var response = await approver.DeleteAsync($"/expertise/{seeded.Id}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task Create_WritesAuditRow()
+    {
+        using var writer = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);
+
+        var response = await writer.PostAsJsonAsync("/expertise", new
+        {
+            domain = "shared",
+            title = "audit-on-create",
+            body = "body content for audit on create",
+            entryType = "Pattern",
+            severity = "Info",
+            source = "test"
+        });
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var json = await response.Content.ReadJsonElementAsync();
+        var id = json.GetProperty("id").GetGuid();
+
+        var audit = await LatestAudit(id);
+        audit.Should().NotBeNull();
+        audit!.Action.Should().Be(AuditAction.Created);
+        audit.BeforeHash.Should().BeNull();
+        audit.AfterHash.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task Update_WritesAuditRowWithDifferentHashes()
+    {
+        ExpertiseEntry seeded;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+            seeded = TestHelpers.SeedEntry(
+                tenant: "test", title: "original-title", body: "original-body",
+                reviewState: ReviewState.Approved);
+            db.ExpertiseEntries.Add(seeded);
+            await db.SaveChangesAsync();
+        }
+
+        using var approver = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope, AuthConstants.WriteApproveScope);
+        var response = await approver.PatchAsJsonAsync(
+            $"/expertise/{seeded.Id}",
+            new { title = "new-title-changes-hash" });
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var audit = await LatestAudit(seeded.Id);
+        audit!.Action.Should().Be(AuditAction.Updated);
+        audit.BeforeHash.Should().NotBeNullOrEmpty();
+        audit.AfterHash.Should().NotBeNullOrEmpty();
+        audit.BeforeHash.Should().NotBe(audit.AfterHash);
+    }
+}
+
+[Collection("Postgres")]
+public class AuditEndpointTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private JwtApiFactory _factory = null!;
+
+    public AuditEndpointTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public async Task InitializeAsync()
+    {
+        _factory = new JwtApiFactory(_postgres.ConnectionString);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+        await db.ExpertiseAuditLogs.IgnoreQueryFilters().ExecuteDeleteAsync();
+        await db.ExpertiseEntries.IgnoreQueryFilters().ExecuteDeleteAsync();
+    }
+
+    public async Task DisposeAsync() => await _factory.DisposeAsync();
+
+    private HttpClient ClientWithScopes(params string[] scopes)
+    {
+        var token = JwtTokenMinter.Mint(
+            tenant: "test",
+            scopes: scopes,
+            groups: ["group-test"]);
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
+    }
+
+    [Fact]
+    public async Task ListAudit_WithoutAdminScope_Returns403()
+    {
+        using var approver = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteApproveScope);
+
+        var response = await approver.GetAsync("/audit");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task ListAudit_WithAdminScope_ReturnsRows()
+    {
+        // Seed an entry + audit row via direct DbContext. Pre-generate the entry Id so
+        // the audit row's FK can reference a known GUID before SaveChanges.
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+            var entry = TestHelpers.SeedEntry(tenant: "test", reviewState: ReviewState.Approved);
+            entry.Id = Guid.NewGuid();
+            db.ExpertiseEntries.Add(entry);
+            db.ExpertiseAuditLogs.Add(new ExpertiseAuditLog
+            {
+                Timestamp = DateTime.UtcNow,
+                Action = AuditAction.Created,
+                EntryId = entry.Id,
+                Tenant = "test",
+                Principal = "test-principal",
+                BeforeHash = null,
+                AfterHash = "deadbeef"
+            });
+            await db.SaveChangesAsync();
+        }
+
+        using var admin = ClientWithScopes(AuthConstants.AdminScope);
+
+        var response = await admin.GetAsync("/audit");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetArrayLength().Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task ListAudit_FiltersByEntryId()
+    {
+        Guid targetId;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+            var keep = TestHelpers.SeedEntry(tenant: "test", title: "keep");
+            keep.Id = Guid.NewGuid();
+            var skip = TestHelpers.SeedEntry(tenant: "test", title: "skip");
+            skip.Id = Guid.NewGuid();
+            db.ExpertiseEntries.AddRange(keep, skip);
+            await db.SaveChangesAsync();
+            targetId = keep.Id;
+
+            db.ExpertiseAuditLogs.AddRange(
+                new ExpertiseAuditLog { Timestamp = DateTime.UtcNow, Action = AuditAction.Created, EntryId = keep.Id, Tenant = "test", Principal = "p" },
+                new ExpertiseAuditLog { Timestamp = DateTime.UtcNow, Action = AuditAction.Created, EntryId = skip.Id, Tenant = "test", Principal = "p" });
+            await db.SaveChangesAsync();
+        }
+
+        using var admin = ClientWithScopes(AuthConstants.AdminScope);
+
+        var response = await admin.GetAsync($"/audit?entryId={targetId}");
+
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetArrayLength().Should().Be(1);
+        json[0].GetProperty("entryId").GetGuid().Should().Be(targetId);
+    }
+
+    [Fact]
+    public async Task ListAudit_AdminSeesAllTenants()
+    {
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+            var a = TestHelpers.SeedEntry(tenant: "test", title: "tenant-a");
+            a.Id = Guid.NewGuid();
+            var b = TestHelpers.SeedEntry(tenant: "other-team", title: "tenant-b");
+            b.Id = Guid.NewGuid();
+            db.ExpertiseEntries.AddRange(a, b);
+            await db.SaveChangesAsync();
+
+            db.ExpertiseAuditLogs.AddRange(
+                new ExpertiseAuditLog { Timestamp = DateTime.UtcNow, Action = AuditAction.Created, EntryId = a.Id, Tenant = "test", Principal = "p" },
+                new ExpertiseAuditLog { Timestamp = DateTime.UtcNow, Action = AuditAction.Created, EntryId = b.Id, Tenant = "other-team", Principal = "p" });
+            await db.SaveChangesAsync();
+        }
+
+        using var admin = ClientWithScopes(AuthConstants.AdminScope);
+
+        var response = await admin.GetAsync("/audit");
+
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetArrayLength().Should().Be(2);
+    }
+}

--- a/tests/ExpertiseApi.Tests/Integration/ApprovalWorkflowTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/ApprovalWorkflowTests.cs
@@ -369,6 +369,72 @@ public class ApprovalWorkflowTests : IAsyncLifetime
         audit.AfterHash.Should().NotBeNullOrEmpty();
         audit.BeforeHash.Should().NotBe(audit.AfterHash);
     }
+
+    [Fact]
+    public async Task Create_SharedEntryByApproveCaller_CreatesAsApproved()
+    {
+        // write.approve callers may specify Tenant="shared" — entry is created directly
+        // as Approved (bypassing the draft queue which only surfaces the caller's own tenant).
+        using var approver = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteApproveScope);
+
+        var response = await approver.PostAsJsonAsync("/expertise", new
+        {
+            domain = "shared",
+            title = "shared-knowledge-direct",
+            body = "authoritative cross-team content",
+            entryType = "Pattern",
+            severity = "Info",
+            source = "test",
+            tenant = "shared"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetProperty("tenant").GetString().Should().Be("shared");
+        json.GetProperty("reviewState").GetString().Should().Be("Approved");
+        json.GetProperty("reviewedBy").GetString().Should().NotBeNullOrEmpty();
+        json.GetProperty("reviewedAt").GetString().Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task Create_SharedEntryByDraftCaller_Returns403()
+    {
+        // write.draft-only callers are not allowed to create Tenant="shared" entries.
+        using var writer = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);
+
+        var response = await writer.PostAsJsonAsync("/expertise", new
+        {
+            domain = "shared",
+            title = "should-be-rejected",
+            body = "draft caller cannot set shared tenant",
+            entryType = "Pattern",
+            severity = "Info",
+            source = "test",
+            tenant = "shared"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Create_WithNonSharedTenantOverride_Returns400()
+    {
+        // Only Tenant="shared" is a valid override — all other tenant values are rejected.
+        using var approver = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteApproveScope);
+
+        var response = await approver.PostAsJsonAsync("/expertise", new
+        {
+            domain = "shared",
+            title = "should-be-rejected",
+            body = "cannot override to arbitrary tenant",
+            entryType = "Pattern",
+            severity = "Info",
+            source = "test",
+            tenant = "other-team"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
 }
 
 [Collection("Postgres")]

--- a/tests/ExpertiseApi.Tests/Integration/ExpertiseEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/ExpertiseEndpointTests.cs
@@ -25,6 +25,8 @@ public class ExpertiseEndpointTests : IAsyncLifetime
 
         using var scope = _factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+        // FK ON DELETE RESTRICT requires audit logs be removed before their entries.
+        await db.ExpertiseAuditLogs.ExecuteDeleteAsync();
         await db.ExpertiseEntries.ExecuteDeleteAsync();
     }
 

--- a/tests/ExpertiseApi.Tests/Integration/SearchEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/SearchEndpointTests.cs
@@ -24,6 +24,7 @@ public class SearchEndpointTests : IAsyncLifetime
 
         using var scope = _factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+        await db.ExpertiseAuditLogs.ExecuteDeleteAsync();
         await db.ExpertiseEntries.ExecuteDeleteAsync();
     }
 

--- a/tests/ExpertiseApi.Tests/Integration/TenantIsolationTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/TenantIsolationTests.cs
@@ -39,8 +39,8 @@ public class TenantIsolationTests : IAsyncLifetime
 
         using var scope = _factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
-        await db.ExpertiseEntries.IgnoreQueryFilters()
-            .ExecuteDeleteAsync();
+        await db.ExpertiseAuditLogs.IgnoreQueryFilters().ExecuteDeleteAsync();
+        await db.ExpertiseEntries.IgnoreQueryFilters().ExecuteDeleteAsync();
     }
 
     public async Task DisposeAsync()
@@ -91,21 +91,22 @@ public class TenantIsolationTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task List_IncludeDraftsWithoutApproveScope_Returns403()
+    public async Task ListDrafts_WithoutApproveScope_Returns403()
     {
         // _testClient carries read + draft scopes but NOT approve.
         await SeedEntry(tenant: "test", reviewState: ReviewState.Draft);
 
-        var response = await _testClient.GetAsync("/expertise?includeDrafts=true");
+        var response = await _testClient.GetAsync("/expertise/drafts");
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
 
     [Fact]
-    public async Task List_IncludeDraftsWithApproveScope_ReturnsDrafts()
+    public async Task ListDrafts_WithApproveScope_ReturnsDraftsAndRejected()
     {
-        var approved = await SeedEntry(tenant: "test", title: "approved", reviewState: ReviewState.Approved);
-        var draft = await SeedEntry(tenant: "test", title: "draft", reviewState: ReviewState.Draft);
+        await SeedEntry(tenant: "test", title: "approved", reviewState: ReviewState.Approved);
+        await SeedEntry(tenant: "test", title: "draft", reviewState: ReviewState.Draft);
+        await SeedEntry(tenant: "test", title: "rejected", reviewState: ReviewState.Rejected);
 
         var approveToken = JwtTokenMinter.Mint(
             tenant: "test",
@@ -114,11 +115,36 @@ public class TenantIsolationTests : IAsyncLifetime
         using var approveClient = _factory.CreateClient();
         approveClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", approveToken);
 
-        var response = await approveClient.GetAsync("/expertise?includeDrafts=true");
+        var response = await approveClient.GetAsync("/expertise/drafts");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var json = await response.Content.ReadJsonElementAsync();
         json.GetArrayLength().Should().Be(2);
+        var titles = new[] { json[0].GetProperty("title").GetString(), json[1].GetProperty("title").GetString() };
+        titles.Should().Contain("draft");
+        titles.Should().Contain("rejected");
+        titles.Should().NotContain("approved");
+    }
+
+    [Fact]
+    public async Task ListDrafts_DoesNotIncludeOtherTenantOrShared()
+    {
+        await SeedEntry(tenant: "test", title: "own-draft", reviewState: ReviewState.Draft);
+        await SeedEntry(tenant: "shared", title: "shared-draft", reviewState: ReviewState.Draft);
+        await SeedEntry(tenant: "other-team", title: "other-draft", reviewState: ReviewState.Draft);
+
+        var approveToken = JwtTokenMinter.Mint(
+            tenant: "test",
+            scopes: [AuthConstants.ReadScope, AuthConstants.WriteApproveScope],
+            groups: ["group-test"]);
+        using var approveClient = _factory.CreateClient();
+        approveClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", approveToken);
+
+        var response = await approveClient.GetAsync("/expertise/drafts");
+
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetArrayLength().Should().Be(1);
+        json[0].GetProperty("title").GetString().Should().Be("own-draft");
     }
 
     [Fact]


### PR DESCRIPTION
Closes #49. Part of #45.

## Summary

PR 4 of the secure rebuild. Implements the approval workflow + audit log writes + scope split on writes, plus closes three Critical findings surfaced by the PR 4 adversarial review.

## Type of Change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [ ] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change (add `!` to PR title)

## New endpoints

| Method | Endpoint | Required scope | Notes |
|---|---|---|---|
| POST | `/expertise/{id}/approve` | `expertise.write.approve` | Draft → Approved. Optional `{visibility}` body (default `Private`) |
| POST | `/expertise/{id}/reject` | `expertise.write.approve` | Draft → Rejected. Required `{rejectionReason}` body, max 2000 chars |
| GET | `/expertise/drafts` | `expertise.write.approve` | Draft + Rejected in caller's tenant only |
| GET | `/audit` | `expertise.admin` | Cross-tenant. Cursor-paginated on `(Timestamp DESC, Id)` |

## Audit log writes

- Repository-layer audit (Decision A2): every state-changing operation (`POST`, `PATCH`, `DELETE`, `/approve`, `/reject`) writes an `ExpertiseAuditLog` row in the same `SaveChangesAsync` as the entry mutation — atomic by construction. Closes the audit-atomicity Critical from review.
- `IntegrityHash` is now written on every `Create` / `Update` (was only set by the `rehash` CLI before this PR).
- `BeforeHash` / `AfterHash` carry SHA-256 hashes of the canonical content fields per `IntegrityHashService`; equal hashes mean the content was not modified (e.g., approve/reject change `ReviewState` only, not content).

## State machine + concurrency (Decision E1)

- Postgres `xmin` system column added as EF Core `RowVersion` concurrency token on `ExpertiseEntry`. Migration is no-op DDL (`xmin` is a Postgres system column that already exists on every table; the migration only adds EF model snapshot tracking).
- Concurrent `/approve` + `/reject` race against the same draft now resolves to one 200 + one 409 instead of last-write-wins.
- `/approve` and `/reject` return 409 when the entry is not in `Draft` state.

## PATCH state regression (Decision C1, ADR-003)

When a `write.draft`-only caller PATCHes an `Approved` entry, the entry regresses to `Draft` so it forces re-approval. A caller carrying `write.approve` preserves the `Approved` state. Without this rule the approval workflow does not actually mitigate ASI06 — content would be mutable post-approval without re-review.

## Soft-delete shared-entry guard (Decision D1, NEW Critical from review)

Soft-deleting a `Tenant = "shared"` entry now requires `expertise.write.approve`. A `write.draft`-only caller attempting to delete a shared entry receives 403 (not 404 — the caller already knows the entry exists since they can read it).

## Read filter changes (Decision F1, NEW Critical from review)

- Reads default to `ReviewState = Approved`.
- `?includeDrafts=true` removed from `/expertise`, `/expertise/search`, and `/expertise/search/semantic`. The previous behavior silently exposed both `Draft` AND `Rejected` entries (including potentially sensitive `RejectionReason` content) to any `write.approve` caller. Reviewers now use the dedicated `/expertise/drafts` endpoint.

## Forwarded headers

`Program.cs` registers `UseForwardedHeaders()` before `UseAuthentication()` so audit `IpAddress` reflects the real client IP behind ingress. By default trusts only loopback. Production must configure `ForwardedHeaders:KnownNetworks` (CIDR list) — typically the cluster pod CIDR. Documented in CLAUDE.md and SKILL.md.

## Test Plan

- [x] `dotnet test ExpertiseApi.slnx` — 146/146 passing (was 125 on PR 3 merge; +21 new tests)
- [x] **New `ApprovalWorkflowTests`** covers:
  - `Approve_DraftWithApproveScope_TransitionsToApproved`
  - `Approve_WithoutApproveScope_Returns403`
  - `Approve_AlreadyApprovedEntry_Returns409`
  - `Approve_CrossTenantEntry_Returns404`
  - `Approve_WithVisibilityShared_SetsVisibility`
  - `Reject_DraftWithReason_TransitionsToRejected`
  - `Reject_WithoutReason_Returns400`
  - `Reject_OverlongReason_Returns400`
  - `Approve_WritesIntegrityHashAndAuditChain`
  - `ConcurrentApproveAndReject_OneSucceedsOneConflicts` (uses `Task.WhenAll`)
  - `Patch_OnApprovedByDraftCaller_RegressesToDraft`
  - `Patch_OnApprovedByApproveCaller_PreservesApproved`
  - `Delete_SharedEntryByWriteDraftCaller_Returns403`
  - `Delete_SharedEntryByApproveCaller_Succeeds`
  - `Create_WritesAuditRow`
  - `Update_WritesAuditRowWithDifferentHashes`
- [x] **New `AuditEndpointTests`** covers:
  - `ListAudit_WithoutAdminScope_Returns403`
  - `ListAudit_WithAdminScope_ReturnsRows`
  - `ListAudit_FiltersByEntryId`
  - `ListAudit_AdminSeesAllTenants`
- [x] **`TenantIsolationTests`** updated for `/expertise/drafts` (was `?includeDrafts=true`)
- [x] Existing 109 tests from PR 1-3 still pass
- [x] `dotnet format --verify-no-changes` clean
- [x] `markdownlint-cli2` clean on `CLAUDE.md`, `README.md`, `SKILL.md`
- [x] DB migration `AddXminRowVersion` is no-op DDL (verified before commit)

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files
- [x] Database migrations are reversible — yes (no-op Up/Down for xmin metadata-only migration)
- [x] API changes are backward-compatible — `/expertise/{id}/approve`, `/reject`, `/drafts`, `/audit` are new. Removing `?includeDrafts=true` is a behavior change documented above (pre-prod, low blast radius).
- [x] CLAUDE.md, SKILL.md, README.md updated

## Plan-before-code decisions (approved)

- **A2** — Repository-layer audit writes (atomic by construction)
- **B1** — State machine: Draft⇄Approved via /approve, Draft⇄Rejected via /reject. No direct Approved→Rejected.
- **C1** — PATCH state regression for write.draft callers on Approved entries
- **D1** — Shared-entry soft-delete requires write.approve
- **E1** — xmin RowVersion concurrency token
- **F1** — Removed ?includeDrafts query parameter; /drafts is the canonical reviewer endpoint
- **G1** — /drafts is caller's tenant only (no shared)
- **H1** — RejectionReason required, max 2000 chars

## What is NOT in this PR

- Approved→Rejected direct transition → tracked separately for PR 5
- Cross-tenant admin mutation (admin spans tenants for /audit only) → PR 5
- Tenant-scoped /audit for write.approve holders (admin-only today) → PR 5
- Pagination on /expertise/drafts → PR 5
- Audit log retention / GDPR pseudonymization → future
- Visibility toggle via PATCH for write.approve → PR 5
- ADR-003 clarification on ?includeDrafts deprecation → small docs PR

## Migration safety

The `AddXminRowVersion` migration body is a no-op (`xmin` is a Postgres system column that exists on every table). Both `Up()` and `Down()` are empty. Applying or rolling back is safe. The model snapshot now reflects EF's `xid`-typed concurrency token mapping.

## Cross-repo coordination

None. PR 4 is API-internal.