### PR TITLE
docs: align ADRs and SKILL.md with shipped auth and approval surface

### DIFF
--- a/.claude/skills/expertise-api-design/SKILL.md
+++ b/.claude/skills/expertise-api-design/SKILL.md
@@ -103,13 +103,18 @@ Single-row `EmbeddingMetadata` table tracks model name, dimensions, and `LastRee
 |--------|----------|-------|---------|-----------------|
 | GET | `/expertise` | `expertise.read` | Filter by domain, tags, type, severity | `domain`, `tags` (comma-separated), `entryType`, `severity`, `includeDeprecated` |
 | GET | `/expertise/{id}` | `expertise.read` | Single entry | |
-| POST | `/expertise` | `expertise.write` | Create entry (generates embedding) | |
-| POST | `/expertise/batch` | `expertise.write` | Create up to 100 entries (generates embeddings, deduplicates) | Max 100 entries per batch |
-| PATCH | `/expertise/{id}` | `expertise.write` | Update entry (regenerates embedding if title/body changed) | |
-| DELETE | `/expertise/{id}` | `expertise.write` | Soft delete (sets DeprecatedAt) | |
+| POST | `/expertise` | `expertise.write.draft` | Create entry (generates embedding) | |
+| POST | `/expertise/batch` | `expertise.write.draft` | Create up to 100 entries (generates embeddings, deduplicates) | Max 100 entries per batch |
+| PATCH | `/expertise/{id}` | `expertise.write.draft` | Update entry (regenerates embedding if title/body changed) | |
+| DELETE | `/expertise/{id}` | `expertise.write.draft` | Soft delete (sets DeprecatedAt). Shared entries require `expertise.write.approve`. | |
+| GET | `/expertise/drafts` | `expertise.write.approve` | List Draft + Rejected entries in caller's tenant | |
+| POST | `/expertise/{id}/approve` | `expertise.write.approve` | Transition Draft → Approved | |
+| POST | `/expertise/{id}/reject` | `expertise.write.approve` | Transition Draft → Rejected (requires reason) | |
 | GET | `/expertise/search?q=` | `expertise.read` | Keyword full-text search (tsvector) | `includeDeprecated` |
 | GET | `/expertise/search/semantic?q=` | `expertise.read` | Semantic vector search (pgvector) | `limit` (1-100, default 10), `includeDeprecated` |
+| GET | `/audit` | `expertise.admin` | Cross-tenant audit log | `entryId`, `principal`, `action`, `from`, `to`, `limit` (1-200, default 50), cursor (`afterTimestamp` + `afterId`) |
 | GET | `/health` | none | Liveness probe | |
+| GET | `/metrics` | none | Prometheus scrape endpoint | |
 | GET | `/query` | none | Interactive browser UI for read-only API exploration | |
 
 CLI:
@@ -161,7 +166,7 @@ Four scopes with hierarchical implication (`admin ⊇ approve ⊇ draft ⊇ read
 
 ### TenantContext
 
-A `TenantContext { Tenant, Principal, Agent?, Scopes[] }` is built per request and stashed on `HttpContext.Features`. All authentication paths (JWT, ApiKey, LocalDev) populate it. Endpoints read it via `HttpContext.RequireTenantContext()`. Per ADR-001 every `IExpertiseRepository` method takes a `TenantContext` argument and constructs explicit `WHERE Tenant IN (ctx.Tenant, "shared") AND ReviewState = Approved` predicates. The default review state filter is lifted by `?includeDrafts=true` only when the caller carries `expertise.write.approve` (otherwise the endpoint returns 403); the tenant filter is unconditional.
+A `TenantContext { Tenant, Principal, Agent?, Scopes[] }` is built per request and stashed on `HttpContext.Features`. All authentication paths (JWT, ApiKey, LocalDev) populate it. Endpoints read it via `HttpContext.RequireTenantContext()`. Per ADR-001 every `IExpertiseRepository` method takes a `TenantContext` argument and constructs explicit `WHERE Tenant IN (ctx.Tenant, "shared") AND ReviewState = Approved` predicates. The default review state filter is lifted via `GET /expertise/drafts` for callers carrying `expertise.write.approve` (caller's tenant only); the tenant filter is unconditional.
 
 When the principal authenticates successfully but no tenant maps (e.g. group not in `GroupToTenantMapping`), `TenantContext.Tenant` is `null` and the authorization handler returns 403.
 
@@ -175,7 +180,7 @@ When the principal authenticates successfully but no tenant maps (e.g. group not
 
 Cross-tenant operations return **404, not 403**, on `GET`, `PATCH`, and `DELETE` so existence is not disclosed.
 
-### Approval workflow (PR 4)
+### Approval workflow
 
 Reads default to `ReviewState = Approved`. The previous `?includeDrafts=true` query parameter on `/expertise` and `/expertise/search*` was replaced by a dedicated `GET /expertise/drafts` endpoint that returns `Draft` and `Rejected` entries in the caller's tenant only (no `shared` for the draft queue). Requires `expertise.write.approve`.
 
@@ -259,13 +264,14 @@ All 6 personal phase steps are complete:
 | 5 | Done | Helm chart + SOPS secrets + bootstrap manifests + DDNS script |
 | 6 | Done | Backup CronJob (Helm) + manual backup/restore wrapper |
 
-## Production Hardening Phase (not started)
+## Production Hardening — outstanding
 
-- Entra ID OIDC integration for business deployment
-- Business k3s bootstrap and deploy
-- Monitoring / observability (OpenTelemetry, Prometheus metrics)
-- Rate limiting
-- CI/CD pipeline
+Shipped: multi-issuer OIDC (ADR-002 → ADR-005), four-scope split + audit log (ADR-003), Serilog + Prometheus metrics, CodeQL/Trivy/Hadolint security pipeline (ADR-004), semantic-release.
+
+Outstanding:
+
+- Rate limiting (per-principal + per-tenant)
+- Production deployments (Entra-backed business cluster; Authentik-backed homelab)
 
 ## Full Design Document
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ curl "http://localhost:5000/expertise/search/semantic?q=test&limit=5" \
   -H "Authorization: Bearer dev-api-key-change-me"
 
 # 9. OpenAPI docs
-# Browse to http://localhost:5000/scalar/v1
+# Browse to http://localhost:5000/scalar/v1 (Development only — gated on IsDevelopment())
 
 # 10. Query page (interactive browser UI for read-only browsing and search)
 # Browse to http://localhost:5000/query
@@ -156,8 +156,8 @@ Four scopes drive the four authorization policies. The hierarchy is `admin ⊇ a
 | --- | --- | --- |
 | `expertise.read` | `ReadAccess` | All `GET` endpoints |
 | `expertise.write.draft` | `WriteAccess` | `POST`, `PATCH`, `DELETE` (drafts in caller's own tenant) |
-| `expertise.write.approve` | `WriteApproveAccess` | `/approve`, `/reject` (PR 4) |
-| `expertise.admin` | `AdminAccess` | `/audit`, cross-tenant ops (PR 4) |
+| `expertise.write.approve` | `WriteApproveAccess` | `/approve`, `/reject` |
+| `expertise.admin` | `AdminAccess` | `/audit`, cross-tenant ops |
 
 The legacy `expertise.write` scope is normalized to `expertise.write.draft` during one transition cycle.
 
@@ -174,7 +174,7 @@ Every read path is scoped to `Tenant IN (caller_tenant, "shared") AND ReviewStat
 
 ### Approval workflow
 
-Reads default to `ReviewState = Approved`. Reviewers see `Draft` and `Rejected` entries via `GET /expertise/drafts` (requires `expertise.write.approve`, caller's tenant only — no cross-tenant or shared draft visibility). The previous `?includeDrafts=true` query parameter on `/expertise` and `/expertise/search*` was replaced by `/expertise/drafts` in PR 4.
+Reads default to `ReviewState = Approved`. Reviewers see `Draft` and `Rejected` entries via `GET /expertise/drafts` (requires `expertise.write.approve`, caller's tenant only — no cross-tenant or shared draft visibility). The previous `?includeDrafts=true` query parameter on `/expertise` and `/expertise/search*` was replaced by `/expertise/drafts`.
 
 Approval transitions:
 

--- a/README.md
+++ b/README.md
@@ -94,11 +94,12 @@ helm upgrade --install expertise-api ./helm/expertise-api \
   --create-namespace
 ```
 
-Docker images are published to GHCR on every push to `main`:
+Docker images are published to GHCR when a release is cut from `main`:
 
 ```text
-ghcr.io/thesemicolon/agent-expertise-api:latest
-ghcr.io/thesemicolon/agent-expertise-api:<short-sha>
+ghcr.io/thesemicolon/agent-expertise-api:latest          # most recent stable release
+ghcr.io/thesemicolon/agent-expertise-api:v1.2.3          # immutable SemVer tag
+ghcr.io/thesemicolon/agent-expertise-api:1.2             # tracks the latest 1.2.x
 ```
 
 ## Testing

--- a/adrs/002-multi-idp-oidc.md
+++ b/adrs/002-multi-idp-oidc.md
@@ -1,6 +1,6 @@
 # Multi-issuer OIDC via JwtBearerOptions.ValidIssuers allowlist
 
-- Status: accepted
+- Status: superseded by ADR-005
 - Date: 2026-04-28
 
 ## Context and Problem Statement

--- a/adrs/003-scope-split.md
+++ b/adrs/003-scope-split.md
@@ -26,9 +26,9 @@ Scope semantics:
 
 | Scope | Permits |
 |-------|---------|
-| `expertise.read` | All `GET` endpoints. Reads are always filtered to `Tenant IN (caller, 'shared') AND ReviewState = 'Approved'` unless `?includeDrafts=true` is passed and the caller also has `write.approve`. |
+| `expertise.read` | All `GET` endpoints. Reads are always filtered to `Tenant IN (caller, 'shared') AND ReviewState = 'Approved'`; reviewers see drafts via `GET /expertise/drafts` (requires `write.approve`). |
 | `expertise.write.draft` | `POST`, `PATCH` on caller's own tenant only. `ReviewState` is forced to `Draft`. `Tenant` is forced to the caller's tenant. `Visibility` is forced to `Private`. The caller cannot override these by sending them in the request body. |
-| `expertise.write.approve` | Everything `write.draft` permits, plus: setting `ReviewState = 'Approved'` directly on `POST`, calling `POST /expertise/{id}/approve` and `/reject`, setting `Tenant = 'shared'`, setting `Visibility = 'Shared'`, and editing Approved entries (which transitions them back to `Draft` for non-approvers, but stays `Approved` for approvers). |
+| `expertise.write.approve` | Everything `write.draft` permits, plus: calling `POST /expertise/{id}/approve` and `/reject`, setting `Tenant = 'shared'`, setting `Visibility = 'Shared'`, and editing Approved entries (which transitions them back to `Draft` for non-approvers, but stays `Approved` for approvers). |
 | `expertise.admin` | Everything `write.approve` permits, plus: `GET /audit`, soft-delete on shared entries, and tenant reassignment. |
 
 Scope expansion is **policy-side, not token-side**: a token carrying `expertise.admin` is treated as if it also carries `approve`, `draft`, and `read`. This keeps IdP configuration simple — operators issue exactly one scope per role — and centralizes the expansion logic in the authorization handler.
@@ -53,8 +53,8 @@ A `GET /expertise/{id}` for an entry in another tenant returns 404 rather than 4
 - Good, because the audit log gives the team a tamper-evident record of who promoted what and when, queryable via `/audit` for `expertise.admin` holders.
 - Good, because shared entries (`Tenant = 'shared'`) require an explicit `write.approve` action — drift into the shared keyspace is no longer accidental.
 - Bad, because curator workflow now requires a human-in-the-loop step for every entry that should reach canonical state. This is intentional; the framework's curator agent operates with `write.approve` scope to triage drafts on behalf of the operator. Operators must never grant `write.approve` to long-lived non-interactive service principals.
-- Bad, because the legacy `expertise.write` scope is now ambiguous and must be deprecated cleanly. The cutover plan handles this in PR 6 (production breaking change, Conventional Commits `!`).
-- Bad, because `?includeDrafts=true` adds a UI/agent path that must be tested for tenant-scoping. Approvers see drafts in their own tenant only, never drafts in other tenants — even with `expertise.admin`.
+- Bad, because the legacy `expertise.write` scope is now ambiguous and must be deprecated cleanly. Removal is tracked as a future breaking change (Conventional Commits `!`).
+- Bad, because the dedicated `GET /expertise/drafts` endpoint adds a UI/agent path that must be tested for tenant-scoping. Approvers see drafts in their own tenant only, never drafts in other tenants — even with `expertise.admin`.
 
 ## Related
 

--- a/adrs/005-multi-issuer-jwt-policy-scheme.md
+++ b/adrs/005-multi-issuer-jwt-policy-scheme.md
@@ -1,0 +1,45 @@
+# Per-issuer JwtBearer schemes behind a Bearer policy scheme
+
+- Status: accepted
+- Date: 2026-04-30
+- Supersedes: ADR-002
+
+## Context and Problem Statement
+
+ADR-002 chose multi-issuer OIDC via a single `AddJwtBearer` registration with `JwtBearerOptions.ValidIssuers` populated from `Auth:Oidc:Issuers[]`. During implementation we discovered that a flat `ValidIssuers` / `ValidAudiences` configuration permits cross-issuer audience contamination: a token validly signed by Authentik whose `aud` happens to equal the Entra audience would pass validation, because the framework checks `aud` against the union of allowed audiences without pinning each audience to its issuing IdP.
+
+We need audience validation to be pinned per-issuer. An Authentik token carrying an Entra audience must fail.
+
+## Considered Options
+
+- Keep flat `ValidIssuers` and accept the cross-issuer audience risk
+- Register one named `JwtBearer` scheme per issuer; use a `Bearer` policy scheme to route tokens by their `iss` claim to the matching named scheme
+- Wrap the framework's validator with a custom post-validation handler that re-checks the issuer/audience pair
+
+## Decision Outcome
+
+Chosen option: **per-issuer named `JwtBearer` scheme behind a `Bearer` policy scheme.**
+
+For each entry in `Auth:Oidc:Issuers[]` the API registers a named `JwtBearer` scheme with that issuer's specific `Authority`, `ValidAudiences`, and `MetadataAddress`. A `Bearer` policy scheme is registered as the default authentication scheme; its `ForwardDefaultSelector` reads the incoming token's `iss` claim (unvalidated) and forwards to the matching named scheme, which then performs the full signature, issuer, audience, and lifetime validation. Endpoints declare `RequireAuthorization()` against `Bearer`.
+
+This preserves ADR-002's underlying decision (multi-IdP OIDC, single deployment, native framework auth, config-driven issuer list) and adds per-issuer audience pinning.
+
+Reasons:
+
+- Cross-issuer audience contamination is structurally impossible — each named scheme validates its own narrow audience list.
+- Adding a new issuer remains a single entry in `Auth:Oidc:Issuers[]`. The registration is loop-driven.
+- The framework's JWKS rotation, clock-skew defaults, and signature validation are unchanged.
+- Custom validation wrapping (option 3) discards more framework behaviour than is necessary; a policy-scheme indirection is a single line of code per issuer.
+
+## Consequences
+
+- Good, because audience contamination across IdPs cannot happen.
+- Good, because ADR-002's operational benefits (one binary, one image, config-driven additions) are preserved.
+- Bad, because the policy-scheme indirection adds one routing decision in the auth pipeline (`SelectScheme` in `AuthExtensions.cs`). The routing reads the unvalidated `iss` claim — safe because the forwarded scheme then validates the signature, but worth understanding when reading the auth code.
+- Bad, because the trailing-slash gotcha from ADR-002 still applies — issuer strings are byte-exact in both routing and validation. Mitigated by integration tests that mint tokens with the configured issuer values.
+
+## Related
+
+- ADR-002 (multi-IdP OIDC) — superseded by this ADR.
+- ADR-001 (tenancy model).
+- ADR-003 (four-scope split).


### PR DESCRIPTION
## Summary

Documentation accuracy fixes for the cumulative work since v0.1.3. Aligns ADRs, SKILL.md, README, and CLAUDE.md with the actually-shipped auth, approval, and CI/CD surface; supersedes ADR-002 with ADR-005 to reflect that the implementation evolved from a flat `ValidIssuers` list to per-issuer JwtBearer schemes behind a `Bearer` policy scheme (audience pinning per IdP). No code changed.

Findings addressed (from the multi-agent repo review): E3, E4, E5, E6, E7, E8, W20, W21, W22.

## Type of Change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [x] `docs` — documentation only
- [ ] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [ ] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change (add `!` to PR title)

## Per-file changes

- **`adrs/002-multi-idp-oidc.md`** — status flipped to `superseded by ADR-005`. Body untouched per the supersession-not-editing ADR rule.
- **`adrs/005-multi-issuer-jwt-policy-scheme.md`** (new) — captures the actual implementation: per-issuer named `JwtBearer` schemes routed by a `Bearer` policy scheme to pin audience per IdP and prevent cross-issuer audience contamination.
- **`adrs/003-scope-split.md`** — replaced `?includeDrafts=true` references with `GET /expertise/drafts`; dropped the "POST sets `ReviewState=Approved` directly" claim (never implemented — auto-approve only fires for `Tenant=shared`); removed the "PR 6" inline reference on the legacy-scope deprecation note.
- **`.claude/skills/expertise-api-design/SKILL.md`** — corrected POST/POST batch/PATCH/DELETE scope from `expertise.write` to `expertise.write.draft`; added 5 missing endpoint rows (`/expertise/drafts`, `/approve`, `/reject`, `/audit`, `/metrics`); fixed the `?includeDrafts=true` reference in the TenantContext section; rewrote the "Production Hardening Phase (not started)" block — Prometheus metrics and CI/CD shipped (PR #36, PR #27, PR #68); rate-limiting and prod deploys remain.
- **`README.md`** — replaced the bogus `:<short-sha>` tag example with the actual SemVer tags published by `release.yml` (`:latest`, `:v1.2.3`, `:1.2`); clarified images publish on release, not every push to `main`.
- **`CLAUDE.md`** — added "Development only" qualifier to the Scalar URL; removed `(PR 4)` and `in PR 4` PR-number references from the scope table and approval-workflow paragraph.

## Test Plan

- [x] `markdownlint-cli2` clean on all changed markdown files (0 errors)
- [x] `grep` confirms no remaining `PR 4`, `in PR 6`, `<short-sha>`, or stale `?includeDrafts=true` query-param references (the two remaining `?includeDrafts=true` mentions are intentional historical migration notes — "the previous … was replaced by …")
- [x] No code changed → `dotnet test` not affected
- [ ] Helm render tests — N/A (chart not touched)

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files
- [x] Database migrations are reversible (if applicable) — N/A
- [x] API changes are backward-compatible (if applicable) — N/A (docs only; the documented surface now matches the shipped surface)
- [x] CLAUDE.md updated (if commands, endpoints, or workflow changed) — yes, this PR is the update