### PR TITLE
ci(lint-pr-title): bypass title lint for dependabot

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   lint:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3


### PR DESCRIPTION
## Summary

Skip the PR title lint check when \`github.actor == 'dependabot[bot]'\`. Dependabot's NuGet ecosystem produces \`chore: Bump X\` (capital B, no scope) which fails the \`subjectPattern: ^[a-z].+[^.]$\` rule, even with \`commit-message: prefix=chore include=scope\` configured in \`.github/dependabot.yml\`. This is a Dependabot quirk specific to the NuGet handler — the github-actions ecosystem produces \`chore(deps): bump X\` correctly under the same config.

## Type of Change

- [ ] \`feat\` — new feature
- [ ] \`fix\` — bug fix
- [ ] \`docs\` — documentation only
- [ ] \`chore\` — maintenance
- [ ] \`refactor\` — restructuring without behavior change
- [ ] \`test\` — adding or updating tests
- [x] \`ci\` — CI/CD changes
- [ ] \`style\` — formatting or linting fixes
- [ ] Breaking change (add \`!\` to PR title)

## Why this trade-off

The Conventional Commits rule (\`description is imperative, lowercase, no period\`) exists for human authors. Dependabot's \`chore: Bump X from Y to Z\` is structurally a valid Conventional Commits message — \`type:\` separator is present, the description parses cleanly. Only the casing convention differs.

Two options were considered:

1. **Keep retitling each Dependabot PR by hand.** Done twice already (4+5 PRs), and Dependabot's NuGet handler will keep producing the same format — every weekly cycle creates new toil.
2. **Bypass the lint for the bot.** This PR. One-line change, scope contained to bot-authored PRs, human-author PRs still gated. The \`dev\` branch squash-merge log will have mixed casing on \`bump\` lines — accepted as cosmetic.

## What still applies to Dependabot PRs

- \`ci.yml\` Build & Test — runs the full 149-test suite via Testcontainers
- \`codeql.yml\` SAST analysis
- \`security.yml\` Trivy + Hadolint
- \`dependabot-auto-merge.yml\` from #87 — gates auto-merge on patch/minor only

The only thing skipped is the title format lint.

## Test Plan

- [x] YAML structurally valid (committed without local errors)
- [ ] CI checks pass on this PR (this PR's title \`ci(lint-pr-title): ...\` passes the lint workflow because actor is \`pdavis\`, not dependabot)
- [ ] After merge, manually trigger a re-run of the lint workflow on PRs #83, #84, #85, #86 (or wait for Dependabot rebase) — should report \`skipped\` instead of \`failure\`

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files
- [x] CLAUDE.md updated — n/a, the bypass is operational behavior, not a stack change

## After this merges

- Nudge PRs #83, #84, #85, #86 (a comment of \`@dependabot rebase\` will fire \`pull_request: synchronize\` and re-run the lint workflow with the bypass active)
- Run \`gh pr merge --auto --squash\` on the patch/minors among #80–#86; leave the 3 majors (#81, #84, #86) for review