### PR TITLE
chore(quality): suppress CA2007 globally + CA1861 in tests/migrations (PR7b of issue #101)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,35 @@
+# Repo-wide analyzer severity configuration. See ADR-006 for the broader
+# CA1515 cleanup; the entries here address the next two contributors to the
+# baseline that issue #101 tracks.
+#
+# Formatting rules (indent_size, charset, line_endings) are intentionally
+# omitted from this file — files in this repo are not currently consistent
+# enough for those rules to land without a separate normalization pass.
+
+root = true
+
+[*.cs]
+# CA2007: ConfigureAwait(false). The rule's rationale ("avoid deadlocks from
+# capturing the SynchronizationContext") does not apply to ASP.NET Core or
+# console apps — neither installs a SynchronizationContext, so awaited
+# continuations always run on the thread pool. Adding ConfigureAwait(false)
+# everywhere produces ~110 warnings of pure noise in this codebase. The rule
+# is the canonical example of "library code wants this, application code
+# doesn't" — and this is application code.
+dotnet_diagnostic.CA2007.severity = none
+
+# Test code: CA1861 fires on every `new[] { ... }` literal passed as a method
+# argument, suggesting it be hoisted to a static readonly field. In test
+# arrange/act blocks the array is allocated once per test invocation and
+# readability beats the micro-optimization. The rule remains active for
+# production code under src/, where genuine hot paths benefit from the fix.
+[tests/**/*.cs]
+dotnet_diagnostic.CA1861.severity = none
+
+# EF Core migration scaffolding emits MigrationBuilder calls with literal
+# `new[] {...}` arguments as its canonical syntax. We can't reshape what
+# `dotnet ef migrations add` generates without forking the EF templates, so
+# silence the rule in the Migrations folder. ADR-006 records the same pattern
+# applied to CA1515.
+[**/Migrations/*.cs]
+dotnet_diagnostic.CA1861.severity = none


### PR DESCRIPTION
## Summary

Second sub-PR of the analyzer-baseline decomposition. Adds a root `.editorconfig` with two scoped suppressions.

### CA2007 (ConfigureAwait) — globally suppressed (was 110, now 0)

The rule's rationale is to avoid `SynchronizationContext`-capture deadlocks. Neither ASP.NET Core nor console apps install a `SynchronizationContext`, so awaited continuations always run on the thread pool. Adding `ConfigureAwait(false)` everywhere in this codebase is pure noise — the canonical "library wants this, application doesn't" rule.

### CA1861 (`static readonly` arrays) — suppressed in `tests/` and `Migrations/` (was 42, now 0)

Path-scoped, not global. The rule remains active for production code under `src/`, where genuine hot paths benefit from the fix. Confirmed: **zero CA1861 occurrences in `src/` today**.

- `tests/**/*.cs` — test arrange/act blocks pass `new[] {...}` arrays to production code per test invocation. Readability beats the micro-optimization for code paths that run once per test.
- `**/Migrations/*.cs` — EF Core migration scaffolding emits `MigrationBuilder` calls with literal `new[] {...}` as its canonical syntax. We can't reshape what `dotnet ef migrations add` generates.

### Independent of PR7a

PR7b only touches `.editorconfig` (a new file). PR7a (#117) adds `src/ExpertiseApi/Migrations/.editorconfig` (CA1515 suppression). The two files cover different diagnostics — no override collision. PR7b can merge before, after, or in parallel with PR7a.

## Type of Change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [x] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [ ] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change (add `!` to PR title)

## Test Plan

- [x] `dotnet build ExpertiseApi.slnx -c Release` — **0 errors, 143 warnings (was 219 on dev; -76 from CA2007 + CA1861)**
- [x] `dotnet test --filter Unit` — **86/86 pass**
- [ ] Integration tests: deferred to CI

## Projected baseline trajectory

| Stage | Warning count | Drop |
|---|---|---|
| dev today | 219 | — |
| After PR7a (CA1515) | ~111 | -108 |
| After PR7a + PR7b (CA1515 + CA2007 + CA1861) | **~35** | -184 |
| After PR7c (CA1062 + CA1848 + leftover) | **single digits** | target |

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean (1 Info-level future-proofing note about glob pattern; valid for current layout)
- [x] No code change — analyzer config only
- [x] API changes are backward-compatible — N/A
- [ ] CLAUDE.md "Security Scanning" baseline update — deferred to PR7c when the final number is known