### PR TITLE
ci: harden workflows with concurrency, scoped permissions, and dependabot improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,3 +54,7 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    groups:
+      docker-images:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ on:
 permissions:
   contents: read
 
+# Cancel queued PR runs when a new push lands on the same PR ref. Don't cancel
+# push-to-dev runs in flight — they may be the input to a release cut.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-and-test:
     name: Build & Test
@@ -49,4 +55,18 @@ jobs:
         run: bash scripts/download-models.sh
 
       - name: Test
-        run: dotnet test ExpertiseApi.slnx --configuration Release --no-build --verbosity normal
+        run: |
+          dotnet test ExpertiseApi.slnx \
+            --configuration Release \
+            --no-build \
+            --verbosity normal \
+            --logger "trx;LogFileName=test-results.trx" \
+            --results-directory test-results
+
+      - name: Upload test results on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results
+          path: test-results/*.trx
+          retention-days: 14

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze C#

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,15 +2,16 @@ name: Dependabot auto-merge
 
 on: pull_request_target
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   auto-merge:
-    if: github.actor == 'dependabot[bot]'
+    # Read PR author from the immutable webhook payload, not the runtime actor
+    # (github.actor can shift on re-runs and PR comments).
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Fetch Dependabot metadata
@@ -18,7 +19,9 @@ jobs:
         uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.4.0
 
       - name: Enable auto-merge for patch and minor
-        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -10,7 +10,8 @@ permissions:
 
 jobs:
   lint:
-    if: github.actor != 'dependabot[bot]'
+    # Read PR author from the immutable webhook payload, not the runtime actor.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,16 +4,23 @@ on:
   push:
     branches: [main]
 
+# Default to least-priv at the workflow level; jobs scope up only what they need.
 permissions:
-  contents: write
-  packages: write
-  issues: write
-  pull-requests: write
+  contents: read
+
+# Never cancel a release in flight; only one release runs at a time per ref.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   release:
     name: Semantic Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write       # tag + commit changelog
+      issues: write         # release-notes / issue comments
+      pull-requests: write  # release-notes / PR comments
     outputs:
       new-release-published: ${{ steps.semantic.outputs.new_release_published }}
       new-release-version: ${{ steps.semantic.outputs.new_release_version }}
@@ -35,6 +42,9 @@ jobs:
     if: needs.release.outputs.new-release-published == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read    # checkout
+      packages: write   # push to GHCR
 
     steps:
       - name: Checkout

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   trivy:
     name: Trivy filesystem scan


### PR DESCRIPTION
## Summary

Workflow hardening from the multi-agent repo review (E11, E12, W9, W10, W11, W12, W13). Concurrency on every workflow, per-job permissions on `dependabot-auto-merge.yml` and `release.yml`, payload-embedded actor checks, the long `if:` line in `dependabot-auto-merge.yml` split, a `docker-images` Dependabot group, and TRX test artifacts on failure.

## Type of Change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [x] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change (add `!` to PR title)

## Per-finding mapping

| Finding | File | What changed |
| --- | --- | --- |
| **W9 concurrency** | `ci.yml`, `codeql.yml`, `security.yml` | Concurrency group keyed on `github.ref`; `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` so PR runs cancel on new push but push-to-dev runs are protected. |
| **W9 + release safety** | `release.yml` | Concurrency group keyed on `github.ref` with `cancel-in-progress: false` — never cancel a release in flight; only one release runs at a time. |
| **W11 per-job perms** | `release.yml` | Workflow-level `contents:write/packages:write/issues:write/pull-requests:write` reduced to `contents:read`. Release job scopes up `contents/issues/pull-requests:write` (semantic-release tag + notes). Build-and-push job scopes up `contents:read + packages:write` only (GHCR push). |
| **W10 + E11 dep-auto-merge perms** | `dependabot-auto-merge.yml` | Workflow-level permissions moved to job level so they only apply when the `dependabot[bot]` actor guard matches. |
| **E12 actor identity** | `lint-pr-title.yml`, `dependabot-auto-merge.yml` | `github.actor` → `github.event.pull_request.user.login` (payload-embedded, more spoofing-resistant). |
| **E11 long-line yamllint** | `dependabot-auto-merge.yml` | 142-char `if:` condition split across two lines. |
| **W13 test results** | `ci.yml` | `dotnet test` writes TRX to `test-results/`; failures upload `test-results/*.trx` as a 14-day artifact. Inline PR annotations deferred. |
| **W12 docker dep group** | `dependabot.yml` | `docker-images` group added to docker ecosystem so multiple base-image bumps land in one PR. |

## On `pull_request_target`

Earlier review framed `pull_request_target` on `dependabot-auto-merge.yml` as overly broad. After verification: this is the intentional and recommended pattern for Dependabot auto-merge — Dependabot PRs are granted a write-capable `GITHUB_TOKEN` only on `pull_request_target` (post-2021 GitHub default). The mitigations applied here:

- The workflow does not check out PR code, so the elevated privilege does not reach attacker-controlled paths.
- Permissions are now scoped to the job, not the workflow.
- The actor guard is the spoofing-resistant `github.event.pull_request.user.login`.

## Test Plan

- [x] `yamllint .github/` → 0 errors, 0 warnings on workflow files (the previous 142-char hard error is gone)
- [x] PR title pre-validated against `subjectPattern` rules manually (the validator script is on the open `chore/pr-title-validator` PR — once merged, future PRs will run it via `scripts/validate-pr.sh`)
- [x] Diff reviewed end-to-end; `actions/upload-artifact@043fb46... # v7.0.1` SHA verified via `gh api repos/actions/upload-artifact/tags`
- [ ] Workflow correctness verifiable post-merge via the next CI run

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files
- [x] Database migrations are reversible — N/A
- [x] API changes are backward-compatible — N/A
- [x] CLAUDE.md updated — N/A (workflow file table at line 244 still describes the same workflows)

## Out of scope (deferred)

- **Action SHA pin audit** — `actions/checkout@de0fac... # v6.0.2` is correct (v6 released Jan 2026).
- **Trivy `ignore-unfixed: true` → `false`** and **Hadolint `no-fail: true` → `false`** — policy decisions, separate work.
- **Inline test-result annotations** via `EnricoMi/publish-unit-test-result-action` — adds an action + `checks: write` permission; happy to do as a follow-up if you want it.