### PR TITLE
chore(quality): drive analyzer baseline to zero + add CI gate (PR7c of issue #101)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,6 +18,25 @@ root = true
 # doesn't" — and this is application code.
 dotnet_diagnostic.CA2007.severity = none
 
+# CA1062: validate parameters of public methods are non-null. The codebase has
+# <Nullable>enable</Nullable>; non-null parameters are the type system's
+# contract, not a runtime defensive layer. After the CA1515 internal sweep
+# (ADR-006), only ~20 sites remain (mostly methods on the carve-out types
+# Program/AuthMode and method overrides where the base interface declares the
+# parameter as non-nullable). Sweeping `ArgumentNullException.ThrowIfNull` at
+# every public method entry duplicates the type system's promise without
+# adding behavior in any reachable scenario. Suppress globally; rely on NRT.
+dotnet_diagnostic.CA1062.severity = none
+
+# CA1848: use LoggerMessage source-generated delegates instead of LogXxx
+# extension methods. The optimization eliminates the boxing/parameter-array
+# allocation per log call. For an internal API service at moderate traffic
+# the per-request perf delta is sub-millisecond; converting the ~32 call
+# sites to partial methods would meaningfully reduce log-statement
+# readability. Revisit only if profiling shows a hot-path log call as a
+# meaningful fraction of request latency.
+dotnet_diagnostic.CA1848.severity = none
+
 # Test code: CA1861 fires on every `new[] { ... }` literal passed as a method
 # argument, suggesting it be hoisted to a static readonly field. In test
 # arrange/act blocks the array is allocated once per test invocation and
@@ -33,3 +52,21 @@ dotnet_diagnostic.CA1861.severity = none
 # applied to CA1515.
 [**/Migrations/*.cs]
 dotnet_diagnostic.CA1861.severity = none
+
+# CA1308: the data layer uses `.ToLowerInvariant()` for case-insensitive title
+# matching against PostgreSQL columns indexed via LOWER(). The rule's
+# preference for ToUpperInvariant() exists because some Turkish characters
+# round-trip differently through lowercase, but the data here is constrained
+# to the ASCII subset used by entry titles and the SQL index is keyed on
+# LOWER(). Forcing ToUpperInvariant would break the index match.
+[src/ExpertiseApi/Data/*.cs]
+dotnet_diagnostic.CA1308.severity = none
+
+# CA1873: avoid expensive log argument evaluation when logging is disabled.
+# The CLI commands (reembed, rehash) log per-batch progress as one-shot
+# maintenance operations — they always run with logging enabled by the
+# operator invoking the command. Wrapping every LogXxx in `if
+# (logger.IsEnabled(...))` adds noise without measurable benefit for these
+# code paths.
+[src/ExpertiseApi/Cli/*.cs]
+dotnet_diagnostic.CA1873.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -55,10 +55,11 @@ dotnet_diagnostic.CA1861.severity = none
 
 # CA1308: the data layer uses `.ToLowerInvariant()` for case-insensitive title
 # matching against PostgreSQL columns indexed via LOWER(). The rule's
-# preference for ToUpperInvariant() exists because some Turkish characters
-# round-trip differently through lowercase, but the data here is constrained
-# to the ASCII subset used by entry titles and the SQL index is keyed on
-# LOWER(). Forcing ToUpperInvariant would break the index match.
+# preference for ToUpperInvariant() exists because some characters can round-
+# trip differently through lowercase, but here the lowercased form is the
+# deliberate invariant normalization used by both the application and the SQL
+# index. Forcing ToUpperInvariant() would diverge from LOWER(title) and break
+# the intended index-aligned comparison behavior.
 [src/ExpertiseApi/Data/*.cs]
 dotnet_diagnostic.CA1308.severity = none
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,16 @@ jobs:
       - name: Build
         run: dotnet build ExpertiseApi.slnx --configuration Release --no-restore --disable-build-servers
 
+      # Analyzer baseline gate (issue #101, ADR-006). The codebase reached
+      # zero analyzer warnings via PR7a/PR7b/PR7c; this step prevents
+      # regression. Use `dotnet format analyzers` so whitespace/style noise
+      # cannot trip the gate — only analyzer-rule violations do.
+      # Note: --no-restore is intentionally omitted; `dotnet format analyzers`
+      # invokes its own MSBuild instance which doesn't see the prior
+      # restore's output via project.assets.json under all path layouts.
+      - name: Format gate (analyzers must be clean)
+        run: dotnet format analyzers ExpertiseApi.slnx --verify-no-changes
+
       - name: Download ONNX model files
         run: bash scripts/download-models.sh
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,7 +323,7 @@ Findings flow into the GitHub Security tab (Code scanning + Dependabot + Secret 
 
 Triggers for CodeQL, Trivy, and Hadolint: push to `main`/`dev`, pull requests targeting `main`/`dev`, weekly schedule (Sunday 06:00 UTC), and manual dispatch.
 
-The .NET analyzers run as **warnings**, not errors. The build is green with the current main-project warning baseline (~223 as of 2026-04-30, up from 201 at PR #68 due to feature work in PRs #36, #37, #52, #53, #59, #60); the cleanup is tracked separately. Top contributors: CA2007 (ConfigureAwait — generally noise in ASP.NET Core), CA1515 (consider internal types), CA1062 (null-arg validation), CA1861 (static readonly arrays), CA1848 (LoggerMessage delegates). The test project overrides `<AnalysisMode>Minimum</AnalysisMode>` to suppress xUnit conventions (underscore method names, `Random` for test data) that produce false-positive security findings.
+The .NET analyzers run as **warnings** with `<AnalysisMode>All</AnalysisMode>`. The baseline reached **0 warnings** via issue #101's three-PR cleanup (CA1515 internal sweep + ADR-006; CA2007/CA1861 scoped suppressions; CA1062/CA1848 globally suppressed; CA1873 in `Cli/`; CA1308 in `Data/`; mechanical fixes for the residual culture/comparison/async family). The `Format gate` step in `ci.yml` runs `dotnet format analyzers --verify-no-changes` to prevent regression. The test project overrides `<AnalysisMode>Minimum</AnalysisMode>` to suppress xUnit conventions (underscore method names, `Random` for test data) that produce false-positive security findings.
 
 See `adrs/004-security-scanning-stack.md` for the design rationale and known gaps (no reachability-aware SCA, no API security spec analysis).
 

--- a/src/ExpertiseApi/Auth/LocalDevAuthHandler.cs
+++ b/src/ExpertiseApi/Auth/LocalDevAuthHandler.cs
@@ -39,7 +39,7 @@ internal class LocalDevAuthHandler(
             return Task.FromResult(AuthenticateResult.NoResult());
 
         var body = raw[TokenPrefix.Length..];
-        var sepIndex = body.IndexOf(':');
+        var sepIndex = body.IndexOf(':', StringComparison.Ordinal);
         if (sepIndex <= 0)
         {
             Logger.LogWarning("LocalDev token rejected: malformed format (expected dev:tenant:scopes)");

--- a/src/ExpertiseApi/Data/ExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/ExpertiseRepository.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using ExpertiseApi.Auth;
 using ExpertiseApi.Models;
 using ExpertiseApi.Services;
@@ -378,6 +379,12 @@ internal class ExpertiseRepository(
             .ToListAsync(ct);
     }
 
+    [SuppressMessage("Globalization", "CA1304:Specify CultureInfo",
+        Justification = "EF Core LINQ expression — translates to SQL LOWER() against the AddTitleLowerIndex; not invoked in C#.")]
+    [SuppressMessage("Globalization", "CA1311:Specify a culture or use an invariant version",
+        Justification = "EF Core LINQ expression — translates to SQL LOWER() against the AddTitleLowerIndex; not invoked in C#.")]
+    [SuppressMessage("Performance", "CA1862:Use the StringComparison overload of String.Equals",
+        Justification = "EF Core does not consistently translate StringComparison overloads to SQL; the .ToLower() pattern matches the dedicated LOWER(title) index introduced by AddTitleLowerIndex.")]
     public async Task<ExpertiseEntry?> FindExactMatchAsync(string domain, string title, TenantContext ctx, CancellationToken ct)
     {
         return await ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx)

--- a/src/ExpertiseApi/Data/ExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/ExpertiseRepository.cs
@@ -380,18 +380,23 @@ internal class ExpertiseRepository(
     }
 
     [SuppressMessage("Globalization", "CA1304:Specify CultureInfo",
-        Justification = "EF Core LINQ expression — translates to SQL LOWER() against the AddTitleLowerIndex; not invoked in C#.")]
+        Justification = "e.Title.ToLower() in this LINQ expression translates to PostgreSQL's LOWER() function and never executes on the .NET runtime; specifying a CultureInfo would not affect the SQL translation. The input parameter is normalized with ToLowerInvariant() above to keep the C#-side value culture-stable.")]
     [SuppressMessage("Globalization", "CA1311:Specify a culture or use an invariant version",
-        Justification = "EF Core LINQ expression — translates to SQL LOWER() against the AddTitleLowerIndex; not invoked in C#.")]
+        Justification = "e.Title.ToLower() in this LINQ expression translates to PostgreSQL's LOWER() function; specifying a culture has no effect on the SQL output.")]
     [SuppressMessage("Performance", "CA1862:Use the StringComparison overload of String.Equals",
         Justification = "EF Core does not consistently translate StringComparison overloads to SQL; the .ToLower() pattern matches the dedicated LOWER(title) index introduced by AddTitleLowerIndex.")]
     public async Task<ExpertiseEntry?> FindExactMatchAsync(string domain, string title, TenantContext ctx, CancellationToken ct)
     {
+        // Normalize the input parameter once with InvariantCulture so the
+        // captured value is culture-stable. The server-side `e.Title.ToLower()`
+        // translates to SQL LOWER(), hitting the AddTitleLowerIndex; both sides
+        // are now deterministic and locale-independent on the .NET runtime.
+        var lowerTitle = title.ToLowerInvariant();
         return await ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx)
             .Where(e => e.DeprecatedAt == null)
             .Where(e => e.ReviewState != ReviewState.Rejected)
             .Where(e => e.Domain == domain)
-            .Where(e => e.Title.ToLower() == title.ToLower())
+            .Where(e => e.Title.ToLower() == lowerTitle)
             .FirstOrDefaultAsync(ct);
     }
 

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -1,5 +1,6 @@
 #pragma warning disable SKEXP0070
 
+using System.Globalization;
 using ExpertiseApi.Auth;
 using ExpertiseApi.Cli;
 using ExpertiseApi.Data;
@@ -15,7 +16,7 @@ using System.Text.Json.Serialization;
 using Scalar.AspNetCore;
 
 Log.Logger = new LoggerConfiguration()
-    .WriteTo.Console()
+    .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
     .CreateBootstrapLogger();
 
 var builder = WebApplication.CreateBuilder(args);
@@ -139,13 +140,15 @@ app.MapAuditEndpoints();
 if (metricsEnabled)
     app.MapMetrics().AllowAnonymous();
 
-try { app.Run(); }
+try { await app.RunAsync(); }
+#pragma warning disable CA1031 // Top-level fatal handler — log any unhandled exception then exit. Re-throwing here would suppress the log and produce a less-useful stack trace.
 catch (Exception ex)
+#pragma warning restore CA1031
 {
     Log.Fatal(ex, "Application terminated unexpectedly");
     Environment.ExitCode = 1;
 }
-finally { Log.CloseAndFlush(); }
+finally { await Log.CloseAndFlushAsync(); }
 
 // WebApplicationFactory<Program> requires Program to be visible to the test
 // assembly via the C# type system. [InternalsVisibleTo] does not satisfy the

--- a/src/ExpertiseApi/Services/IntegrityHashService.cs
+++ b/src/ExpertiseApi/Services/IntegrityHashService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 using System.Text.Json;
 using ExpertiseApi.Models;
@@ -6,6 +7,8 @@ namespace ExpertiseApi.Services;
 
 internal static class IntegrityHashService
 {
+    [SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase",
+        Justification = "Output is hex-encoded SHA-256 (0-9, a-f only). The Turkish-locale gotcha that motivates the rule cannot apply to ASCII hex characters.")]
     public static string Compute(
         string tenant,
         string title,

--- a/tests/ExpertiseApi.Tests/Unit/ScopeAuthorizationHandlerTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/ScopeAuthorizationHandlerTests.cs
@@ -74,7 +74,7 @@ public class ScopeAuthorizationHandlerTests
         authCtx.HasSucceeded.Should().BeTrue();
     }
 
-    private static HttpContext HttpCtxWithTenant(string? tenant, params string[] scopes)
+    private static DefaultHttpContext HttpCtxWithTenant(string? tenant, params string[] scopes)
     {
         var ctx = new DefaultHttpContext();
         ctx.SetTenantContext(new TenantContext(


### PR DESCRIPTION
## Summary

Final sub-PR of the analyzer-baseline decomposition. **Closes issue #101.**

**Net effect: 219 warnings on dev (pre-PR7a) → 0 warnings post-PR7c.** CI gate prevents regression.

| Stage | Warnings | Drop |
|---|---|---|
| dev (pre-cleanup) | 219 | — |
| After PR7a (#117 — CA1515 internal sweep) | 111 | -108 |
| After PR7b (#118 — CA2007 + CA1861 suppressions) | 92 | -19 (CA1515 already gone, so CA2007/CA1861 dropped less than the dev-baseline projection — most CA1062 had been on now-internal types) |
| **After PR7c (this PR)** | **0** | **-92** |

### Suppressions added to root `.editorconfig`

| Rule | Scope | Rationale |
|---|---|---|
| `CA1062` | global | NRT-enabled codebase; non-null parameters are the type system's contract, not a runtime defensive layer |
| `CA1848` | global | LoggerMessage delegate perf delta is sub-millisecond per request at this scale; readability beats micro-optimization |
| `CA1873` | `src/ExpertiseApi/Cli/*.cs` | CLI commands run one-shot with logging enabled by the operator; `if-isEnabled` guard adds noise without benefit |
| `CA1308` | `src/ExpertiseApi/Data/*.cs` | `ToLowerInvariant` matches the SQL `LOWER()` index introduced by `AddTitleLowerIndex` |

### Mechanical fixes

- **`Program.cs`**: `app.Run()` → `await app.RunAsync()` (CA1849); `Log.CloseAndFlush()` → `await Log.CloseAndFlushAsync()` (CA1849); `WriteTo.Console()` → `WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)` (CA1305); `#pragma warning disable CA1031` around the top-level catch with rationale comment
- **`Auth/LocalDevAuthHandler.cs`**: `body.IndexOf(':')` → `body.IndexOf(':', StringComparison.Ordinal)` (CA1307)
- **`tests/ScopeAuthorizationHandlerTests.cs`**: private helper return type `HttpContext` → `DefaultHttpContext` (CA1859)

### Per-method `[SuppressMessage]` with rationale

- **`Data/ExpertiseRepository.FindExactMatchAsync`** — CA1304 / CA1311 / CA1862. The `.Title.ToLower() == title.ToLower()` is an EF LINQ expression that translates to SQL `LOWER(...)` — required to hit the `AddTitleLowerIndex`. Not invoked in C#.
- **`Services/IntegrityHashService.Compute`** — CA1308. Output is hex-encoded SHA-256 (ASCII only); the Turkish-locale gotcha that motivates the rule cannot apply.

### CI gate

New **`Format gate (analyzers must be clean)`** step in `ci.yml` after Build:

```yaml
- name: Format gate (analyzers must be clean)
  run: dotnet format analyzers ExpertiseApi.slnx --verify-no-changes
```

Whitespace/style noise cannot trip this gate — only analyzer-rule violations do. `--no-restore` intentionally omitted (incompatible with `dotnet format analyzers`'s MSBuild reinvocation).

### CLAUDE.md

`Security Scanning` paragraph updated: was 223 baseline + cleanup-tracked-separately language; now reflects the 0-warning state and the CI gate.

## Type of Change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [x] `docs` — documentation only (CLAUDE.md update)
- [x] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [x] `ci` — CI/CD changes (Format gate)
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change (add `!` to PR title)

## Test Plan

- [x] `dotnet build ExpertiseApi.slnx -c Release` — **0 errors, 0 warnings**
- [x] `dotnet format analyzers ExpertiseApi.slnx --verify-no-changes` — **exit 0**
- [x] `dotnet test --filter Unit` — **86/86 pass**
- [ ] Integration tests: deferred to CI

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files
- [x] Database migrations are reversible — N/A
- [x] API changes are backward-compatible — `await app.RunAsync()` is functionally identical to `app.Run()` for the host's lifetime; same for `Log.CloseAndFlushAsync()`. SuppressMessage attributes have zero runtime effect
- [x] CLAUDE.md updated — yes, "Security Scanning" paragraph reflects the new baseline + CI gate

Closes #101