### PR TITLE
chore(docker): add nuget cache mounts and explicit APP_UID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,22 +7,26 @@ WORKDIR /src
 # Copy project file first for layer caching of the restore step
 COPY src/ExpertiseApi/ExpertiseApi.csproj src/ExpertiseApi/
 
-RUN dotnet restore src/ExpertiseApi/ExpertiseApi.csproj
+RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
+    dotnet restore src/ExpertiseApi/ExpertiseApi.csproj
 
 # Copy the rest of the source and publish
 COPY src/ src/
 
-RUN dotnet publish src/ExpertiseApi/ExpertiseApi.csproj \
+RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
+    dotnet publish src/ExpertiseApi/ExpertiseApi.csproj \
     --configuration Release \
     --no-restore \
     --output /app/publish
 
 # ── Migration bundle stage ─────────────────────────────────────────────────────
 FROM build AS bundle
-RUN dotnet tool install --global dotnet-ef --version 10.0.*
+RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
+    dotnet tool install --global dotnet-ef --version 10.0.*
 ENV PATH="$PATH:/root/.dotnet/tools"
 
-RUN dotnet ef migrations bundle \
+RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
+    dotnet ef migrations bundle \
     --project src/ExpertiseApi/ExpertiseApi.csproj \
     --configuration Release \
     --no-build \
@@ -33,6 +37,10 @@ RUN dotnet ef migrations bundle \
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app
 
+# Match the upstream image's app user. ARG default is the fallback if a
+# future base-image revision ever drops the inherited APP_UID env var.
+ARG APP_UID=1654
+
 COPY --from=build /app/publish .
 COPY --from=bundle /app/efbundle ./efbundle
 
@@ -42,6 +50,10 @@ RUN test -f models/model.onnx || (echo 'ERROR: Model files missing — run scrip
 
 RUN chown -R $APP_UID:$APP_UID /app/models/
 
+# curl is installed for the HEALTHCHECK below. The slim aspnet:10.0 image ships
+# with neither curl nor wget, so any HTTP-probe-based healthcheck must install
+# something. The HEALTHCHECK directive is consumed by Docker / Compose only —
+# Kubernetes uses its own livenessProbe / readinessProbe (see Helm chart).
 RUN apt-get update && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

Dockerfile hardening from the multi-agent repo review (E9, E10). Adds BuildKit NuGet cache mounts to all four `RUN dotnet …` invocations and declares `ARG APP_UID=1654` in the runtime stage so the `chown` / `USER` directives don't silently rely on an inherited base-image env var.

## Type of Change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [x] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [ ] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change (add `!` to PR title)

## Per-finding mapping

### E9 — NuGet cache mounts

Four `RUN` invocations now use `--mount=type=cache,id=nuget,target=/root/.nuget/packages`:

| Line (new) | Stage | Command |
| --- | --- | --- |
| 10 | build | `dotnet restore` |
| 16 | build | `dotnet publish` (still resolves via local cache despite `--no-restore`) |
| 24 | bundle | `dotnet tool install --global dotnet-ef` (tool binary persists in layer; NuGet fetch is cached) |
| 28 | bundle | `dotnet ef migrations bundle` |

The shared `id=nuget` means all stages reuse one cache. `# syntax=docker/dockerfile:1` (line 1) already enables BuildKit, so no infrastructure change.

### E10 — Explicit `ARG APP_UID`

The runtime stage uses `$APP_UID` for `chown` and `USER`. Verified locally that `mcr.microsoft.com/dotnet/aspnet:10.0` sets `APP_UID=1654` as an ENV (resolves to user `app`), but the docker-expert review flagged that *relying* on an inherited base-image variable is fragile. Declaring `ARG APP_UID=1654` in the runtime stage:

- documents the dependency,
- provides a fallback if upstream ever drops the env,
- changes nothing about the resolved value today.

## Out of scope (investigated and deferred)

### W14 — `apt-get install curl` for HEALTHCHECK

Verified via `docker run --rm mcr.microsoft.com/dotnet/aspnet:10.0 sh -c 'command -v curl; command -v wget'` — neither is present in the slim image. Swapping curl→wget doesn't reduce attack surface; we still need to install something. Cleaner alternatives (a static HTTP probe binary, in-process dotnet check, removing HEALTHCHECK entirely) are bigger refactors. **Kept curl + added a comment** explaining that the HEALTHCHECK is consumed by Docker/Compose only, while Kubernetes uses its own livenessProbe (Helm).

### W23 — `**/models` in .dockerignore

The original recommendation conflicts with the existing `COPY src/ExpertiseApi/models/ ./models/` directive at line 39. Excluding `**/models` from the build context would break that COPY (it can't find files that aren't in the context). The current setup — models present locally via `scripts/download-models.sh`, copied in, validated by the build-time guard at line 41 — is internally consistent. A self-contained build (download stage inside Docker) is a separate refactor; happy to do it as a follow-up if you want it.

## Test Plan

- [x] `docker buildx build --check .` → "Check complete, no warnings found."
- [x] `hadolint Dockerfile` → only DL3008 (unpinned apt-get version) which was already present (pre-existing finding, unchanged scope)
- [x] PR title pre-validated by `scripts/validate-pr.sh` → PASS
- [ ] Full `docker build .` — not run locally (requires `scripts/download-models.sh` first); CI will exercise it via the release workflow on main

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files (`hadolint` shows only the pre-existing DL3008)
- [x] Database migrations are reversible — N/A
- [x] API changes are backward-compatible — N/A (image build only; runtime behavior unchanged)
- [x] CLAUDE.md updated — N/A (no surface change visible to operators)