### PR TITLE
chore(ci): add pre-flight pr-title validator script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,16 @@ Scope shorthand (`read`, `draft`, `approve`, `admin`) expands to full scope stri
 
 GHCR image: `ghcr.io/thesemicolon/agent-expertise-api` (multi-arch: amd64 + arm64).
 
+### Pre-flight PR validator
+
+`scripts/validate-pr.sh` runs the same checks `lint-pr-title.yml` enforces (plus branch name + base branch from `agent-framework/rules/github-flow.md`) so failures surface locally before a PR is opened. Run it before every `gh pr create` / `gh pr edit --title`:
+
+```bash
+scripts/validate-pr.sh --title "fix: patch concurrency mapping" --branch fix/foo --base dev
+```
+
+`--branch` defaults to the current git branch, `--base` defaults to `dev`, `--title` is required. Exit codes: `0` PASS, `1` FAIL, `2` precondition failure (missing args). The most common trip-ups are uppercase first letters in the subject (acronyms like `PATCH`, `JWT`, `OIDC` and proper nouns like `PostgreSQL`/`GitHub` must lowercase at the start).
+
 ## Testing
 
 ### Test Prerequisites

--- a/scripts/validate-pr.sh
+++ b/scripts/validate-pr.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+#
+# Pre-flight validator for PR title, branch name, and base branch.
+# Mirrors the rules enforced by .github/workflows/lint-pr-title.yml plus the
+# branch-naming and target-branch conventions from agent-framework github-flow.md.
+#
+# Usage:
+#   scripts/validate-pr.sh [--title "<title>"] [--branch "<branch>"] [--base "<base>"]
+#                          [--verbose] [--help]
+#
+# When --branch is omitted it is auto-detected from `git rev-parse --abbrev-ref HEAD`.
+# When --base is omitted it defaults to "dev" (per github-flow.md).
+# --title is required (it lives in the PR UI, not in git state).
+#
+# Exit codes:
+#   0  all checks passed (warnings are informational only)
+#   1  one or more errors found
+#   2  precondition failure (missing args, not in a git repo)
+#
+
+set -euo pipefail
+
+# --- Output helpers (per agent-framework script-output-conventions.md) ---
+# Full helper set kept for consistency across framework scripts; skip() and info()
+# are unused in this script but remain part of the canonical signature.
+error_count=0
+warn_count=0
+VERBOSE=false
+
+ok()    { echo "OK    [$1] $2"; }
+# shellcheck disable=SC2317  # part of canonical helper set
+skip()  { echo "SKIP  [$1] $2"; }
+warn()  { echo "WARN  [$1] $2"; ((warn_count++)) || true; }
+# shellcheck disable=SC2317  # part of canonical helper set
+info()  { echo "INFO  $*"; }
+err()   { echo "ERROR [$1] $2" >&2; ((error_count++)) || true; }
+detail(){ if $VERBOSE; then echo "      $*"; fi; }
+
+usage() {
+  sed -n '2,15p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+# --- Argument parsing ---
+TITLE=""
+BRANCH=""
+BASE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --title)   TITLE="${2:-}"; shift 2 ;;
+    --branch)  BRANCH="${2:-}"; shift 2 ;;
+    --base)    BASE="${2:-}"; shift 2 ;;
+    --verbose|-v) VERBOSE=true; shift ;;
+    --help|-h) usage; exit 0 ;;
+    *) err "args" "Unknown argument: $1"; usage >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$TITLE" ]]; then
+  err "args" "--title is required"
+  usage >&2
+  exit 2
+fi
+
+# --- Auto-detect branch from git when not explicit ---
+if [[ -z "$BRANCH" ]]; then
+  if git rev-parse --git-dir >/dev/null 2>&1; then
+    BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    detail "auto-detected branch: $BRANCH"
+  else
+    err "args" "--branch not given and current directory is not a git repository"
+    exit 2
+  fi
+fi
+
+# --- Default base ---
+if [[ -z "$BASE" ]]; then
+  BASE="dev"
+  detail "default base: dev"
+fi
+
+echo "PR Validation"
+echo "=================================="
+echo "title:  $TITLE"
+echo "branch: $BRANCH"
+echo "base:   $BASE"
+echo ""
+
+# --- Conventional Commits types (matches lint-pr-title.yml `types`) ---
+TYPES_REGEX='(feat|fix|docs|chore|refactor|test|ci|style|perf)'
+
+# --- Check 1: title format ---
+# Matches the workflow's enforcement: <type>(<scope>)?!?: <subject>
+# where the subject portion satisfies the workflow's subjectPattern: ^[a-z].+[^.]$.
+TITLE_REGEX="^${TYPES_REGEX}(\\([a-z0-9._-]+\\))?!?: [a-z][^.]*[^.]$"
+
+if [[ "$TITLE" =~ $TITLE_REGEX ]]; then
+  ok "title-format" "Conventional Commits with lowercase subject (no trailing period)"
+else
+  err "title-format" "Title does not conform to Conventional Commits format"
+  detail "expected: <type>(<scope>)?!?: <lowercase-subject-no-period>"
+  detail "types:    feat|fix|docs|chore|refactor|test|ci|style|perf"
+  detail "got:      '$TITLE'"
+
+  # Specific diagnostics — most common failures
+  if [[ ! "$TITLE" =~ ^${TYPES_REGEX} ]]; then
+    detail "hint:     title must start with one of the allowed types"
+  elif [[ ! "$TITLE" =~ ^${TYPES_REGEX}(\([a-z0-9._-]+\))?!?:\  ]]; then
+    detail "hint:     missing ': ' (colon + space) between type/scope and subject"
+  else
+    SUBJECT="${TITLE#*: }"
+    if [[ "$SUBJECT" =~ ^[A-Z] ]]; then
+      detail "hint:     subject starts uppercase — lowercase ALL acronyms and proper nouns at the start (e.g. 'PATCH' → 'patch', 'JWT' → 'jwt', 'PostgreSQL' → 'postgresql')"
+    fi
+    if [[ "$SUBJECT" =~ \.$ ]]; then
+      detail "hint:     subject ends with a period — remove it"
+    fi
+  fi
+fi
+
+# --- Check 2: branch format (per github-flow.md) ---
+BRANCH_REGEX="^${TYPES_REGEX}/[a-z0-9][a-z0-9-]*$"
+
+if [[ "$BRANCH" =~ $BRANCH_REGEX ]]; then
+  ok "branch-format" "<type>/kebab-case-description"
+else
+  # Don't error on dev/main/HEAD — those are normal local-state branches that
+  # the user may be validating titles against before creating a feature branch.
+  case "$BRANCH" in
+    dev|main|HEAD)
+      warn "branch-format" "On '$BRANCH' — create a feature branch before opening the PR (per github-flow.md)" ;;
+    *)
+      err "branch-format" "Branch '$BRANCH' does not match <type>/kebab-case-description"
+      detail "expected: <type>/<lowercase-kebab-case>"
+      detail "types:    feat|fix|docs|chore|refactor|test|ci|style|perf"
+      detail "got:      '$BRANCH'"
+      ;;
+  esac
+fi
+
+# --- Check 3: base branch (per github-flow.md) ---
+case "$BASE" in
+  dev)
+    ok "base-branch" "Targeting integration branch (dev)" ;;
+  main)
+    warn "base-branch" "Targeting main directly — only release promotions from dev should target main (per github-flow.md)" ;;
+  *)
+    warn "base-branch" "Targeting unusual base '$BASE' — verify this is intentional" ;;
+esac
+
+# --- Summary ---
+echo ""
+echo "=================================="
+if (( error_count > 0 )); then
+  echo "FAIL — ${error_count} error(s), ${warn_count} warning(s)"
+  exit 1
+else
+  echo "PASS — 0 errors, ${warn_count} warning(s)"
+  exit 0
+fi


### PR DESCRIPTION
## Summary

Adds `scripts/validate-pr.sh` — a local pre-flight that runs the same checks `lint-pr-title.yml` enforces, plus the branch-name and target-branch conventions from `agent-framework/rules/github-flow.md`. Designed to be run before every `gh pr create` so failures surface locally instead of at CI time.

Motivation: [PR #91](https://github.com/TheSemicolon/agent-expertise-api/pull/91) failed lint-pr-title because the title started with uppercase `PATCH`. The workflow's `subjectPattern: ^[a-z].+[^.]$` requires lowercase first letter — and that applies to every acronym (`JWT`, `OIDC`, `API`), HTTP verb (`PATCH`, `GET`, `POST`), and proper noun (`PostgreSQL`, `GitHub`) when it lands at the start of the subject. Pre-flight validation avoids whack-a-mole.

The framework-level follow-up (templating this into the default loadout, adding `rules/pr-validation.md`, wiring into `setup-repo.sh`) is tracked upstream as [TheSemicolon/agent-framework#226](https://github.com/TheSemicolon/agent-framework/issues/226).

## Type of Change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [x] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change (add `!` to PR title)

## Files

- **`scripts/validate-pr.sh`** (new, executable). Three checks: title-format (Conventional Commits + lowercase subject + no trailing period), branch-format (`<type>/kebab-case`), and base-branch (warn on `main`, ok on `dev`). Output follows `agent-framework/rules/script-output-conventions.md` (OK/SKIP/WARN/ERROR/INFO labels, summary block, exit codes 0/1/2). Includes diagnostic hints — the `PATCH` case prints a hint listing the canonical lowercase fix.
- **`CLAUDE.md`** — adds a "Pre-flight PR validator" subsection under CI/CD, with usage and the most common trip-up (uppercase first letter) called out.

## Usage

```bash
scripts/validate-pr.sh --title "<title>" [--branch "<branch>"] [--base "<base>"]
```

`--branch` defaults to the current git branch, `--base` defaults to `dev`, `--title` is required. Exit codes: `0` PASS, `1` FAIL, `2` precondition failure.

## Test Plan

- [x] Original failing PR #91 title → ERROR with hint pointing at `PATCH → patch`
- [x] Corrected lowercase title → PASS
- [x] Trailing period → ERROR with "remove the period" hint
- [x] Disallowed type (`wip:`) → ERROR with allowed types listed
- [x] Bad branch name (`random-feature`) → ERROR with expected pattern
- [x] Targeting `main` → WARN (not error — intentional, since release promotions do target main)
- [x] Auto-detect mode (no `--branch`) → reads `git rev-parse --abbrev-ref HEAD`
- [x] Missing `--title` → exit 2 (precondition failure) with usage
- [x] `shellcheck scripts/validate-pr.sh` → clean
- [x] `markdownlint-cli2 CLAUDE.md` → clean
- [x] Self-dogfooded: this PR's own title was validated by the script before `gh pr create`

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files
- [x] Database migrations are reversible (if applicable) — N/A
- [x] API changes are backward-compatible (if applicable) — N/A
- [x] CLAUDE.md updated — yes, new subsection

## Followups

Tracked in [agent-framework#226](https://github.com/TheSemicolon/agent-framework/issues/226): template this script into the framework's default loadout, add `rules/pr-validation.md`, wire into `setup-repo.sh`. Once that lands, this repo's copy can be replaced by the canonical version.