### PR TITLE
chore(codeql): exclude generated code via paths-ignore

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,13 @@
+name: CodeQL config
+
+# Excludes generated source-generator output and build artifacts from CodeQL
+# analysis. Source-generator output (notably from
+# Microsoft.AspNetCore.OpenApi.SourceGenerators under obj/Release/.../generated/)
+# is third-party code we don't author and can't reasonably fix; including it
+# produces ~6 false-positive alerts (cs/constant-condition, cs/linq/missed-select,
+# cs/nested-if-statements, cs/useless-assignment-to-local) that drown the real
+# findings.
+paths-ignore:
+  - '**/obj/**'
+  - '**/bin/**'
+  - '**/*.generated.cs'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,6 +48,7 @@ jobs:
           languages: csharp
           build-mode: manual
           queries: security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Restore dependencies
         run: dotnet restore ExpertiseApi.slnx --disable-build-servers

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,13 @@
+# Hadolint configuration — see https://github.com/hadolint/hadolint
+#
+# DL3008 — "Pin versions in apt get install" — is intentionally ignored.
+# The runtime stage installs `curl` for the HEALTHCHECK probe. The slim
+# `mcr.microsoft.com/dotnet/aspnet:10.0` base image ships with neither curl nor
+# wget, so the install is necessary. Pinning curl to a Debian package version
+# would force a Dockerfile bump on every CVE patch (e.g. curl=8.x.y-z), which
+# is not a pattern we maintain for security-tooling packages installed only to
+# support a healthcheck. The healthcheck itself is consumed by Docker and
+# Compose only — Kubernetes uses livenessProbe/readinessProbe defined in the
+# Helm chart.
+ignored:
+  - DL3008


### PR DESCRIPTION
## Summary

Adds `.github/codeql/codeql-config.yml` excluding `**/obj/**`, `**/bin/**`, and `**/*.generated.cs` from CodeQL analysis, and wires it via the `config-file` input on `github/codeql-action/init` in `codeql.yml`.

Source-generator output (notably from `Microsoft.AspNetCore.OpenApi.SourceGenerators` under `obj/Release/.../generated/`) is third-party code we don't author. Including it produces ~6 false-positive alerts (`cs/constant-condition`, `cs/linq/missed-select`, `cs/nested-if-statements`, `cs/useless-assignment-to-local`) that drown the real findings tracked in #100.

> **Note:** chained PR — base is `chore/hadolint-dl3008` (PR #108). GitHub will auto-retarget to `dev` once #108 merges.

## Type of Change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [x] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [ ] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change (add `!` to PR title)

## Test Plan

- [x] yamllint clean on both files
- [x] actionlint clean on `codeql.yml`
- [x] No code change — no `dotnet test` impact
- [ ] Post-merge: confirm next CodeQL run shows alerts on generated paths transition to `fixed`

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files
- [ ] Database migrations are reversible (if applicable) — N/A
- [ ] API changes are backward-compatible (if applicable) — N/A
- [ ] CLAUDE.md updated (if commands, endpoints, or workflow changed) — N/A

Closes #99