### PR TITLE
chore(quality): flip public types to internal (PR7a of issue #101)

### DIFF
--- a/adrs/006-internal-types-and-internalsvisibleto.md
+++ b/adrs/006-internal-types-and-internalsvisibleto.md
@@ -1,0 +1,52 @@
+# Internal types by default; tests via `InternalsVisibleTo`
+
+- Status: accepted
+- Date: 2026-05-04
+
+## Context and Problem Statement
+
+The .NET analyzer baseline (issue #101) carries 108 occurrences of CA1515 ("consider making types internal") in `src/ExpertiseApi/`. The baseline blocks any future tightening of the build gate — `dotnet format --verify-no-changes` cannot be enforced in CI until the warning count is in single digits.
+
+The project is a single-assembly ASP.NET Core service. The only cross-assembly consumer of types from `src/ExpertiseApi/` is the test assembly (`ExpertiseApi.Tests`). There is no SDK NuGet, no shared-contract package, and no second non-test project. The `public` access modifier on application types therefore conveys no meaningful API contract — it is the C# default, not an intentional surface.
+
+## Considered Options
+
+1. **Global suppression of CA1515 in `Directory.Build.props`** with a rationale comment ("application code, no library consumers")
+2. **Move types to `internal`** and grant the test project access via `[InternalsVisibleTo]`
+3. **Status quo** — leave types `public` and accept the ongoing analyzer noise
+
+## Decision Outcome
+
+Chosen option: **2 — move types to `internal` + `InternalsVisibleTo`**.
+
+The accessibility modifier should reflect intent. `internal` accurately describes 99% of types in this codebase (everything except `Program`, which `WebApplicationFactory<Program>` requires `public`). Suppressing the analyzer would silence the signal but leave the code carrying false claims about its own API surface; flipping the types puts the modifier where it belongs and recovers the analyzer signal for any genuinely-public API we might add later.
+
+### Carve-outs (stay `public`)
+
+Three categories are explicitly excluded from the sweep, with inline `[SuppressMessage]` annotations explaining each:
+
+1. **`Program` (`src/ExpertiseApi/Program.cs:150`).** `WebApplicationFactory<TEntryPoint>` requires `TEntryPoint` to be visible to the test assembly via the C# type system, not via `[InternalsVisibleTo]` — the constraint crosses into `Microsoft.AspNetCore.Mvc.Testing`, a third-party assembly that the IVT grant does not cover. The `public partial class Program;` stub is the canonical pattern; do not remove or flip it.
+2. **`AuthMode` (`src/ExpertiseApi/Auth/AuthMode.cs`).** Consumed as a parameter type by `[Theory]` tests in `AuthModeStartupGuardTests.cs`. xUnit 2 (current) requires test methods to be `public`, and public methods cannot take internal parameter types. Cascading the test method to `internal` is not viable in xUnit 2. If/when the test project upgrades to xUnit 3 (which supports non-public test methods), `AuthMode` can flip to `internal`.
+3. **All classes in `src/ExpertiseApi/Migrations/`.** EF migration scaffolding (`dotnet ef migrations add`) emits `public partial class` by default. Flipping the existing migrations to `internal` would create persistent drift — every future migration would re-add as `public`. Suppressed via folder-scoped `.editorconfig` rather than per-file annotations.
+
+The fourth carve-out originally proposed — `DesignTimeDbContextFactory` — was dropped after empirical validation: EF Core's `dotnet ef` tooling honors `internal` factories via reflection (`Activator.CreateInstance` with non-public binding flags), so the defensive concern was unfounded. The factory is now `internal`.
+
+### `[InternalsVisibleTo]` entries
+
+The API project already grants `InternalsVisibleTo("ExpertiseApi.Tests")`. This ADR adds:
+
+- **`InternalsVisibleTo("DynamicProxyGenAssembly2")`** — required for NSubstitute (which uses Castle DynamicProxy) to mock `internal` interfaces. Without this entry, `Substitute.For<IInternalInterface>()` throws `TypeLoadException` at first invocation — silent at build time, silent at xUnit discovery, fails only when the test runs. This is a well-known Castle convention; the assembly name is fixed.
+
+### Consequences
+
+- **Good:** the access modifier becomes truthful. CA1515 drops from 108 occurrences to 0–3 (the carve-outs). The build gets noticeably closer to the single-digit baseline that gates `dotnet format` enforcement in CI.
+- **Good:** changes to internal types no longer require the same care as public-API changes — refactoring is easier.
+- **Bad:** forecloses the path of consuming these types from another assembly without superseding this ADR. If the project grows a typed-client SDK, a shared-contract package, or splits into multiple projects, the relevant types will need to flip back to `public` (or move to a new shared assembly).
+- **Bad:** strong-naming the API assembly later would require updating the IVT entries to include the public-key tokens of the test assembly and `DynamicProxyGenAssembly2`. Recorded as a known follow-up; not in scope today.
+- **Neutral:** ASP.NET Core JSON model binding, DI registration, EF Core entity discovery, and xUnit `[InlineData]` enum constants all work identically with `internal` types — verified by full unit-test pass after the sweep.
+
+## References
+
+- Issue: [#101](https://github.com/TheSemicolon/agent-expertise-api/issues/101)
+- PR: this ADR's PR (the CA1515 sweep)
+- Related: [ADR-004](004-security-scanning-stack.md) records the original 201-warning baseline; this ADR moves CA1515 (the largest contributor) toward closure.

--- a/src/ExpertiseApi/Auth/ApiKeyAuthHandler.cs
+++ b/src/ExpertiseApi/Auth/ApiKeyAuthHandler.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 
 namespace ExpertiseApi.Auth;
 
-public class ApiKeyAuthHandler(
+internal class ApiKeyAuthHandler(
     IOptionsMonitor<AuthenticationSchemeOptions> options,
     ILoggerFactory logger,
     UrlEncoder encoder,

--- a/src/ExpertiseApi/Auth/AuthConstants.cs
+++ b/src/ExpertiseApi/Auth/AuthConstants.cs
@@ -1,6 +1,6 @@
 namespace ExpertiseApi.Auth;
 
-public static class AuthConstants
+internal static class AuthConstants
 {
     public const string ScopeClaimType = "scope";
 
@@ -16,7 +16,7 @@ public static class AuthConstants
     /// </summary>
     public const string LegacyWriteScope = "expertise.write";
 
-    public static class Policies
+    internal static class Policies
     {
         public const string ReadAccess = "ReadAccess";
         public const string WriteAccess = "WriteAccess";

--- a/src/ExpertiseApi/Auth/AuthExtensions.cs
+++ b/src/ExpertiseApi/Auth/AuthExtensions.cs
@@ -7,7 +7,7 @@ using Microsoft.IdentityModel.Tokens;
 
 namespace ExpertiseApi.Auth;
 
-public static class AuthExtensions
+internal static class AuthExtensions
 {
     public const string BearerScheme = "Bearer";
 

--- a/src/ExpertiseApi/Auth/AuthMode.cs
+++ b/src/ExpertiseApi/Auth/AuthMode.cs
@@ -1,5 +1,16 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace ExpertiseApi.Auth;
 
+// Carve-out: this enum is consumed as a parameter type by [Theory] tests in
+// AuthModeStartupGuardTests. xUnit 2 requires test methods to be public, and
+// public methods cannot take internal parameter types. If/when the test
+// project upgrades to xUnit 3 (which supports non-public test methods), this
+// can flip to `internal`. See ADR-006.
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit 2 [Theory] parameter type; see ADR-006.")]
 public enum AuthMode
 {
     /// <summary>OIDC only. Required for non-Development environments.</summary>

--- a/src/ExpertiseApi/Auth/HttpTenantContextAccessor.cs
+++ b/src/ExpertiseApi/Auth/HttpTenantContextAccessor.cs
@@ -7,7 +7,7 @@ namespace ExpertiseApi.Auth;
 /// treats that as "no filter" (CLI / design-time) and falls back to the explicit
 /// repository <c>Where</c> clauses for safety.
 /// </summary>
-public sealed class HttpTenantContextAccessor(IHttpContextAccessor httpContextAccessor)
+internal sealed class HttpTenantContextAccessor(IHttpContextAccessor httpContextAccessor)
     : ITenantContextAccessor
 {
     public string? Tenant =>
@@ -18,7 +18,7 @@ public sealed class HttpTenantContextAccessor(IHttpContextAccessor httpContextAc
 /// Always returns <c>null</c>. Used by <see cref="Data.DesignTimeDbContextFactory"/>
 /// so <c>dotnet ef</c> tooling can construct a DbContext without an HTTP scope.
 /// </summary>
-public sealed class NoOpTenantContextAccessor : ITenantContextAccessor
+internal sealed class NoOpTenantContextAccessor : ITenantContextAccessor
 {
     public string? Tenant => null;
 }

--- a/src/ExpertiseApi/Auth/ITenantContextAccessor.cs
+++ b/src/ExpertiseApi/Auth/ITenantContextAccessor.cs
@@ -12,7 +12,7 @@ namespace ExpertiseApi.Auth;
 /// <see cref="Data.IExpertiseRepository"/> remain the primary safeguard.
 /// </para>
 /// </summary>
-public interface ITenantContextAccessor
+internal interface ITenantContextAccessor
 {
     string? Tenant { get; }
 }

--- a/src/ExpertiseApi/Auth/JwtTenantContextEvents.cs
+++ b/src/ExpertiseApi/Auth/JwtTenantContextEvents.cs
@@ -8,7 +8,7 @@ namespace ExpertiseApi.Auth;
 /// JwtBearer schemes — each scheme is registered with its <see cref="OidcIssuerOptions"/>
 /// in the scheme's <see cref="JwtBearerEvents.OnTokenValidated"/>.
 /// </summary>
-public static class JwtTenantContextEvents
+internal static class JwtTenantContextEvents
 {
     public static Task BuildTenantContext(TokenValidatedContext ctx, OidcIssuerOptions issuer)
     {

--- a/src/ExpertiseApi/Auth/LocalDevAuthHandler.cs
+++ b/src/ExpertiseApi/Auth/LocalDevAuthHandler.cs
@@ -16,7 +16,7 @@ namespace ExpertiseApi.Auth;
 /// value is passed through verbatim.
 /// </para>
 /// </summary>
-public class LocalDevAuthHandler(
+internal class LocalDevAuthHandler(
     IOptionsMonitor<AuthenticationSchemeOptions> options,
     ILoggerFactory logger,
     UrlEncoder encoder)

--- a/src/ExpertiseApi/Auth/OidcIssuerOptions.cs
+++ b/src/ExpertiseApi/Auth/OidcIssuerOptions.cs
@@ -1,6 +1,6 @@
 namespace ExpertiseApi.Auth;
 
-public class OidcIssuerOptions
+internal class OidcIssuerOptions
 {
     /// <summary>
     /// Logical name for the issuer (e.g. "Entra", "Authentik"). Used as the JwtBearer scheme name.
@@ -52,7 +52,7 @@ public class OidcIssuerOptions
     public string GroupClaim { get; set; } = "groups";
 }
 
-public enum TenantSource
+internal enum TenantSource
 {
     /// <summary>Walk group claims through <see cref="OidcIssuerOptions.GroupToTenantMapping"/>.</summary>
     Groups,

--- a/src/ExpertiseApi/Auth/ScopeRequirement.cs
+++ b/src/ExpertiseApi/Auth/ScopeRequirement.cs
@@ -2,12 +2,12 @@ using Microsoft.AspNetCore.Authorization;
 
 namespace ExpertiseApi.Auth;
 
-public sealed class ScopeRequirement(string scope) : IAuthorizationRequirement
+internal sealed class ScopeRequirement(string scope) : IAuthorizationRequirement
 {
     public string Scope { get; } = scope;
 }
 
-public sealed class ScopeAuthorizationHandler : AuthorizationHandler<ScopeRequirement>
+internal sealed class ScopeAuthorizationHandler : AuthorizationHandler<ScopeRequirement>
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
 

--- a/src/ExpertiseApi/Auth/TenantContext.cs
+++ b/src/ExpertiseApi/Auth/TenantContext.cs
@@ -14,13 +14,13 @@ namespace ExpertiseApi.Auth;
 /// has all four scopes present (admin ⊇ approve ⊇ draft ⊇ read).
 /// </para>
 /// </summary>
-public sealed record TenantContext(
+internal sealed record TenantContext(
     string? Tenant,
     ClaimsPrincipal Principal,
     string? Agent,
     IReadOnlySet<string> Scopes);
 
-public static class TenantContextHttpExtensions
+internal static class TenantContextHttpExtensions
 {
     public static TenantContext? GetTenantContext(this HttpContext ctx) =>
         ctx.Features.Get<TenantContext>();

--- a/src/ExpertiseApi/Cli/ReembedCommand.cs
+++ b/src/ExpertiseApi/Cli/ReembedCommand.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace ExpertiseApi.Cli;
 
-public static class ReembedCommand
+internal static class ReembedCommand
 {
     public static bool IsReembedRequested(string[] args) =>
         args.Length > 0 && args[0].Equals("reembed", StringComparison.OrdinalIgnoreCase);

--- a/src/ExpertiseApi/Cli/RehashCommand.cs
+++ b/src/ExpertiseApi/Cli/RehashCommand.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace ExpertiseApi.Cli;
 
-public static class RehashCommand
+internal static class RehashCommand
 {
     public static bool IsRehashRequested(string[] args) =>
         args.Length > 0 && args[0].Equals("rehash", StringComparison.OrdinalIgnoreCase);

--- a/src/ExpertiseApi/Data/DesignTimeDbContextFactory.cs
+++ b/src/ExpertiseApi/Data/DesignTimeDbContextFactory.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore.Design;
 
 namespace ExpertiseApi.Data;
 
-public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<ExpertiseDbContext>
+internal class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<ExpertiseDbContext>
 {
     public ExpertiseDbContext CreateDbContext(string[] args)
     {

--- a/src/ExpertiseApi/Data/ExpertiseDbContext.cs
+++ b/src/ExpertiseApi/Data/ExpertiseDbContext.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace ExpertiseApi.Data;
 
-public class ExpertiseDbContext(
+internal class ExpertiseDbContext(
     DbContextOptions<ExpertiseDbContext> options,
     ITenantContextAccessor tenantAccessor) : DbContext(options)
 {

--- a/src/ExpertiseApi/Data/ExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/ExpertiseRepository.cs
@@ -7,7 +7,7 @@ using Pgvector.EntityFrameworkCore;
 
 namespace ExpertiseApi.Data;
 
-public class ExpertiseRepository(
+internal class ExpertiseRepository(
     ExpertiseDbContext db,
     IHttpContextAccessor httpContextAccessor,
     ILogger<ExpertiseRepository> logger) : IExpertiseRepository

--- a/src/ExpertiseApi/Data/IExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/IExpertiseRepository.cs
@@ -15,7 +15,7 @@ namespace ExpertiseApi.Data;
 /// against the entry-mutated-but-no-audit-row failure mode.
 /// </para>
 /// </summary>
-public interface IExpertiseRepository
+internal interface IExpertiseRepository
 {
     Task<ExpertiseEntry?> GetByIdAsync(Guid id, TenantContext ctx, CancellationToken ct = default);
 
@@ -96,7 +96,7 @@ public interface IExpertiseRepository
 /// <summary>
 /// Outcome of a write operation that can fail for reasons other than "not found."
 /// </summary>
-public enum WriteOutcome
+internal enum WriteOutcome
 {
     Success,
     NotFound,
@@ -112,7 +112,7 @@ public enum WriteOutcome
 /// Cursor-paginated audit log query. Cursor is <c>(AfterTimestamp, AfterId)</c> for
 /// keyset pagination ordered by <c>(Timestamp DESC, Id)</c>.
 /// </summary>
-public record AuditLogFilter(
+internal record AuditLogFilter(
     Guid? EntryId = null,
     string? Principal = null,
     AuditAction? Action = null,

--- a/src/ExpertiseApi/Endpoints/AuditEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/AuditEndpoints.cs
@@ -9,7 +9,7 @@ namespace ExpertiseApi.Endpoints;
 /// Cross-tenant audit log queries. Admin-only per ADR-003 line 32. Tenant-scoped audit
 /// reads for non-admin reviewers are deferred (tracked separately).
 /// </summary>
-public static class AuditEndpoints
+internal static class AuditEndpoints
 {
     public static RouteGroupBuilder MapAuditEndpoints(this WebApplication app)
     {

--- a/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
@@ -8,7 +8,7 @@ using Pgvector;
 
 namespace ExpertiseApi.Endpoints;
 
-public static class ExpertiseEndpoints
+internal static class ExpertiseEndpoints
 {
     public static RouteGroupBuilder MapExpertiseEndpoints(this WebApplication app)
     {
@@ -428,15 +428,15 @@ public static class ExpertiseEndpoints
     private const int MaxRejectionReasonLength = 2000;
 }
 
-public enum BatchEntryStatus { Created, Duplicate, Rejected, Failed }
+internal enum BatchEntryStatus { Created, Duplicate, Rejected, Failed }
 
-public record BatchEntryResult(
+internal record BatchEntryResult(
     int Index,
     BatchEntryStatus Status,
     Guid? Id,
     string? Error);
 
-public record CreateExpertiseRequest(
+internal record CreateExpertiseRequest(
     string Domain,
     string Title,
     string Body,
@@ -454,7 +454,7 @@ public record CreateExpertiseRequest(
     /// </summary>
     string? Tenant = null);
 
-public record UpdateExpertiseRequest(
+internal record UpdateExpertiseRequest(
     string? Domain = null,
     string? Title = null,
     string? Body = null,
@@ -464,6 +464,6 @@ public record UpdateExpertiseRequest(
     List<string>? Tags = null,
     string? SourceVersion = null);
 
-public record ApproveExpertiseRequest(Visibility? Visibility = null);
+internal record ApproveExpertiseRequest(Visibility? Visibility = null);
 
-public record RejectExpertiseRequest(string RejectionReason);
+internal record RejectExpertiseRequest(string RejectionReason);

--- a/src/ExpertiseApi/Endpoints/HealthEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/HealthEndpoints.cs
@@ -1,6 +1,6 @@
 namespace ExpertiseApi.Endpoints;
 
-public static class HealthEndpoints
+internal static class HealthEndpoints
 {
     public static void MapHealthEndpoints(this WebApplication app)
     {

--- a/src/ExpertiseApi/Endpoints/SearchEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/SearchEndpoints.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace ExpertiseApi.Endpoints;
 
-public static class SearchEndpoints
+internal static class SearchEndpoints
 {
     public static RouteGroupBuilder MapSearchEndpoints(this WebApplication app)
     {

--- a/src/ExpertiseApi/Endpoints/SemanticSearchEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/SemanticSearchEndpoints.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace ExpertiseApi.Endpoints;
 
-public static class SemanticSearchEndpoints
+internal static class SemanticSearchEndpoints
 {
     public static RouteGroupBuilder MapSemanticSearchEndpoints(this WebApplication app)
     {

--- a/src/ExpertiseApi/ExpertiseApi.csproj
+++ b/src/ExpertiseApi/ExpertiseApi.csproj
@@ -8,6 +8,14 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="ExpertiseApi.Tests" />
+    <!--
+      Castle DynamicProxy (used by NSubstitute, Moq, etc.) needs visibility on
+      `internal` interfaces it proxies. Without this, Substitute.For<IInternalInterface>()
+      throws TypeLoadException at first invocation — silent at build time, silent at
+      xUnit discovery. The assembly name "DynamicProxyGenAssembly2" is a Castle
+      convention and is not configurable. See ADR-006.
+    -->
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ExpertiseApi/Migrations/.editorconfig
+++ b/src/ExpertiseApi/Migrations/.editorconfig
@@ -1,0 +1,5 @@
+# EF Core migration scaffolding generates `public partial class` by default;
+# CA1515 would flag every migration on every regeneration. Suppress here so
+# the rule only governs hand-authored code. See ADR-006.
+[*.cs]
+dotnet_diagnostic.CA1515.severity = none

--- a/src/ExpertiseApi/Models/AuditAction.cs
+++ b/src/ExpertiseApi/Models/AuditAction.cs
@@ -1,6 +1,6 @@
 namespace ExpertiseApi.Models;
 
-public enum AuditAction
+internal enum AuditAction
 {
     Created,
     Updated,

--- a/src/ExpertiseApi/Models/EmbeddingMetadata.cs
+++ b/src/ExpertiseApi/Models/EmbeddingMetadata.cs
@@ -1,6 +1,6 @@
 namespace ExpertiseApi.Models;
 
-public class EmbeddingMetadata
+internal class EmbeddingMetadata
 {
     public int Id { get; set; }
 

--- a/src/ExpertiseApi/Models/EntryType.cs
+++ b/src/ExpertiseApi/Models/EntryType.cs
@@ -1,6 +1,6 @@
 namespace ExpertiseApi.Models;
 
-public enum EntryType
+internal enum EntryType
 {
     IssueFix,
     Caveat,

--- a/src/ExpertiseApi/Models/ExpertiseAuditLog.cs
+++ b/src/ExpertiseApi/Models/ExpertiseAuditLog.cs
@@ -1,6 +1,6 @@
 namespace ExpertiseApi.Models;
 
-public class ExpertiseAuditLog
+internal class ExpertiseAuditLog
 {
     public Guid Id { get; set; }
 

--- a/src/ExpertiseApi/Models/ExpertiseEntry.cs
+++ b/src/ExpertiseApi/Models/ExpertiseEntry.cs
@@ -5,7 +5,7 @@ using Pgvector;
 
 namespace ExpertiseApi.Models;
 
-public class ExpertiseEntry
+internal class ExpertiseEntry
 {
     public Guid Id { get; set; }
 

--- a/src/ExpertiseApi/Models/ReviewState.cs
+++ b/src/ExpertiseApi/Models/ReviewState.cs
@@ -1,6 +1,6 @@
 namespace ExpertiseApi.Models;
 
-public enum ReviewState
+internal enum ReviewState
 {
     Draft,
     Approved,

--- a/src/ExpertiseApi/Models/Severity.cs
+++ b/src/ExpertiseApi/Models/Severity.cs
@@ -1,6 +1,6 @@
 namespace ExpertiseApi.Models;
 
-public enum Severity
+internal enum Severity
 {
     Info,
     Warning,

--- a/src/ExpertiseApi/Models/Visibility.cs
+++ b/src/ExpertiseApi/Models/Visibility.cs
@@ -1,6 +1,6 @@
 namespace ExpertiseApi.Models;
 
-public enum Visibility
+internal enum Visibility
 {
     Private,
     Shared

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -147,4 +147,13 @@ catch (Exception ex)
 }
 finally { Log.CloseAndFlush(); }
 
+// WebApplicationFactory<Program> requires Program to be visible to the test
+// assembly via the C# type system. [InternalsVisibleTo] does not satisfy the
+// constraint because WebApplicationFactory<TEntryPoint> lives in
+// Microsoft.AspNetCore.Mvc.Testing, a third-party assembly. Keep public.
+// See ADR-006.
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "Public anchor for WebApplicationFactory<Program> in tests; see ADR-006.")]
 public partial class Program;

--- a/src/ExpertiseApi/Services/DeduplicationService.cs
+++ b/src/ExpertiseApi/Services/DeduplicationService.cs
@@ -7,13 +7,13 @@ using Pgvector;
 
 namespace ExpertiseApi.Services;
 
-public class DeduplicationOptions
+internal class DeduplicationOptions
 {
     public bool Enabled { get; set; } = true;
     public double SemanticThreshold { get; set; } = 0.10;
 }
 
-public class DeduplicationService(IExpertiseRepository repo, IOptions<DeduplicationOptions> options)
+internal class DeduplicationService(IExpertiseRepository repo, IOptions<DeduplicationOptions> options)
 {
     public async Task<(bool IsDuplicate, ExpertiseEntry? Existing)> CheckAsync(
         CreateExpertiseRequest request, Vector embedding, TenantContext ctx, CancellationToken ct = default)

--- a/src/ExpertiseApi/Services/EmbeddingService.cs
+++ b/src/ExpertiseApi/Services/EmbeddingService.cs
@@ -3,7 +3,7 @@ using Pgvector;
 
 namespace ExpertiseApi.Services;
 
-public class EmbeddingService(IEmbeddingGenerator<string, Embedding<float>> generator)
+internal class EmbeddingService(IEmbeddingGenerator<string, Embedding<float>> generator)
 {
     public static string BuildInputText(string title, string body) => $"{title} {body}";
 

--- a/src/ExpertiseApi/Services/IntegrityHashService.cs
+++ b/src/ExpertiseApi/Services/IntegrityHashService.cs
@@ -4,7 +4,7 @@ using ExpertiseApi.Models;
 
 namespace ExpertiseApi.Services;
 
-public static class IntegrityHashService
+internal static class IntegrityHashService
 {
     public static string Compute(
         string tenant,

--- a/tests/ExpertiseApi.Tests/Infrastructure/TestHelpers.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/TestHelpers.cs
@@ -9,17 +9,17 @@ using Pgvector;
 
 namespace ExpertiseApi.Tests.Infrastructure;
 
-public static class TestHelpers
+internal static class TestHelpers
 {
-    public const string TestApiKey = "test-api-key-12345";
-    public const string TestTenant = "test";
+    internal const string TestApiKey = "test-api-key-12345";
+    internal const string TestTenant = "test";
 
     /// <summary>
     /// Builds a <see cref="TenantContext"/> for direct repository calls in tests
     /// (i.e., outside the HTTP request pipeline). Defaults to read+draft scopes;
     /// callers that need approve/admin can pass them explicitly.
     /// </summary>
-    public static TenantContext CreateTenantContext(
+    internal static TenantContext CreateTenantContext(
         string tenant = TestTenant,
         params string[] scopes)
     {
@@ -40,23 +40,23 @@ public static class TestHelpers
             Scopes: scopeSet);
     }
 
-    public static readonly JsonSerializerOptions JsonOptions = new()
+    internal static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNameCaseInsensitive = true,
         Converters = { new JsonStringEnumConverter() }
     };
 
-    public static async Task<T?> ReadJsonAsync<T>(this HttpContent content)
+    internal static async Task<T?> ReadJsonAsync<T>(this HttpContent content)
         => await content.ReadFromJsonAsync<T>(JsonOptions);
 
-    public static async Task<JsonElement> ReadJsonElementAsync(this HttpContent content)
+    internal static async Task<JsonElement> ReadJsonElementAsync(this HttpContent content)
     {
         var stream = await content.ReadAsStreamAsync();
         var doc = await JsonDocument.ParseAsync(stream);
         return doc.RootElement.Clone();
     }
 
-    public static HttpClient CreateAuthenticatedClient(ApiFactory factory)
+    internal static HttpClient CreateAuthenticatedClient(ApiFactory factory)
     {
         var client = factory.CreateClient();
         client.DefaultRequestHeaders.Authorization =
@@ -64,10 +64,10 @@ public static class TestHelpers
         return client;
     }
 
-    public static HttpClient CreateUnauthenticatedClient(ApiFactory factory)
+    internal static HttpClient CreateUnauthenticatedClient(ApiFactory factory)
         => factory.CreateClient();
 
-    public static ExpertiseEntry SeedEntry(
+    internal static ExpertiseEntry SeedEntry(
         string domain = "shared",
         string title = "Test entry",
         string body = "Test body content for search indexing",
@@ -94,7 +94,7 @@ public static class TestHelpers
         };
     }
 
-    public static Vector CreateTestVector(int dimensions = 384)
+    internal static Vector CreateTestVector(int dimensions = 384)
     {
         var values = new float[dimensions];
         var rng = new Random(42);


### PR DESCRIPTION
## Summary

First sub-PR of the analyzer-baseline decomposition (issue #101). Resolves **CA1515** ("consider making types internal") for **105 of 108 occurrences** across `src/ExpertiseApi/`. Three carve-outs documented in new **ADR-006**.

> Sub-split per the agreed PR7 plan. PR7b (CA2007 + CA1861) and PR7c (CA1062 + CA1848 + leftover triage + CI `dotnet format` gate) follow.

### Carve-outs (stay `public`)

| Type | File | Reason |
|---|---|---|
| `Program` | `src/ExpertiseApi/Program.cs:150` | `WebApplicationFactory<Program>` requires C# type-system visibility, not `[InternalsVisibleTo]` (cross-assembly generic constraint into `Microsoft.AspNetCore.Mvc.Testing`) |
| `AuthMode` | `src/ExpertiseApi/Auth/AuthMode.cs` | Used as `[Theory]` parameter type in `AuthModeStartupGuardTests`. xUnit 2 (current) requires test methods to be public; public methods cannot take internal parameter types. Will flip to internal once tests upgrade to xUnit 3 |
| All `Migrations/*.cs` | `src/ExpertiseApi/Migrations/` | EF scaffolding emits `public partial class`. Suppressed via folder-scoped `.editorconfig` rather than per-class `[SuppressMessage]` |

Each individual carve-out (`Program`, `AuthMode`) carries an inline `[SuppressMessage]` with the rationale and an ADR-006 reference.

### `[InternalsVisibleTo]` additions

- `ExpertiseApi.csproj` already grants `ExpertiseApi.Tests`
- **Added `DynamicProxyGenAssembly2`** — required for NSubstitute (Castle DynamicProxy) to mock `internal` interfaces. Without it, `Substitute.For<IInternalInterface>()` throws `TypeLoadException` at first invocation (silent at build, silent at xUnit discovery — fails only at runtime)

### Empirical validation drove a carve-out reduction

`DesignTimeDbContextFactory` was originally proposed as a fourth carve-out (defensive, per `code-review-expert`'s warning that EF tooling reflection might not see internal types). I validated empirically by running `dotnet ef migrations list` against the internal factory — EF Core discovered and instantiated it correctly and listed all six migrations. Carve-out dropped; the factory is now `internal`.

### Test-side cascade fix

`TestHelpers` (in `tests/ExpertiseApi.Tests/Infrastructure/`) and its members were flipped to `internal`. CS0051 fired because public test-helper methods cannot return internal API types (e.g., `ExpertiseEntry`).

## Type of Change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [x] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [ ] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change (add `!` to PR title)

## Test Plan

- [x] `dotnet build ExpertiseApi.slnx -c Release` — **0 errors, 122 warnings (was 219; -97 from the sweep)**
- [x] `dotnet test --filter Unit` — **86/86 pass** (validates Castle DynamicProxy IVT works for internal interfaces)
- [x] `dotnet ef migrations list` — **discovers internal `DesignTimeDbContextFactory` and lists all six migrations**
- [ ] Integration tests: deferred to CI

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files (1 Info: pre-existing CRLF in csproj, not introduced)
- [x] Database migrations are reversible — N/A; no migration changes
- [x] API changes are backward-compatible — **No external API consumers exist** (single-assembly project; only test assembly references `src/ExpertiseApi/` via `[InternalsVisibleTo]`). HTTP wire contract unchanged
- [ ] CLAUDE.md updated — N/A; no commands, endpoints, or workflow changed (the "Security Scanning" baseline number will be updated in PR7c when the final number is known)

## Out of scope (PR7b / PR7c)

- **PR7b**: CA2007 global suppression (~110 occurrences), CA1861 mechanical sweep (~42 occurrences)
- **PR7c**: CA1062 (~80) + CA1848 (~32) + leftover triage; CI gate on `dotnet format --verify-no-changes` once baseline reaches single digits; CLAUDE.md "Security Scanning" baseline update