### PR TITLE
fix(codeql): triage real-code findings from issue #100

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,13 @@
+name: CodeQL config
+
+# Excludes generated source-generator output and build artifacts from CodeQL
+# analysis. Source-generator output (notably from
+# Microsoft.AspNetCore.OpenApi.SourceGenerators under obj/Release/.../generated/)
+# is third-party code we don't author and can't reasonably fix; including it
+# produces ~6 false-positive alerts (cs/constant-condition, cs/linq/missed-select,
+# cs/nested-if-statements, cs/useless-assignment-to-local) that drown the real
+# findings.
+paths-ignore:
+  - '**/obj/**'
+  - '**/bin/**'
+  - '**/*.generated.cs'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,6 +48,7 @@ jobs:
           languages: csharp
           build-mode: manual
           queries: security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Restore dependencies
         run: dotnet restore ExpertiseApi.slnx --disable-build-servers

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,13 @@
+# Hadolint configuration — see https://github.com/hadolint/hadolint
+#
+# DL3008 — "Pin versions in apt get install" — is intentionally ignored.
+# The runtime stage installs `curl` for the HEALTHCHECK probe. The slim
+# `mcr.microsoft.com/dotnet/aspnet:10.0` base image ships with neither curl nor
+# wget, so the install is necessary. Pinning curl to a Debian package version
+# would force a Dockerfile bump on every CVE patch (e.g. curl=8.x.y-z), which
+# is not a pattern we maintain for security-tooling packages installed only to
+# support a healthcheck. The healthcheck itself is consumed by Docker and
+# Compose only — Kubernetes uses livenessProbe/readinessProbe defined in the
+# Helm chart.
+ignored:
+  - DL3008

--- a/src/ExpertiseApi/Auth/AuthExtensions.cs
+++ b/src/ExpertiseApi/Auth/AuthExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
@@ -149,6 +150,11 @@ public static class AuthExtensions
         });
     }
 
+    [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
+        Justification = "Token-shape detection is best-effort. Any parse failure (malformed token, " +
+                        "unrecognized format, unexpected exception in JsonWebTokenHandler) must fall through " +
+                        "to the first issuer's scheme so JwtBearer surfaces a clean 401. Throwing here would " +
+                        "be a worse user experience than the JwtBearer 401.")]
     private static string SelectScheme(HttpContext ctx, AuthMode mode, IReadOnlyList<OidcIssuerOptions> issuers)
     {
         var header = ctx.Request.Headers.Authorization.FirstOrDefault();
@@ -180,7 +186,7 @@ public static class AuthExtensions
                         return match.Name;
                 }
             }
-            catch
+            catch (Exception)
             {
                 // Fall through to first scheme; JwtBearer will reject cleanly.
             }

--- a/src/ExpertiseApi/Auth/JwtTenantContextEvents.cs
+++ b/src/ExpertiseApi/Auth/JwtTenantContextEvents.cs
@@ -53,13 +53,14 @@ public static class JwtTenantContextEvents
     {
         foreach (var claim in issuer.ScopeClaims)
         {
-            foreach (var value in principal.FindAll(claim).Select(c => c.Value))
-            {
-                if (string.IsNullOrWhiteSpace(value))
-                    continue;
+            // Entra `scp` is space-separated; Authentik `scope` is space-separated.
+            // Entra `roles` is repeated claim per value (one per array entry).
+            var values = principal.FindAll(claim)
+                .Select(c => c.Value)
+                .Where(v => !string.IsNullOrWhiteSpace(v));
 
-                // Entra `scp` is space-separated; Authentik `scope` is space-separated.
-                // Entra `roles` is repeated claim per value (one per array entry).
+            foreach (var value in values)
+            {
                 foreach (var scope in value.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
                     yield return scope;
             }
@@ -104,13 +105,9 @@ public static class JwtTenantContextEvents
 
     private static string? MapTenantFromGroups(ClaimsPrincipal principal, OidcIssuerOptions issuer)
     {
-        foreach (var group in principal.FindAll(issuer.GroupClaim).Select(c => c.Value))
-        {
-            if (issuer.GroupToTenantMapping.TryGetValue(group, out var tenant))
-                return tenant;
-        }
-
-        return null;
+        return principal.FindAll(issuer.GroupClaim)
+            .Select(c => issuer.GroupToTenantMapping.TryGetValue(c.Value, out var tenant) ? tenant : null)
+            .FirstOrDefault(t => t is not null);
     }
 
     /// <summary>

--- a/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using ExpertiseApi.Auth;
 using ExpertiseApi.Data;
 using ExpertiseApi.Models;
@@ -170,6 +171,11 @@ public static class ExpertiseEndpoints
         };
     }
 
+    [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
+        Justification = "Batch ingest uses per-phase and per-item failure isolation. An unexpected " +
+                        "exception in embedding generation, deduplication, or per-entry create must mark " +
+                        "the affected items as Failed and continue processing the rest. The error is " +
+                        "captured in the BatchEntryResult and surfaced to the caller via the 207 response.")]
     private static async Task<IResult> CreateBatch(
         List<CreateExpertiseRequest> requests,
         HttpContext httpContext,

--- a/tests/ExpertiseApi.Tests/Infrastructure/ApiFactory.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/ApiFactory.cs
@@ -59,7 +59,6 @@ public class ApiFactory : WebApplicationFactory<Program>
                 .Returns(callInfo =>
                 {
                     var inputs = callInfo.ArgAt<IEnumerable<string>>(0).ToList();
-                    var embeddings = new List<GeneratedEmbeddings<Embedding<float>>>();
                     var result = new GeneratedEmbeddings<Embedding<float>>();
                     foreach (var _ in inputs)
                     {

--- a/tests/ExpertiseApi.Tests/Integration/TenantIsolationTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/TenantIsolationTests.cs
@@ -62,9 +62,9 @@ public class TenantIsolationTests : IAsyncLifetime
     [Fact]
     public async Task List_OnlyReturnsCallerTenantAndShared()
     {
-        var ownEntry = await SeedEntry(tenant: "test", title: "own-entry");
-        var sharedEntry = await SeedEntry(tenant: "shared", title: "shared-entry");
-        var otherEntry = await SeedEntry(tenant: "other-team", title: "other-entry");
+        _ = await SeedEntry(tenant: "test", title: "own-entry");
+        _ = await SeedEntry(tenant: "shared", title: "shared-entry");
+        _ = await SeedEntry(tenant: "other-team", title: "other-entry");
 
         var response = await _testClient.GetAsync("/expertise");
 

--- a/tests/ExpertiseApi.Tests/Unit/DeduplicationServiceTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/DeduplicationServiceTests.cs
@@ -72,7 +72,7 @@ public class DeduplicationServiceTests
         _repo.FindExactMatchAsync("shared", "Test", Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns(existingEntry);
         _repo.FindNearestInDomainAsync("shared", _testVector, 0.10, Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
-            .Returns((ExpertiseEntry?)null);
+            .Returns(default(ExpertiseEntry));
 
         var (isDuplicate, _) = await service.CheckAsync(request, _testVector, _ctx);
 
@@ -88,7 +88,7 @@ public class DeduplicationServiceTests
         var nearEntry = TestHelpers.SeedEntry(title: "Similar entry");
 
         _repo.FindExactMatchAsync("shared", "Test", Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
-            .Returns((ExpertiseEntry?)null);
+            .Returns(default(ExpertiseEntry));
         _repo.FindNearestInDomainAsync("shared", _testVector, 0.10, Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns(nearEntry);
 
@@ -105,9 +105,9 @@ public class DeduplicationServiceTests
         var request = CreateRequest();
 
         _repo.FindExactMatchAsync("shared", "Test", Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
-            .Returns((ExpertiseEntry?)null);
+            .Returns(default(ExpertiseEntry));
         _repo.FindNearestInDomainAsync("shared", _testVector, 0.10, Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
-            .Returns((ExpertiseEntry?)null);
+            .Returns(default(ExpertiseEntry));
 
         var (isDuplicate, existing) = await service.CheckAsync(request, _testVector, _ctx);
 


### PR DESCRIPTION
## Summary

Resolves the open CodeQL alerts in `src/` and `tests/`. The generated-code alerts were addressed by PR #109 (`paths-ignore` config), already merged.

> **Note:** this PR was originally chained off PR #109. Both predecessors (#108, #109) merged while this was in progress; rebase chain is unnecessary because PR #109's content is already on `dev` and the diff against `dev` shows only this PR's net change.

### Real fixes

| Alert | File:line | Fix |
|---|---|---|
| `cs/unused-collection` (error) + `cs/useless-assignment-to-local` (warning) | `tests/.../ApiFactory.cs:62` | Drop dead `var embeddings = new List<>()` |
| `cs/useless-assignment-to-local` × 3 (warning) | `tests/.../TenantIsolationTests.cs:65–67` | Convert to `_` discards (the `SeedEntry` calls are kept for DB-write side effects) |
| `cs/useless-upcast` × 4 (warning) | `tests/.../DeduplicationServiceTests.cs:75/91/108/110` | Replace `(ExpertiseEntry?)null` with `default(ExpertiseEntry)` — still disambiguates NSubstitute's `Returns<T>()` without an explicit cast |
| `cs/linq/missed-where` (note) | `src/.../JwtTenantContextEvents.cs:56` | Refactor `ExtractRawScopes` inner loop to explicit `.Where(v => !string.IsNullOrWhiteSpace(v))` |
| `cs/linq/missed-where` (note) | `src/.../JwtTenantContextEvents.cs:107` | Refactor `MapTenantFromGroups` to `Select + FirstOrDefault` (single dictionary lookup per group) |

### Intentional catch-all suppressions

`[SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "...")]` on the containing method, with full rationale:

- **`AuthExtensions.cs:183`** (`SelectScheme`) — bare `catch` becomes `catch (Exception)`; any token-shape parse failure must fall through to the first issuer's scheme so JwtBearer surfaces a clean 401.
- **`ExpertiseEndpoints.cs:246/268/302`** (`CreateBatch`) — per-phase / per-item failure isolation; errors are captured in `BatchEntryResult` and returned via the 207 response.

> Note: `[SuppressMessage]` silences the Roslyn CA1031 analyzer; CodeQL's `cs/catch-of-all-exceptions` rule does not honor `SuppressMessage`. After merge, the four `cs/catch-of-all-exceptions` notes can be dismissed in the GitHub Code Scanning UI as "won't fix" with the same justification.

## Out of scope

The linter surfaced two warnings that aren't in CodeQL's findings:

- `ApiFactory.cs` ~line 66: dead `new Random(42).NextBytes(new byte[4])` line. Pre-existing dead code; left alone to keep PR3 narrow to CodeQL findings.
- `ExpertiseEndpoints.cs` ~line 342: `tenantContext.Tenant!` null-forgiving — already tracked by #57.

## Type of Change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [ ] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change (add `!` to PR title)

## Test Plan

- [x] `dotnet build ExpertiseApi.slnx -c Release` — 0 errors, 219 warnings (was 223; -4 from CodeQL fixes incidentally dropping Roslyn analogues)
- [x] `dotnet test ExpertiseApi.slnx --filter "FullyQualifiedName~Unit"` — 86/86 pass
- [ ] Integration tests: deferred to CI (require Postgres + Testcontainers)
- [ ] Post-merge: confirm CodeQL run on `dev` shows the 6 source-code alerts transition to `fixed` (the 4 catch-of-all-exceptions notes will require manual dismissal)

## Checklist

- [x] No secrets or credentials committed
- [x] Linter-clean (whitespace/encoding clean; two flagged items are out-of-scope and tracked above)
- [ ] Database migrations are reversible (if applicable) — N/A
- [x] API changes are backward-compatible — no API change
- [ ] CLAUDE.md updated (if commands, endpoints, or workflow changed) — N/A

Closes #100