### PR TITLE
chore(lint): consolidate markdown/yaml configs and refresh warning baseline

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,12 @@
+config:
+  default: true
+  # MD013 — line length: tables, URLs, and prose routinely exceed 80 chars
+  MD013: false
+  # MD041 — first-line h1: SKILL.md and other docs start with YAML frontmatter
+  MD041: false
+  # MD060 — table column style: aligned forces lines past 80 chars and compact
+  #         conflicts with aligned in the same file
+  MD060: false
+ignores:
+  - "node_modules/**"
+  - ".expertise/**"

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,7 +1,0 @@
-# MD013: line-length — disabled because tables and URLs routinely exceed 80 chars
-# MD060: table-column-style — disabled because aligned style forces lines past
-#        80 chars and compact style conflicts with aligned in the same file
-MD013: false
-MD060: false
-# MD041: first-line-heading — disabled because skill files start with YAML frontmatter
-MD041: false

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,16 @@
+extends: default
+
+ignore: |
+  helm/**/templates/
+  node_modules/
+
+rules:
+  line-length:
+    max: 120
+    level: warning
+  document-start: disable
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: disable
+  truthy:
+    check-keys: false  # GitHub Actions workflows use `on:` which yamllint flags as truthy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,7 +311,7 @@ Findings flow into the GitHub Security tab (Code scanning + Dependabot + Secret 
 
 Triggers for CodeQL, Trivy, and Hadolint: push to `main`/`dev`, pull requests targeting `main`/`dev`, weekly schedule (Sunday 06:00 UTC), and manual dispatch.
 
-The .NET analyzers run as **warnings**, not errors. The build is green with the existing 201 main-project warnings; the cleanup is tracked separately. The test project overrides `<AnalysisMode>Minimum</AnalysisMode>` to suppress xUnit conventions (underscore method names, `Random` for test data) that produce false-positive security findings.
+The .NET analyzers run as **warnings**, not errors. The build is green with the current main-project warning baseline (~223 as of 2026-04-30, up from 201 at PR #68 due to feature work in PRs #36, #37, #52, #53, #59, #60); the cleanup is tracked separately. Top contributors: CA2007 (ConfigureAwait — generally noise in ASP.NET Core), CA1515 (consider internal types), CA1062 (null-arg validation), CA1861 (static readonly arrays), CA1848 (LoggerMessage delegates). The test project overrides `<AnalysisMode>Minimum</AnalysisMode>` to suppress xUnit conventions (underscore method names, `Random` for test data) that produce false-positive security findings.
 
 See `adrs/004-security-scanning-stack.md` for the design rationale and known gaps (no reachability-aware SCA, no API security spec analysis).
 


### PR DESCRIPTION
## Summary

Lint-hygiene cleanup from the multi-agent repo review (W7, W8, W24). Consolidates the two latent markdownlint configs into a single canonical `.markdownlint-cli2.yaml`, adds a `.yamllint.yaml` so yamllint runs deterministically (resolving 27 inline-comment warnings), and refreshes the analyzer-warning baseline in `CLAUDE.md` to match reality (201 → ~223 with provenance).

E13 (dotnet format drift) was dropped after investigation — `dotnet format whitespace` and `dotnet format style` both report 0 changes. The 40-file delta from full `dotnet format` comes from analyzer auto-fixes (CA1515 `public`→`internal`, CA2007 `ConfigureAwait`) that would break the build and conflict with intentional design choices. Worth discussing separately.

## Type of Change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [x] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [ ] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change (add `!` to PR title)

## Per-file changes

### Removed
- **`.markdownlint.yaml`** — legacy config, no longer needed.

### Added
- **`.markdownlint-cli2.yaml`** — canonical markdownlint config. Both files were already on disk; markdownlint-cli2 reads the `*-cli2.yaml` first, so the (previously untracked) cli2 file was silently driving lint runs. New file keeps this repo's intentional rule disables (MD013 line length, MD041 first-line h1, MD060 table column style) plus an `ignores:` list for `node_modules/` and `.expertise/`.
- **`.yamllint.yaml`** — yamllint config so local and (eventual) CI runs match expectations. Sets `line-length: 120 warning`, `comments min-spaces 1` (this single setting resolves all 27 inline-comment warnings the review surfaced), disables `document-start`, disables `truthy.check-keys` (so GitHub Actions `on:` doesn't trip the rule), and ignores `helm/**/templates/` (Go templates aren't valid YAML to yamllint).

### Modified
- **`CLAUDE.md`** — analyzer-warning baseline updated from "existing 201" to "current ~223 as of 2026-04-30" with PR provenance (#36/#37/#52/#53/#59/#60) and top contributing rules (CA2007, CA1515, CA1062, CA1861, CA1848) so the next reader has context.

## Test Plan

- [x] `markdownlint-cli2 README.md CLAUDE.md 'adrs/*.md' '.claude/skills/expertise-api-design/SKILL.md'` → 0 errors
- [x] `yamllint .github/workflows/ helm/ deploy/` → only remaining finding is the 142-char `if:` line in `dependabot-auto-merge.yml` (tracked as E11 in batch 4 — workflow hardening)
- [x] `dotnet format whitespace ExpertiseApi.slnx` → 0 changes
- [x] `dotnet format style ExpertiseApi.slnx` → 0 changes
- [x] `dotnet build ExpertiseApi.slnx` → 0 errors (warnings unchanged)
- [ ] Helm render tests — N/A (chart not touched)

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files
- [x] Database migrations are reversible (if applicable) — N/A
- [x] API changes are backward-compatible (if applicable) — N/A
- [x] CLAUDE.md updated (if commands, endpoints, or workflow changed) — yes, baseline section refreshed

## Followups (separate PRs)

- **E13 (analyzer auto-fix):** suppress CA2007 globally (well-known noise in ASP.NET Core), decide on `public` vs `internal` for repository/auth types (CA1515), then revisit whether to make `dotnet format --verify-no-changes` a CI gate.
- **E11 (142-char `if:` line in `dependabot-auto-merge.yml`):** part of the workflow-hardening batch.