### PR TITLE
fix(auth): fail startup when Auth:Mode=Oidc and zero issuers configured

### DIFF
--- a/.claude/skills/expertise-api-design/SKILL.md
+++ b/.claude/skills/expertise-api-design/SKILL.md
@@ -124,7 +124,7 @@ CLI:
 
 ## Authentication
 
-`Auth:Mode` config switch drives scheme registration. `Oidc` is the only mode permitted outside Development; `LocalDev`, `ApiKey`, and `Hybrid` hard-fail on startup in any non-Development environment. `Hybrid` is the default in Development.
+`Auth:Mode` config switch drives scheme registration. `Oidc` is the only mode permitted outside Development; `LocalDev`, `ApiKey`, and `Hybrid` hard-fail on startup in any non-Development environment. `Hybrid` is the default in Development. `Auth:Mode=Oidc` with zero valid `Auth:Oidc:Issuers` entries also hard-fails on startup (any environment) — without this guard the API boots cleanly but 500s every protected request.
 
 ### Modes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ All endpoints except `/health`, `/query`, and `/metrics` require `Authorization:
 | `ApiKey` | Static `Auth:ApiKey` value (legacy) | Development only |
 | `Hybrid` | All of the above | Development only — default |
 
-The startup guard hard-fails if a non-`Oidc` mode is configured outside Development.
+The startup guard hard-fails if (a) a non-`Oidc` mode is configured outside Development, or (b) `Auth:Mode=Oidc` is configured with zero valid `Auth:Oidc:Issuers` entries (any environment). Without (b) a misconfigured deployment boots cleanly, passes `/health` and `/metrics`, and returns 500 on the first protected request.
 
 ### Scopes
 

--- a/src/ExpertiseApi/Auth/AuthExtensions.cs
+++ b/src/ExpertiseApi/Auth/AuthExtensions.cs
@@ -19,6 +19,7 @@ public static class AuthExtensions
         EnforceModeGuard(mode, environment);
 
         var issuers = LoadIssuers(configuration);
+        EnforceOidcIssuersGuard(mode, issuers);
 
         services.AddHttpContextAccessor();
         services.AddSingleton<IAuthorizationHandler, ScopeAuthorizationHandler>();
@@ -86,6 +87,27 @@ public static class AuthExtensions
             $"Auth:Mode '{mode}' is only permitted when ASPNETCORE_ENVIRONMENT='Development'. " +
             $"Current environment: '{environment.EnvironmentName}'. " +
             "Set Auth:Mode to 'Oidc' for non-Development deployments.");
+    }
+
+    /// <summary>
+    /// Fails startup loudly when <c>Auth:Mode=Oidc</c> is configured but no valid
+    /// <c>Auth:Oidc:Issuers</c> entries are loaded. Without this guard the API boots
+    /// successfully and 500s on the first authenticated request — a deployment-day
+    /// footgun where <c>/health</c> and <c>/metrics</c> look green while every
+    /// protected endpoint is broken. Fires in any environment because explicit
+    /// <c>Auth:Mode=Oidc</c> with zero issuers is misconfiguration regardless of where.
+    /// </summary>
+    internal static void EnforceOidcIssuersGuard(AuthMode mode, IReadOnlyList<OidcIssuerOptions> issuers)
+    {
+        if (mode != AuthMode.Oidc) return;
+        if (issuers.Count > 0) return;
+
+        throw new InvalidOperationException(
+            "Auth:Mode='Oidc' requires at least one valid Auth:Oidc:Issuers entry. " +
+            "Found zero — either the configured list is empty, or every entry's Issuer is " +
+            "blank or starts with '<TODO' (placeholder values are filtered at load time). " +
+            "Either populate Auth:Oidc:Issuers with real issuer URLs, or change Auth:Mode " +
+            "(LocalDev/ApiKey/Hybrid permitted only in Development).");
     }
 
     internal static IReadOnlyList<OidcIssuerOptions> LoadIssuers(IConfiguration configuration)
@@ -183,7 +205,8 @@ public static class AuthExtensions
         AuthMode.Oidc => issuers.Count > 0
             ? issuers[0].Name
             : throw new InvalidOperationException(
-                "Auth:Mode=Oidc requires at least one configured Auth:Oidc:Issuers entry."),
+                "Auth:Mode=Oidc with zero issuers reached request-time fallback — " +
+                "this should be unreachable because EnforceOidcIssuersGuard fails at startup."),
         AuthMode.Hybrid => issuers.Count > 0 ? issuers[0].Name : ApiKeyAuthHandler.SchemeName,
         _ => throw new InvalidOperationException($"Unknown Auth:Mode '{mode}'.")
     };

--- a/tests/ExpertiseApi.Tests/Unit/AuthModeStartupGuardTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/AuthModeStartupGuardTests.cs
@@ -94,6 +94,59 @@ public class AuthModeStartupGuardTests
            .WithMessage("*not a recognized mode*");
     }
 
+    [Theory]
+    [InlineData("Production")]
+    [InlineData("Staging")]
+    [InlineData("Development")]
+    public void EnforceOidcIssuersGuard_OidcWithZeroIssuers_ThrowsInAnyEnvironment(string env)
+    {
+        // Argument env is documentation-only — the guard does not consult IHostEnvironment.
+        // We assert the failure mode is environment-agnostic so the misconfiguration
+        // surfaces loudly even in Development where a developer might assume the
+        // missing issuers will be ignored.
+        _ = env;
+
+        var act = () => AuthExtensions.EnforceOidcIssuersGuard(
+            AuthMode.Oidc,
+            Array.Empty<OidcIssuerOptions>());
+
+        act.Should().Throw<InvalidOperationException>()
+           .WithMessage("*requires at least one valid Auth:Oidc:Issuers entry*");
+    }
+
+    [Fact]
+    public void EnforceOidcIssuersGuard_OidcWithIssuers_DoesNotThrow()
+    {
+        var issuers = new[]
+        {
+            new OidcIssuerOptions
+            {
+                Name = "Test",
+                Issuer = "https://example.com",
+                Audience = "test-aud"
+            }
+        };
+
+        var act = () => AuthExtensions.EnforceOidcIssuersGuard(AuthMode.Oidc, issuers);
+
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [InlineData(AuthMode.LocalDev)]
+    [InlineData(AuthMode.ApiKey)]
+    [InlineData(AuthMode.Hybrid)]
+    public void EnforceOidcIssuersGuard_NonOidcMode_DoesNotThrow_EvenWithZeroIssuers(AuthMode mode)
+    {
+        // Hybrid in particular: zero issuers is a legitimate Development configuration
+        // where ApiKeyAuthHandler is the fallback scheme.
+        var act = () => AuthExtensions.EnforceOidcIssuersGuard(
+            mode,
+            Array.Empty<OidcIssuerOptions>());
+
+        act.Should().NotThrow();
+    }
+
     private class HostingEnvironment : IHostEnvironment
     {
         public string EnvironmentName { get; set; } = Environments.Development;


### PR DESCRIPTION
## Summary

Closes #55. Adds a startup guard that fails loudly when `Auth:Mode=Oidc` is configured with zero valid `Auth:Oidc:Issuers` entries — the deployment-day footgun #55 documented.

This directly amplifies the safety of PR #103: that chart sets `auth.mode: Oidc` and `auth.oidc.issuers: []` as defaults, so a fresh `helm install` with no issuer overrides previously produced a pod that passed `/health` and `/metrics` and 500'd every protected request. Now it crashes at startup with a clear diagnostic visible in `kubectl describe pod` / `kubectl logs`.

The two PRs compound: chart can ship the production-ready defaults (#103) and this guard catches the misconfiguration regardless of the install path.

## Type of Change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [ ] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change (add `!` to PR title)

## Per-file changes

- **`src/ExpertiseApi/Auth/AuthExtensions.cs`** — new `EnforceOidcIssuersGuard(AuthMode, IReadOnlyList<OidcIssuerOptions>)`. Wired into `AddExpertiseAuth` right after `LoadIssuers`. Existing `EnforceModeGuard` and `LoadIssuers` are untouched. The unreachable throw in `FallbackSchemeForMode` is kept as defense-in-depth with a reframed message.
- **`tests/ExpertiseApi.Tests/Unit/AuthModeStartupGuardTests.cs`** — 5 new test cases covering Oidc-zero-issuers (in any env), Oidc-with-issuers, and non-Oidc-with-zero-issuers (LocalDev / ApiKey / Hybrid).
- **`CLAUDE.md`** — startup-guard sentence updated to describe both clauses.
- **`.claude/skills/expertise-api-design/SKILL.md`** — same.

## Decision: fires in any environment

A developer running plain `dotnet run` defaults to `AuthMode.Hybrid` (no impact). A developer who explicitly sets `Auth:Mode=Oidc` is signaling intent to test OIDC integration; failing loud is the safe default for that path too.

## Test Plan

- [x] `dotnet build ExpertiseApi.slnx` → 0 errors, 223 warnings (unchanged baseline)
- [x] `dotnet test ExpertiseApi.slnx --filter "FullyQualifiedName~AuthModeStartupGuardTests"` → 26/26 pass (21 existing + 5 new)
- [x] `dotnet test ExpertiseApi.slnx` → 161/161 pass (no integration-test regressions; `JwtApiFactory` configures a valid test issuer; `ApiFactory` uses default `Hybrid` in Development)
- [x] `markdownlint-cli2 CLAUDE.md SKILL.md` → 0 errors
- [x] `scripts/validate-pr.sh` on PR title → PASS

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files
- [x] Database migrations are reversible — N/A
- [x] API changes are backward-compatible — yes; the only behavior change is failing earlier (startup vs first-request) on a configuration that was already broken
- [x] CLAUDE.md updated — yes (and SKILL.md)