### PR TITLE
ci(dependabot): auto-merge patch and minor bumps

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.4.0
+
+      - name: Enable auto-merge for patch and minor
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary

Adds a workflow that auto-merges Dependabot PRs once their checks pass — but only for **patch** and **minor** updates. Major bumps continue to require manual review.

## Type of Change

- [ ] \`feat\` — new feature
- [ ] \`fix\` — bug fix
- [ ] \`docs\` — documentation only
- [ ] \`chore\` — maintenance
- [ ] \`refactor\` — restructuring without behavior change
- [ ] \`test\` — adding or updating tests
- [x] \`ci\` — CI/CD changes
- [ ] \`style\` — formatting or linting fixes
- [ ] Breaking change (add \`!\` to PR title)

## How it works

1. Dependabot opens a PR
2. \`ci.yml\` + \`codeql.yml\` + \`security.yml\` run as usual (full 149-test suite via Testcontainers, plus SAST and SCA gates)
3. If actor is \`dependabot[bot]\`, this workflow runs \`gh pr merge --auto --squash\`
4. GitHub merges the PR **only after all checks pass**. Auto-merge is a queue, not a bypass — same gate as a manual merge, just without the click

## What gets auto-merged vs manual

| Update type | Behavior |
| --- | --- |
| \`version-update:semver-patch\` (e.g., 10.0.5 → 10.0.7) | Auto-merge |
| \`version-update:semver-minor\` (e.g., 7.0 → 7.1) | Auto-merge |
| \`version-update:semver-major\` (e.g., 7.x → 8.x) | **Manual** — examples: #69, #74, #75 |
| Grouped updates | The action reports the highest update-type in the group — so any group with a major bump stays manual |

## Repo setting flipped (not part of the PR)

\`allow_auto_merge\` was set to \`true\` via API. Without that toggle, \`gh pr merge --auto\` errors with \`enablePullRequestAutoMerge\` (the same error we hit earlier when I tried to use \`--auto\`).

## Why \`pull_request_target\`

Dependabot PRs run with read-only \`GITHUB_TOKEN\` by default — \`pull_request_target\` runs the workflow with the **target branch's** workflow file and grants the configured permissions, which is what allows \`gh pr merge\` to succeed. This is the documented Dependabot auto-merge pattern.

## Test Plan

- [x] Workflow YAML is structurally valid (committed without lint errors locally)
- [ ] CI checks pass on this PR (Build & Test, Analyze C#, Trivy, Hadolint, lint)
- [ ] Verification on next Dependabot patch/minor PR — it should auto-merge after green
- [ ] Verification on next Dependabot major PR (e.g., the FluentAssertions or coverlet bumps) — should NOT auto-merge

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files
- [x] CLAUDE.md updated — n/a, the Security Scanning section already describes Dependabot generically; auto-merge is an operational behavior, not a stack change

## Follow-up (optional, not in this PR)

- Enable \`delete_branch_on_merge\` at the repo level (currently \`false\`) to align with github-flow rule. Dependabot already deletes its own branches; this would catch human feature branches too.
- If we add branch protection on \`dev\` requiring approvals, this workflow needs a separate PAT (with approval scope) because Dependabot can't approve its own PRs. Defer until branch protection is added.