### PR TITLE
chore(docker): resolve Hadolint DL3008 via .hadolint.yaml

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,13 @@
+# Hadolint configuration — see https://github.com/hadolint/hadolint
+#
+# DL3008 — "Pin versions in apt get install" — is intentionally ignored.
+# The runtime stage installs `curl` for the HEALTHCHECK probe. The slim
+# `mcr.microsoft.com/dotnet/aspnet:10.0` base image ships with neither curl nor
+# wget, so the install is necessary. Pinning curl to a Debian package version
+# would force a Dockerfile bump on every CVE patch (e.g. curl=8.x.y-z), which
+# is not a pattern we maintain for security-tooling packages installed only to
+# support a healthcheck. The healthcheck itself is consumed by Docker and
+# Compose only — Kubernetes uses livenessProbe/readinessProbe defined in the
+# Helm chart.
+ignored:
+  - DL3008


### PR DESCRIPTION
## Summary

Adds `.hadolint.yaml` at the repo root with `ignored: [DL3008]` and an inline comment explaining the rationale. The Hadolint workflow (`.github/workflows/security.yml`) picks the file up automatically — no workflow change needed.

DL3008 ("pin versions in apt get install") was firing on the runtime stage's `curl` install, which the Dockerfile installs solely to support the HEALTHCHECK probe. The slim `mcr.microsoft.com/dotnet/aspnet:10.0` base image ships with neither curl nor wget, so the install is necessary. Pinning `curl=8.x.y-z` would force a Dockerfile bump on every CVE patch — a maintenance pattern we don't follow for security tooling installed only to back a healthcheck.

Of the three options enumerated in #102, this is option B (recommended).

## Type of Change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [x] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [ ] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change (add `!` to PR title)

## Test Plan

- [x] yamllint clean on `.hadolint.yaml` (verified locally)
- [x] No code change — no `dotnet test` impact
- [ ] Post-merge: confirm Hadolint workflow run on `dev` reports zero open alerts

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files
- [ ] Database migrations are reversible (if applicable) — N/A
- [ ] API changes are backward-compatible (if applicable) — N/A
- [ ] CLAUDE.md updated (if commands, endpoints, or workflow changed) — N/A

Closes #102