### PR TITLE
fix: patch concurrency mapping and Rejected-entry resubmit path

### DIFF
--- a/.claude/skills/expertise-api-design/SKILL.md
+++ b/.claude/skills/expertise-api-design/SKILL.md
@@ -189,11 +189,13 @@ Reads default to `ReviewState = Approved`. The previous `?includeDrafts=true` qu
 - Require `expertise.write.approve`.
 - Are tenant-scoped — cross-tenant returns 404, even for admins.
 - Validate the source state is `Draft`; otherwise 409.
-- Use a Postgres `xmin` system column as an EF Core RowVersion concurrency token. Concurrent approve+reject races resolve to one 200 + one 409 (no schema migration; `xmin` already exists on every Postgres table).
+- Use a Postgres `xmin` system column as an EF Core RowVersion concurrency token. Concurrent approve+reject and concurrent PATCH races resolve to one 200 + one 409 (no schema migration; `xmin` already exists on every Postgres table). `UpdateAsync` catches `DbUpdateConcurrencyException` and maps it to 409 alongside `ApproveAsync`/`RejectAsync`.
 - Write an `ExpertiseAuditLog` row in the same `SaveChangesAsync` as the state mutation — atomic by construction.
 - `/reject` requires a non-empty `RejectionReason` body field, max 2000 chars.
 
-PATCH state regression (ADR-003): a `write.draft`-only caller editing an `Approved` entry resets it to `Draft` so it requires re-approval. A `write.approve` caller preserves `Approved`. Without this rule the approval workflow does not actually mitigate ASI06 — content can change post-approval.
+PATCH state regression (ADR-003): a `write.draft`-only caller editing an `Approved` or `Rejected` entry resets it to `Draft` and clears review metadata (`ReviewedBy`, `ReviewedAt`, `RejectionReason`) so it requires re-review. A `write.approve` caller preserves the source state. The Approved branch ensures content changes post-approval cannot bypass review (ASI06 mitigation); the Rejected branch enables resubmission after the author addresses the rejection reason.
+
+Dedup queries (exact-match and semantic) exclude `Rejected` entries — otherwise a Rejected entry would permanently block resubmission of identical content. Drafts and Approved entries still dedup as before.
 
 Soft-deleting a `Tenant = "shared"` entry requires `expertise.write.approve` (returns 403 otherwise — 404 would mislead since the caller can read the entry).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,9 +181,11 @@ Approval transitions:
 - `POST /expertise/{id}/approve` — `Draft → Approved`. Sets `ReviewedBy`, `ReviewedAt`, applies optional `Visibility` from request body (default `Private`), clears `RejectionReason`.
 - `POST /expertise/{id}/reject` — `Draft → Rejected`. Body `{ "rejectionReason": "..." }` is required, max 2000 characters.
 - Both require `expertise.write.approve`. Both return 409 if the entry is not in `Draft` state.
-- Both use a Postgres `xmin` row-version concurrency token: a concurrent approve+reject race resolves to one 200 + one 409 instead of last-write-wins.
+- Both use a Postgres `xmin` row-version concurrency token: a concurrent approve+reject race resolves to one 200 + one 409 instead of last-write-wins. The same applies to concurrent PATCHes — `UpdateAsync` catches `DbUpdateConcurrencyException` and returns 409.
 
-PATCH state regression (per ADR-003): when a `write.draft`-only caller PATCHes an `Approved` entry, the entry regresses to `Draft` (forces re-approval). A caller carrying `write.approve` preserves the `Approved` state. This closes the ASI06 path where post-approval content edits would otherwise bypass review.
+PATCH state regression (per ADR-003): when a `write.draft`-only caller PATCHes an `Approved` or `Rejected` entry, the entry regresses to `Draft` and review metadata (`ReviewedBy`, `ReviewedAt`, `RejectionReason`) is cleared. A caller carrying `write.approve` preserves the source state. The Approved branch closes the ASI06 path where post-approval content edits would otherwise bypass review; the Rejected branch lets an author resubmit content after addressing the rejection reason.
+
+Dedup queries (exact-match and semantic) exclude `Rejected` entries so a Rejected entry does not permanently block resubmission of identical content. Drafts and Approved entries still dedup as before.
 
 Soft-deleting a `Tenant = "shared"` entry requires `expertise.write.approve`. A `write.draft` caller attempting to delete a shared entry receives 403.
 

--- a/src/ExpertiseApi/Data/ExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/ExpertiseRepository.cs
@@ -163,14 +163,14 @@ public class ExpertiseRepository(
         return entry;
     }
 
-    public async Task<ExpertiseEntry?> UpdateAsync(Guid id, TenantContext ctx, Func<ExpertiseEntry, Task> applyUpdates, CancellationToken ct)
+    public async Task<(WriteOutcome Outcome, ExpertiseEntry? Entry)> UpdateAsync(Guid id, TenantContext ctx, Func<ExpertiseEntry, Task> applyUpdates, CancellationToken ct)
     {
         var entry = await ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx)
             .Where(e => e.Id == id)
             .Where(e => e.DeprecatedAt == null)
             .FirstOrDefaultAsync(ct);
         if (entry is null)
-            return null;
+            return (WriteOutcome.NotFound, null);
 
         var beforeHash = entry.IntegrityHash ?? IntegrityHashService.Compute(entry);
 
@@ -179,20 +179,30 @@ public class ExpertiseRepository(
         entry.IntegrityHash = IntegrityHashService.Compute(entry);
 
         // ADR-003 state-regression rule: a write.draft-only caller editing an Approved
-        // entry resets it to Draft (forces re-approval); write.approve callers preserve
-        // the Approved state. Without this, the approval workflow does not actually
-        // mitigate ASI06 — content can change post-approval without re-review.
-        if (entry.ReviewState == ReviewState.Approved
+        // or Rejected entry resets it to Draft (forces re-review); write.approve callers
+        // preserve the source state. Without this, the approval workflow does not
+        // actually mitigate ASI06 — content can change post-approval without re-review,
+        // and a Rejected entry could not be resubmitted at all.
+        if ((entry.ReviewState == ReviewState.Approved || entry.ReviewState == ReviewState.Rejected)
             && !ctx.Scopes.Contains(AuthConstants.WriteApproveScope))
         {
             entry.ReviewState = ReviewState.Draft;
             entry.ReviewedBy = null;
             entry.ReviewedAt = null;
+            entry.RejectionReason = null;
         }
 
         db.ExpertiseAuditLogs.Add(BuildAuditRow(AuditAction.Updated, entry, ctx, beforeHash, entry.IntegrityHash));
-        await db.SaveChangesAsync(ct);
-        return entry;
+
+        try
+        {
+            await db.SaveChangesAsync(ct);
+            return (WriteOutcome.Success, entry);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            return (WriteOutcome.ConcurrentConflict, null);
+        }
     }
 
     public async Task<WriteOutcome> SoftDeleteAsync(Guid id, TenantContext ctx, CancellationToken ct)
@@ -372,6 +382,7 @@ public class ExpertiseRepository(
     {
         return await ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx)
             .Where(e => e.DeprecatedAt == null)
+            .Where(e => e.ReviewState != ReviewState.Rejected)
             .Where(e => e.Domain == domain)
             .Where(e => e.Title.ToLower() == title.ToLower())
             .FirstOrDefaultAsync(ct);
@@ -382,6 +393,7 @@ public class ExpertiseRepository(
         var lowerTitles = titles.Select(t => t.ToLowerInvariant()).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
         return await ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx)
             .Where(e => e.DeprecatedAt == null)
+            .Where(e => e.ReviewState != ReviewState.Rejected)
             .Where(e => e.Domain == domain)
             .Where(e => lowerTitles.Contains(e.Title.ToLowerInvariant()))
             .ToListAsync(ct);
@@ -391,6 +403,7 @@ public class ExpertiseRepository(
     {
         var candidate = await ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx)
             .Where(e => e.DeprecatedAt == null)
+            .Where(e => e.ReviewState != ReviewState.Rejected)
             .Where(e => e.Domain == domain)
             .Where(e => e.Embedding != null)
             .OrderBy(e => e.Embedding!.CosineDistance(queryVector))
@@ -419,6 +432,7 @@ public class ExpertiseRepository(
     {
         return await ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx)
             .Where(e => e.DeprecatedAt == null)
+            .Where(e => e.ReviewState != ReviewState.Rejected)
             .Where(e => e.Domain == domain)
             .Where(e => e.Embedding != null)
             .ToListAsync(ct);

--- a/src/ExpertiseApi/Data/IExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/IExpertiseRepository.cs
@@ -47,10 +47,14 @@ public interface IExpertiseRepository
     /// <summary>
     /// Applies the caller-supplied delegate to the entry, then commits. State-regression
     /// rule (ADR-003): when a <c>write.draft</c>-only caller mutates an <c>Approved</c>
-    /// entry, the entry is reset to <c>Draft</c>; <c>write.approve</c> callers preserve
-    /// <c>Approved</c> state. The state regression and audit row are written atomically.
+    /// or <c>Rejected</c> entry, the entry is reset to <c>Draft</c> and review metadata
+    /// (<c>ReviewedBy</c>, <c>ReviewedAt</c>, <c>RejectionReason</c>) is cleared;
+    /// <c>write.approve</c> callers preserve the source state. The state regression and
+    /// audit row are written atomically. Returns <see cref="WriteOutcome.NotFound"/> when
+    /// the entry is missing or in another tenant; <see cref="WriteOutcome.ConcurrentConflict"/>
+    /// when an <c>xmin</c> race is lost.
     /// </summary>
-    Task<ExpertiseEntry?> UpdateAsync(Guid id, TenantContext ctx, Func<ExpertiseEntry, Task> applyUpdates, CancellationToken ct = default);
+    Task<(WriteOutcome Outcome, ExpertiseEntry? Entry)> UpdateAsync(Guid id, TenantContext ctx, Func<ExpertiseEntry, Task> applyUpdates, CancellationToken ct = default);
 
     /// <summary>
     /// Soft-deletes by setting <see cref="ExpertiseEntry.DeprecatedAt"/>. Soft-deleting a

--- a/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
@@ -140,7 +140,7 @@ public static class ExpertiseEndpoints
         var tenantContext = httpContext.RequireTenantContext();
         var needsReembed = request.Title is not null || request.Body is not null;
 
-        var updated = await repo.UpdateAsync(id, tenantContext, async entry =>
+        var (outcome, updated) = await repo.UpdateAsync(id, tenantContext, async entry =>
         {
             if (request.Domain is not null) entry.Domain = request.Domain;
             if (request.Tags is not null) entry.Tags = request.Tags;
@@ -158,7 +158,16 @@ public static class ExpertiseEndpoints
             }
         }, ct);
 
-        return updated is null ? Results.NotFound() : Results.Ok(updated);
+        return outcome switch
+        {
+            WriteOutcome.Success => Results.Ok(updated),
+            WriteOutcome.NotFound => Results.NotFound(),
+            WriteOutcome.ConcurrentConflict => Results.Problem(
+                title: "Concurrent modification",
+                detail: "The entry was modified by another request. Reload and retry.",
+                statusCode: StatusCodes.Status409Conflict),
+            _ => Results.Problem(statusCode: StatusCodes.Status500InternalServerError),
+        };
     }
 
     private static async Task<IResult> CreateBatch(

--- a/tests/ExpertiseApi.Tests/Integration/ApprovalWorkflowTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/ApprovalWorkflowTests.cs
@@ -435,6 +435,165 @@ public class ApprovalWorkflowTests : IAsyncLifetime
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
+
+    [Fact]
+    public async Task Patch_OnRejectedByDraftCaller_RegressesToDraft_ClearsRejectionReason()
+    {
+        // Symmetric to Patch_OnApprovedByDraftCaller_RegressesToDraft. A write.draft caller
+        // editing a Rejected entry resets it to Draft and clears rejection metadata so the
+        // author can resubmit content after addressing the rejection reason.
+        ExpertiseEntry seeded;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+            seeded = TestHelpers.SeedEntry(
+                tenant: "test", title: "rejected-content", reviewState: ReviewState.Rejected);
+            seeded.ReviewedBy = "previous-rejector";
+            seeded.ReviewedAt = DateTime.UtcNow;
+            seeded.RejectionReason = "needs more detail";
+            db.ExpertiseEntries.Add(seeded);
+            await db.SaveChangesAsync();
+        }
+
+        using var writer = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);
+        var response = await writer.PatchAsJsonAsync(
+            $"/expertise/{seeded.Id}",
+            new { body = "edited body — addresses rejection reason" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetProperty("reviewState").GetString().Should().Be("Draft");
+        json.GetProperty("rejectionReason").ValueKind.Should().Be(System.Text.Json.JsonValueKind.Null);
+        json.GetProperty("reviewedBy").ValueKind.Should().Be(System.Text.Json.JsonValueKind.Null);
+        json.GetProperty("reviewedAt").ValueKind.Should().Be(System.Text.Json.JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task Patch_OnRejectedByApproveCaller_PreservesRejected()
+    {
+        // Symmetric to Patch_OnApprovedByApproveCaller_PreservesApproved. A write.approve
+        // caller editing a Rejected entry preserves the Rejected state — the regression
+        // rule only fires for write.draft-only callers.
+        ExpertiseEntry seeded;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+            seeded = TestHelpers.SeedEntry(
+                tenant: "test", title: "rejected-content", reviewState: ReviewState.Rejected);
+            seeded.RejectionReason = "needs more detail";
+            db.ExpertiseEntries.Add(seeded);
+            await db.SaveChangesAsync();
+        }
+
+        using var approver = ClientWithScopes(
+            AuthConstants.ReadScope, AuthConstants.WriteDraftScope, AuthConstants.WriteApproveScope);
+        var response = await approver.PatchAsJsonAsync(
+            $"/expertise/{seeded.Id}",
+            new { body = "edited by approver — stays Rejected" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetProperty("reviewState").GetString().Should().Be("Rejected");
+        json.GetProperty("rejectionReason").GetString().Should().Be("needs more detail");
+    }
+
+    [Fact]
+    public async Task ConcurrentPatch_RaceProducesAtLeastOne409()
+    {
+        // UpdateAsync catches DbUpdateConcurrencyException (xmin race) and returns 409
+        // instead of bubbling as an unhandled 500. Fans out to several concurrent PATCHes
+        // to make the race reliable — exactly two clients can occasionally serialize
+        // (both 200) on a fast in-process test server.
+        const int concurrency = 5;
+        var seeded = await SeedDraft(title: "racey-patch");
+        var clients = Enumerable.Range(0, concurrency)
+            .Select(_ => ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope))
+            .ToArray();
+
+        try
+        {
+            var tasks = clients
+                .Select((c, i) => c.PatchAsJsonAsync($"/expertise/{seeded.Id}", new { body = $"writer {i}" }))
+                .ToArray();
+
+            var results = await Task.WhenAll(tasks);
+            var statuses = results.Select(r => (int)r.StatusCode).ToList();
+
+            statuses.Should().Contain(200, "at least one PATCH must win the race");
+            statuses.Should().Contain(409, "at least one PATCH must lose the xmin race and map to 409");
+            statuses.Should().OnlyContain(s => s == 200 || s == 409, "no other status is expected");
+        }
+        finally
+        {
+            foreach (var c in clients) c.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Create_DuplicateTitleOfRejectedEntry_Succeeds()
+    {
+        // Dedup queries must exclude Rejected entries; otherwise a Rejected entry
+        // permanently blocks resubmission of identical content. Same title + body as
+        // the seeded entry — without the Rejected-exclusion fix this would 409.
+        const string title = "previously-rejected";
+        const string body = "exact body that would otherwise dedup";
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+            var rejected = TestHelpers.SeedEntry(
+                domain: "shared", tenant: "test", title: title, body: body,
+                reviewState: ReviewState.Rejected);
+            rejected.RejectionReason = "prior rejection";
+            db.ExpertiseEntries.Add(rejected);
+            await db.SaveChangesAsync();
+        }
+
+        using var writer = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);
+        var response = await writer.PostAsJsonAsync("/expertise", new
+        {
+            domain = "shared",
+            title,
+            body,
+            entryType = "Pattern",
+            severity = "Info",
+            source = "test"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [Fact]
+    public async Task Create_DuplicateTitleOfDraftEntry_Conflicts()
+    {
+        // Dedup-against-Draft is preserved: a same-tenant user submitting the same content
+        // as their own existing draft should still get a 409. Only Rejected entries are
+        // excluded from dedup. Identical title + body triggers FindExactMatchAsync in
+        // DeduplicationService.
+        const string title = "in-progress-draft";
+        const string body = "exact body content for dedup match";
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+            var draft = TestHelpers.SeedEntry(
+                domain: "shared", tenant: "test", title: title, body: body,
+                reviewState: ReviewState.Draft);
+            db.ExpertiseEntries.Add(draft);
+            await db.SaveChangesAsync();
+        }
+
+        using var writer = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);
+        var response = await writer.PostAsJsonAsync("/expertise", new
+        {
+            domain = "shared",
+            title,
+            body,
+            entryType = "Pattern",
+            severity = "Info",
+            source = "test"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
 }
 
 [Collection("Postgres")]

--- a/tests/ExpertiseApi.Tests/Integration/ApprovalWorkflowTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/ApprovalWorkflowTests.cs
@@ -504,29 +504,29 @@ public class ApprovalWorkflowTests : IAsyncLifetime
         // instead of bubbling as an unhandled 500. Fans out to several concurrent PATCHes
         // to make the race reliable — exactly two clients can occasionally serialize
         // (both 200) on a fast in-process test server.
-        const int concurrency = 5;
         var seeded = await SeedDraft(title: "racey-patch");
-        var clients = Enumerable.Range(0, concurrency)
-            .Select(_ => ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope))
-            .ToArray();
 
-        try
+        using var c0 = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);
+        using var c1 = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);
+        using var c2 = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);
+        using var c3 = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);
+        using var c4 = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);
+
+        var tasks = new[]
         {
-            var tasks = clients
-                .Select((c, i) => c.PatchAsJsonAsync($"/expertise/{seeded.Id}", new { body = $"writer {i}" }))
-                .ToArray();
+            c0.PatchAsJsonAsync($"/expertise/{seeded.Id}", new { body = "writer 0" }),
+            c1.PatchAsJsonAsync($"/expertise/{seeded.Id}", new { body = "writer 1" }),
+            c2.PatchAsJsonAsync($"/expertise/{seeded.Id}", new { body = "writer 2" }),
+            c3.PatchAsJsonAsync($"/expertise/{seeded.Id}", new { body = "writer 3" }),
+            c4.PatchAsJsonAsync($"/expertise/{seeded.Id}", new { body = "writer 4" })
+        };
 
-            var results = await Task.WhenAll(tasks);
-            var statuses = results.Select(r => (int)r.StatusCode).ToList();
+        var results = await Task.WhenAll(tasks);
+        var statuses = results.Select(r => (int)r.StatusCode).ToList();
 
-            statuses.Should().Contain(200, "at least one PATCH must win the race");
-            statuses.Should().Contain(409, "at least one PATCH must lose the xmin race and map to 409");
-            statuses.Should().OnlyContain(s => s == 200 || s == 409, "no other status is expected");
-        }
-        finally
-        {
-            foreach (var c in clients) c.Dispose();
-        }
+        statuses.Should().Contain(200, "at least one PATCH must win the race");
+        statuses.Should().Contain(409, "at least one PATCH must lose the xmin race and map to 409");
+        statuses.Should().OnlyContain(s => s == 200 || s == 409, "no other status is expected");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes two bugs from the multi-agent repo review (E1, E2). PATCH races now correctly produce 409 (instead of 500) and Rejected entries no longer permanently block resubmission of identical content. Both fixes ride on the existing `xmin` row-version + `ReviewState`-regression machinery — no schema changes.

## Type of Change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [ ] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change (add `!` to PR title)

## Per-finding changes

### E1 — PATCH races map to 409, not 500

`UpdateAsync` in `ExpertiseRepository.cs` now wraps `SaveChangesAsync` in `try/catch DbUpdateConcurrencyException` and returns `WriteOutcome.ConcurrentConflict` (mirroring the existing `ApproveAsync`/`RejectAsync` pattern). The endpoint maps it to `Results.Problem(..., statusCode: 409)`.

**Signature change:** `IExpertiseRepository.UpdateAsync` returns `(WriteOutcome, ExpertiseEntry?)` instead of `ExpertiseEntry?`. Internal-only consumer is the PATCH endpoint, updated in lockstep.

### E2a — Dedup queries exclude Rejected entries

Added `Where(e => e.ReviewState != ReviewState.Rejected)` to all four dedup methods:

- `FindExactMatchAsync`
- `FindExactMatchesAsync`
- `FindNearestInDomainAsync`
- `FindAllEmbeddingsInDomainAsync`

Drafts and Approved entries still dedup (preserves the "you already drafted this" UX). A Rejected entry no longer triggers the dedup gate so an author can resubmit improved content after addressing the rejection reason.

### E2b — `Rejected → Draft` PATCH regression

Extended the existing `Approved → Draft` regression rule (ADR-003) to also cover `Rejected → Draft`:

```diff
-if (entry.ReviewState == ReviewState.Approved
-    && !ctx.Scopes.Contains(AuthConstants.WriteApproveScope))
+if ((entry.ReviewState == ReviewState.Approved || entry.ReviewState == ReviewState.Rejected)
+    && !ctx.Scopes.Contains(AuthConstants.WriteApproveScope))
 {
     entry.ReviewState = ReviewState.Draft;
     entry.ReviewedBy = null;
     entry.ReviewedAt = null;
+    entry.RejectionReason = null;
 }
```

State machine after the fix:

- `Draft → Approved` via `/approve` (write.approve)
- `Draft → Rejected` via `/reject` (write.approve)
- `Approved → Draft` via PATCH (write.draft only)
- **`Rejected → Draft` via PATCH (write.draft only)** ← new
- `Approved` preserved on PATCH by write.approve caller
- `Rejected` preserved on PATCH by write.approve caller

## Tests

Added in `ApprovalWorkflowTests.cs`:

- `Patch_OnRejectedByDraftCaller_RegressesToDraft_ClearsRejectionReason`
- `Patch_OnRejectedByApproveCaller_PreservesRejected`
- `ConcurrentPatch_RaceProducesAtLeastOne409` — uses 5 concurrent clients (instead of 2) to make the `xmin` race reliable; asserts at least one 200 and at least one 409, and only those two statuses
- `Create_DuplicateTitleOfRejectedEntry_Succeeds`
- `Create_DuplicateTitleOfDraftEntry_Conflicts` (regression guard for the preserved draft-vs-draft dedup)

## Test Plan

- [x] `dotnet build ExpertiseApi.slnx` → 0 errors, 223 warnings (unchanged baseline)
- [x] `dotnet test ExpertiseApi.slnx --filter "FullyQualifiedName~ApprovalWorkflowTests"` → 24/24 pass (20 existing + 4 new in this class — `ConcurrentPatch_RaceProducesAtLeastOne409` replaces a stricter version, net +3 tests in the class plus the dedup pair)
- [x] `dotnet test ExpertiseApi.slnx` → 154/154 pass
- [x] `markdownlint-cli2` clean on all changed markdown
- [ ] Helm render tests — N/A

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files
- [x] Database migrations are reversible (if applicable) — N/A (no schema change)
- [x] API changes are backward-compatible — yes; the `UpdateAsync` interface change is internal-only (only the endpoint consumes it). HTTP behavior change is strictly improving: 500 → 409 on PATCH races, and Rejected entries newly support resubmission.
- [x] CLAUDE.md updated — yes, both the `xmin`/concurrency line and the PATCH state-regression paragraph; SKILL.md updated to match