### PR TITLE
feat(host): add native OS service install (archetype A2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,19 @@ AI agents (Claude Code, GitHub Copilot) consume this API via HTTP with a bearer 
 
 All endpoints except `/health`, `/query`, and `/metrics` require `Authorization: Bearer <token>`.
 
+## Native OS service install (Archetype A2)
+
+For a solo developer who wants the API as a persistent OS service rather
+than `docker compose up`, see `scripts/install.sh` (macOS + Linux + WSL),
+`scripts/install.ps1` (Windows), and the README's "Archetype A2" section.
+
+The API host wires `builder.Host.UseSystemd().UseWindowsService(...)` in
+`Program.cs` immediately after `WebApplication.CreateBuilder(args)`. Both
+calls are no-ops outside their host environment, so Docker / Helm /
+`dotnet run` paths remain identical.
+
+Daily-use control: `scripts/expertise-apictl {start|stop|restart|status|logs|health}`.
+
 ## Authentication
 
 `Auth:Mode` config switch governs which authentication scheme(s) are accepted:

--- a/README.md
+++ b/README.md
@@ -102,6 +102,66 @@ ghcr.io/thesemicolon/agent-expertise-api:v1.2.3          # immutable SemVer tag
 ghcr.io/thesemicolon/agent-expertise-api:1.2             # tracks the latest 1.2.x
 ```
 
+### Archetype A2: native OS service install (no Docker)
+
+For a single developer who wants the API always-on without the Docker
+Desktop VM tax (~2 GB RAM idle on macOS / Windows), `scripts/install.sh`
+(macOS + Linux + WSL) and `scripts/install.ps1` (Windows) install the API
+as a native OS service:
+
+- **Linux**: systemd `--user` unit, `Type=notify`, sandboxed
+  (`ProtectSystem=strict`, `ProtectHome=read-only`, `PrivateTmp`, etc.)
+- **macOS**: launchd `LaunchAgent` (per-user), `KeepAlive { Crashed = true }`
+- **Windows**: Windows Service via `sc.exe` with Virtual Account
+  `NT SERVICE\expertise-api`, failure recovery 5s/5s/30s
+
+Quick start (macOS / Linux / WSL):
+
+```bash
+./scripts/install.sh                              # per-user install, fdd publish
+edit ~/.config/expertise-api/secrets.env          # set ConnectionStrings__DefaultConnection
+./scripts/expertise-apictl status                 # daily-use service control
+./scripts/expertise-apictl logs -f                # follow logs (journald / launchd)
+./scripts/expertise-apictl health                 # curl /health
+./scripts/uninstall.sh --yes                      # remove service + binaries
+./scripts/uninstall.sh --yes --purge              # also remove models + secrets
+```
+
+Quick start (Windows, elevated PowerShell 7+):
+
+```powershell
+.\scripts\install.ps1                            # publish + create service + start
+Get-Service expertise-api
+.\scripts\expertise-apictl.ps1 status
+.\scripts\expertise-apictl.ps1 health
+.\scripts\uninstall.ps1 -WhatIf:$false           # apply uninstall (default is dry-run via SupportsShouldProcess)
+```
+
+Postgres must be installed separately (the script does not provision it):
+
+| OS | Install |
+|---|---|
+| macOS  | `brew install postgresql@17 pgvector && brew services start postgresql@17` |
+| Debian/Ubuntu | `sudo apt install postgresql-17 postgresql-17-pgvector` |
+| Windows | EDB installer + pgvector MSI ([pgvector-windows releases](https://github.com/pgvector/pgvector-windows)) |
+
+Then create the database and enable pgvector once:
+
+```sql
+CREATE DATABASE expertise;
+\c expertise
+CREATE EXTENSION vector;
+```
+
+For a solo dev with a single API process, **PgBouncer can be skipped
+locally** — Npgsql's built-in pool is sufficient. Reintroduce PgBouncer
+when the workload becomes multi-process.
+
+Design rationale, footgun catalog (systemd `MemoryDenyWriteExecute`,
+launchd `EnvironmentVariables` secret-leak, Windows Virtual Account
+rationale, etc.) is captured in the synthesis doc at
+[`TheSemicolon/pi_config:notes/agent-expertise-api-hosting.md`](https://github.com/TheSemicolon/pi_config/blob/main/notes/agent-expertise-api-hosting.md).
+
 ## Testing
 
 The test suite uses xUnit, FluentAssertions, NSubstitute, and [Testcontainers](https://dotnet.testcontainers.org/) (PostgreSQL + pgvector). **Docker must be running** for integration tests.

--- a/scripts/expertise-apictl
+++ b/scripts/expertise-apictl
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+#
+# expertise-apictl — daily-use service control wrapper for agent-expertise-api.
+#
+# Hides per-OS service-manager differences (systemctl --user, launchctl,
+# sc.exe via WSL interop). Installed by scripts/install.sh; symlink it into
+# your PATH manually if you want a global command.
+#
+# Usage:
+#   expertise-apictl start|stop|restart|status
+#   expertise-apictl logs [-f] [-n LINES]
+#   expertise-apictl health
+#   expertise-apictl --help
+#
+
+set -euo pipefail
+
+SERVICE="expertise-api"
+LABEL="com.thesemicolon.expertise-api"
+HEALTH_URL="${EXPERTISE_API_URL:-http://127.0.0.1:8080}/health"
+
+log() { printf '[expertise-apictl] %s\n' "$1"; }
+err() { printf '[expertise-apictl] ERROR: %s\n' "$1" >&2; exit 1; }
+
+usage() { sed -n '2,15p' "$0" | sed 's/^# \{0,1\}//'; }
+
+detect_os() {
+  case "$(uname -s)" in
+    Darwin) echo macos ;;
+    Linux)
+      if grep -qiE '(microsoft|wsl)' /proc/version 2>/dev/null && command -v sc.exe >/dev/null 2>&1; then
+        echo wsl_to_windows
+      else
+        echo linux
+      fi ;;
+    *) err "unsupported OS: $(uname -s) — use expertise-apictl.ps1 on Windows" ;;
+  esac
+}
+
+OS="$(detect_os)"
+
+cmd_start() {
+  case "${OS}" in
+    linux)          systemctl --user start "${SERVICE}.service" ;;
+    macos)          launchctl kickstart "gui/$(id -u)/${LABEL}" ;;
+    wsl_to_windows) sc.exe start "${SERVICE}" ;;
+  esac
+}
+
+cmd_stop() {
+  case "${OS}" in
+    linux)          systemctl --user stop "${SERVICE}.service" ;;
+    macos)          launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true ;;
+    wsl_to_windows) sc.exe stop "${SERVICE}" ;;
+  esac
+}
+
+cmd_restart() { cmd_stop; sleep 1; cmd_start; }
+
+cmd_status() {
+  case "${OS}" in
+    linux)
+      systemctl --user status --no-pager "${SERVICE}.service" || true ;;
+    macos)
+      if launchctl print "gui/$(id -u)/${LABEL}" 2>/dev/null \
+          | awk '/^[[:space:]]*(state|pid|last exit code|program) =/ {print}'; then
+        :
+      else
+        err "service not loaded — run scripts/install.sh"
+      fi ;;
+    wsl_to_windows)
+      sc.exe query "${SERVICE}" ;;
+  esac
+}
+
+cmd_logs() {
+  local follow=0 lines=200
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -f|--follow) follow=1; shift ;;
+      -n|--lines)  lines="${2:?}"; shift 2 ;;
+      *) err "unknown logs flag: $1" ;;
+    esac
+  done
+  case "${OS}" in
+    linux)
+      if (( follow == 1 )); then
+        journalctl --user -u "${SERVICE}.service" -n "${lines}" -f
+      else
+        journalctl --user -u "${SERVICE}.service" -n "${lines}" --no-pager
+      fi ;;
+    macos)
+      local logfile="${HOME}/Library/Logs/expertise-api/stdout.log"
+      [[ -f "${logfile}" ]] || err "no log file at ${logfile}"
+      if (( follow == 1 )); then
+        tail -n "${lines}" -f "${logfile}"
+      else
+        tail -n "${lines}" "${logfile}"
+      fi ;;
+    wsl_to_windows)
+      powershell.exe -NoProfile -Command \
+        "Get-WinEvent -ProviderName '${SERVICE}' -MaxEvents ${lines} | Format-List" ;;
+  esac
+}
+
+cmd_health() {
+  command -v curl >/dev/null 2>&1 || err "curl not found"
+  if curl -fsS --max-time 5 "${HEALTH_URL}"; then
+    printf '\n'
+    log "health: OK"
+  else
+    err "health check failed against ${HEALTH_URL}"
+  fi
+}
+
+case "${1:-}" in
+  start)      shift; cmd_start "$@" ;;
+  stop)       shift; cmd_stop "$@" ;;
+  restart)    shift; cmd_restart "$@" ;;
+  status)     shift; cmd_status "$@" ;;
+  logs)       shift; cmd_logs "$@" ;;
+  health)     shift; cmd_health "$@" ;;
+  ''|-h|--help) usage ;;
+  *) err "unknown subcommand: $1 (try --help)" ;;
+esac

--- a/scripts/expertise-apictl.ps1
+++ b/scripts/expertise-apictl.ps1
@@ -1,0 +1,64 @@
+#requires -Version 7
+<#
+.SYNOPSIS
+  Daily-use service control for agent-expertise-api on Windows.
+
+.DESCRIPTION
+  Mirrors scripts/expertise-apictl (the Unix wrapper). Wraps Get-Service /
+  Start-Service / Stop-Service / Get-WinEvent for the Windows Service.
+
+.EXAMPLE
+  .\expertise-apictl.ps1 status
+  .\expertise-apictl.ps1 logs -Follow
+  .\expertise-apictl.ps1 health
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory, Position = 0)]
+    [ValidateSet('start', 'stop', 'restart', 'status', 'logs', 'health')]
+    [string]$Command,
+
+    [int]$Lines = 200,
+    [switch]$Follow,
+    [string]$ServiceName = 'expertise-api',
+    [string]$HealthUrl   = 'http://127.0.0.1:8080/health'
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+switch ($Command) {
+    'start'   { Start-Service $ServiceName }
+    'stop'    { Stop-Service $ServiceName -Force }
+    'restart' { Restart-Service $ServiceName -Force }
+    'status'  { Get-Service $ServiceName | Format-List Name, Status, StartType, DisplayName }
+    'logs' {
+        if ($Follow) {
+            # Get-WinEvent has no native -Wait; poll every second.
+            $last = (Get-Date).AddMinutes(-5)
+            while ($true) {
+                Get-WinEvent -FilterHashtable @{ ProviderName = $ServiceName; StartTime = $last } `
+                    -ErrorAction SilentlyContinue |
+                    Sort-Object TimeCreated |
+                    ForEach-Object {
+                        '{0}  {1}  {2}' -f $_.TimeCreated, $_.LevelDisplayName, $_.Message
+                        $last = $_.TimeCreated.AddMilliseconds(1)
+                    }
+                Start-Sleep -Seconds 1
+            }
+        } else {
+            Get-WinEvent -ProviderName $ServiceName -MaxEvents $Lines -ErrorAction SilentlyContinue |
+                Format-List TimeCreated, LevelDisplayName, Message
+        }
+    }
+    'health' {
+        try {
+            $r = Invoke-RestMethod -Uri $HealthUrl -TimeoutSec 5
+            $r | Format-List
+            Write-Host "[expertise-apictl] health: OK"
+        } catch {
+            Write-Error "[expertise-apictl] health check failed against $HealthUrl : $_"
+            exit 1
+        }
+    }
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,219 @@
+#requires -Version 7
+<#
+.SYNOPSIS
+  Install agent-expertise-api as a Windows Service.
+
+.DESCRIPTION
+  Archetype A2 installer for Windows. Publishes the API per RID, copies it to
+  Program Files, creates a Virtual Account-backed Windows Service via sc.exe,
+  and configures auto-restart on failure. See docs section "Archetype A2".
+
+.PARAMETER InstallPrefix
+  Install root. Default: C:\Program Files\ExpertiseApi
+
+.PARAMETER DataPrefix
+  Data root for models, logs, secrets. Default: C:\ProgramData\ExpertiseApi
+
+.PARAMETER ServiceName
+  Windows Service name. Default: expertise-api
+
+.PARAMETER PublishMode
+  fdd | scd. Default: fdd. SCD adds ~80 MB but skips the .NET runtime check.
+
+.PARAMETER Bind
+  ASPNETCORE_URLS value. Default: http://127.0.0.1:8080
+
+.PARAMETER SkipPreflight
+  Skip pre-flight checks (.NET runtime, port, postgres, disk).
+
+.EXAMPLE
+  .\install.ps1
+  .\install.ps1 -PublishMode scd -Bind 'http://127.0.0.1:9090'
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string]$InstallPrefix = "$env:ProgramFiles\ExpertiseApi",
+    [string]$DataPrefix    = "$env:ProgramData\ExpertiseApi",
+    [string]$ServiceName   = 'expertise-api',
+    [ValidateSet('fdd', 'scd')]
+    [string]$PublishMode   = 'fdd',
+    [string]$Bind          = 'http://127.0.0.1:8080',
+    [switch]$SkipPreflight
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$RepoRoot = (Resolve-Path "$PSScriptRoot\..").Path
+$BinDir   = Join-Path $InstallPrefix 'bin'
+$ModelDir = Join-Path $DataPrefix    'models'
+$ConfigDir = Join-Path $DataPrefix   'config'
+$LogDir   = Join-Path $DataPrefix    'logs'
+$SecretsFile = Join-Path $ConfigDir  'secrets.env'
+
+function Write-Log  { param([string]$Msg) Write-Host "[install.ps1] $Msg" }
+function Write-Err  { param([string]$Msg) Write-Error "[install.ps1] $Msg"; exit 1 }
+function Write-Warn { param([string]$Msg) Write-Warning "[install.ps1] $Msg" }
+
+# ---- Admin check (sc.exe + Program Files writes need elevation) -----------
+$identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+$principal = [System.Security.Principal.WindowsPrincipal]::new($identity)
+if (-not $principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Err 'must be run from an elevated PowerShell prompt (Run as Administrator)'
+}
+
+# ---- Pre-flight ----------------------------------------------------------
+function Invoke-Preflight {
+    Write-Log "pre-flight: PublishMode=$PublishMode Bind=$Bind"
+
+    if ($PublishMode -eq 'fdd') {
+        $dotnet = Get-Command dotnet -ErrorAction SilentlyContinue
+        if (-not $dotnet) { Write-Err 'dotnet CLI not found in PATH' }
+        $runtimes = & dotnet --list-runtimes 2>$null
+        if (-not ($runtimes | Where-Object { $_ -match '^Microsoft\.AspNetCore\.App 10\.' })) {
+            Write-Err 'ASP.NET Core 10 runtime not installed (https://dot.net)'
+        }
+        Write-Log 'dotnet runtime: OK'
+    }
+
+    $portStr = ($Bind -split ':')[-1] -replace '/', ''
+    $port = [int]$portStr
+    $listening = Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue
+    if ($listening) { Write-Err "port $port already in use" }
+    Write-Log "port ${port}: free"
+
+    $pg = Test-NetConnection -ComputerName 127.0.0.1 -Port 5432 -InformationLevel Quiet -WarningAction SilentlyContinue
+    if ($pg) { Write-Log 'postgres 127.0.0.1:5432: reachable' }
+    else { Write-Warn 'postgres 127.0.0.1:5432 NOT reachable — service will start but health checks will fail' }
+
+    $drive = Split-Path -Qualifier $InstallPrefix
+    $disk = Get-CimInstance -ClassName Win32_LogicalDisk -Filter "DeviceID = '$drive'"
+    $availMib = [math]::Round($disk.FreeSpace / 1MB, 0)
+    if ($availMib -lt 200) { Write-Err "insufficient disk space on ${drive}: $availMib MiB" }
+    Write-Log "disk space: $availMib MiB"
+}
+
+# ---- Publish -------------------------------------------------------------
+function Invoke-Publish {
+    Write-Log "publishing to $BinDir (rid=win-x64, mode=$PublishMode)"
+    New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
+    $self = if ($PublishMode -eq 'scd') { 'true' } else { 'false' }
+    Push-Location $RepoRoot
+    try {
+        & dotnet publish src/ExpertiseApi/ExpertiseApi.csproj `
+            --configuration Release `
+            --runtime win-x64 `
+            --self-contained $self `
+            -p:UseAppHost=true `
+            --output $BinDir
+        if ($LASTEXITCODE -ne 0) { Write-Err 'dotnet publish failed' }
+    } finally { Pop-Location }
+    Write-Log 'publish: complete'
+}
+
+# ---- Models --------------------------------------------------------------
+function Confirm-Models {
+    if ((Test-Path (Join-Path $ModelDir 'model.onnx')) -and (Test-Path (Join-Path $ModelDir 'vocab.txt'))) {
+        Write-Log "ONNX models present at $ModelDir"; return
+    }
+    Write-Log "downloading ONNX models to $ModelDir"
+    New-Item -ItemType Directory -Force -Path $ModelDir | Out-Null
+    # download-models.sh requires bash (Git Bash, WSL, or skip and instruct user)
+    $bash = Get-Command bash -ErrorAction SilentlyContinue
+    if ($bash) {
+        $env:DEST_DIR = $ModelDir
+        & bash (Join-Path $RepoRoot 'scripts/download-models.sh')
+    } else {
+        Write-Warn "bash not found — download model files manually to $ModelDir"
+        Write-Warn 'See scripts/download-models.sh for the source URLs'
+    }
+}
+
+# ---- Config / secrets stub ----------------------------------------------
+function Confirm-ConfigStubs {
+    foreach ($d in $ConfigDir, $LogDir) {
+        New-Item -ItemType Directory -Force -Path $d | Out-Null
+    }
+
+    if (-not (Test-Path $SecretsFile)) {
+        Write-Log "creating secrets stub at $SecretsFile"
+        $stub = @'
+# secrets.env — read by the service at start. Do NOT commit. Do NOT log.
+#
+# Set the connection string after install. Example:
+#   ConnectionStrings__DefaultConnection=Host=127.0.0.1;Port=5432;Database=expertise;Username=expertise;Password=CHANGE_ME
+'@
+        Set-Content -Path $SecretsFile -Value $stub -Encoding UTF8
+        # Restrict ACL: only the service identity + Administrators
+        icacls $SecretsFile /inheritance:r | Out-Null
+        icacls $SecretsFile /grant:r 'Administrators:R' "NT SERVICE\$ServiceName`:R" "SYSTEM:R" | Out-Null
+    } else {
+        Write-Log "secrets file present at $SecretsFile (preserved)"
+    }
+}
+
+# ---- Service create/update ----------------------------------------------
+function Install-WindowsService {
+    $exe = Join-Path $BinDir 'ExpertiseApi.exe'
+    if (-not (Test-Path $exe)) { Write-Err "expected $exe not found after publish" }
+
+    $binPath = "`"$exe`""
+    $account = "NT SERVICE\$ServiceName"
+
+    $existing = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+    if ($existing) {
+        Write-Log "service exists — stopping for update"
+        if ($existing.Status -eq 'Running') { Stop-Service $ServiceName -Force }
+        & sc.exe config $ServiceName binPath= $binPath start= auto obj= $account | Out-Null
+    } else {
+        Write-Log "creating service $ServiceName (Virtual Account: $account)"
+        & sc.exe create $ServiceName binPath= $binPath start= auto obj= $account `
+            DisplayName= 'Agent Expertise API' depend= '' | Out-Null
+    }
+
+    & sc.exe description $ServiceName 'Self-hosted REST API for AI-agent expertise (embedding + retrieval)' | Out-Null
+
+    # Failure recovery: 5s, 5s, 30s; reset after 1 day
+    & sc.exe failure $ServiceName reset= 86400 actions= 'restart/5000/restart/5000/restart/30000' | Out-Null
+    & sc.exe failureflag $ServiceName 1 | Out-Null
+
+    # Service-SID hardening
+    & sc.exe sidtype $ServiceName unrestricted | Out-Null
+    & sc.exe privs $ServiceName SeChangeNotifyPrivilege | Out-Null
+
+    # Environment via REG_MULTI_SZ on the service key
+    $envKey = "HKLM:\SYSTEM\CurrentControlSet\Services\$ServiceName"
+    $envValues = @(
+        "ASPNETCORE_URLS=$Bind"
+        'ASPNETCORE_ENVIRONMENT=Production'
+        'DOTNET_NOLOGO=true'
+        'DOTNET_PRINT_TELEMETRY_MESSAGE=false'
+        "Onnx__ModelPath=$(Join-Path $ModelDir 'model.onnx')"
+        "Onnx__VocabPath=$(Join-Path $ModelDir 'vocab.txt')"
+    )
+    New-ItemProperty -Path $envKey -Name 'Environment' `
+        -PropertyType MultiString -Value $envValues -Force | Out-Null
+
+    # Grant Virtual Account write to ProgramData
+    icacls $DataPrefix /grant:r "${account}:(OI)(CI)M" | Out-Null
+
+    Start-Service $ServiceName
+    Write-Log "service started"
+}
+
+# ---- Main ----------------------------------------------------------------
+if (-not $SkipPreflight) { Invoke-Preflight }
+Invoke-Publish
+Confirm-Models
+Confirm-ConfigStubs
+Install-WindowsService
+
+Write-Log 'install complete'
+Write-Log "  binary:  $BinDir"
+Write-Log "  models:  $ModelDir"
+Write-Log "  config:  $ConfigDir"
+Write-Log "  logs:    $LogDir (Serilog file sink + EventLog)"
+Write-Log "  bind:    $Bind"
+Write-Log ''
+Write-Log "Edit $SecretsFile to set the database connection string,"
+Write-Log "then check the service with: Get-Service $ServiceName"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,365 @@
+#!/usr/bin/env bash
+#
+# install.sh — install agent-expertise-api as a native OS service on
+# macOS (launchd LaunchAgent) or Linux (systemd --user unit).
+#
+# This is the Archetype A2 installer (no Docker). For the Compose flow see
+# deploy/local/docker-compose.yml; for k8s see helm/expertise-api/.
+#
+# Usage:
+#   scripts/install.sh [--prefix DIR] [--bind ADDR:PORT] [--system]
+#                      [--publish-mode fdd|scd] [--skip-preflight]
+#                      [--rid RID] [--help]
+#
+# Defaults: per-user install, fdd publish, bind 127.0.0.1:8080.
+#
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Helpers (style matches scripts/download-models.sh)
+# ---------------------------------------------------------------------------
+log()  { printf '[install] %s\n' "$1"; }
+warn() { printf '[install] WARN: %s\n' "$1" >&2; }
+err()  { printf '[install] ERROR: %s\n' "$1" >&2; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Defaults & arg parsing
+# ---------------------------------------------------------------------------
+INSTALL_SCOPE="user"          # user | system
+PUBLISH_MODE="fdd"            # fdd | scd
+BIND_ADDR="127.0.0.1:8080"
+SKIP_PREFLIGHT=0
+EXPLICIT_RID=""
+PREFIX_OVERRIDE=""
+
+usage() { sed -n '2,15p' "$0" | sed 's/^# \{0,1\}//'; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --prefix)         PREFIX_OVERRIDE="${2:?--prefix needs a path}"; shift 2 ;;
+    --bind)           BIND_ADDR="${2:?--bind needs ADDR:PORT}"; shift 2 ;;
+    --system)         INSTALL_SCOPE="system"; shift ;;
+    --publish-mode)   PUBLISH_MODE="${2:?--publish-mode needs fdd|scd}"; shift 2 ;;
+    --skip-preflight) SKIP_PREFLIGHT=1; shift ;;
+    --rid)            EXPLICIT_RID="${2:?--rid needs a runtime identifier}"; shift 2 ;;
+    --help|-h)        usage; exit 0 ;;
+    *)                err "unknown flag: $1 (try --help)" ;;
+  esac
+done
+
+[[ "${PUBLISH_MODE}" == "fdd" || "${PUBLISH_MODE}" == "scd" ]] \
+  || err "--publish-mode must be 'fdd' or 'scd'"
+
+# ---------------------------------------------------------------------------
+# OS detection
+# ---------------------------------------------------------------------------
+detect_os() {
+  case "$(uname -s)" in
+    Darwin)  echo macos ;;
+    Linux)
+      if grep -qiE '(microsoft|wsl)' /proc/version 2>/dev/null; then
+        echo wsl
+      else
+        echo linux
+      fi ;;
+    MINGW*|MSYS*|CYGWIN*)
+      err "Use scripts/install.ps1 from native PowerShell 7+; Git-Bash cannot create Windows Services." ;;
+    *) err "unsupported OS: $(uname -s)" ;;
+  esac
+}
+
+detect_rid() {
+  local arch; arch="$(uname -m)"
+  case "${OS}" in
+    macos)
+      case "${arch}" in
+        arm64)  echo osx-arm64 ;;
+        x86_64) echo osx-x64 ;;
+        *)      err "unsupported macOS arch: ${arch}" ;;
+      esac ;;
+    linux|wsl)
+      case "${arch}" in
+        x86_64)         echo linux-x64 ;;
+        aarch64|arm64)  echo linux-arm64 ;;
+        *)              err "unsupported Linux arch: ${arch}" ;;
+      esac ;;
+  esac
+}
+
+OS="$(detect_os)"
+RID="${EXPLICIT_RID:-$(detect_rid)}"
+
+# ---------------------------------------------------------------------------
+# Path layout per OS (matches notes/agent-expertise-api-hosting.md §A2)
+# ---------------------------------------------------------------------------
+if [[ -n "${PREFIX_OVERRIDE}" ]]; then
+  PREFIX="${PREFIX_OVERRIDE}"
+elif [[ "${OS}" == "macos" ]]; then
+  PREFIX="${HOME}/Library/Application Support/expertise-api"
+  LOG_DIR="${HOME}/Library/Logs/expertise-api"
+  CONFIG_DIR="${HOME}/Library/Application Support/expertise-api"
+else
+  # Linux / WSL — XDG
+  if [[ "${INSTALL_SCOPE}" == "system" ]]; then
+    PREFIX="/opt/expertise-api"
+    LOG_DIR="/var/log/expertise-api"
+    CONFIG_DIR="/etc/expertise-api"
+  else
+    PREFIX="${HOME}/.local/share/expertise-api"
+    LOG_DIR="${XDG_STATE_HOME:-${HOME}/.local/state}/expertise-api"
+    CONFIG_DIR="${XDG_CONFIG_HOME:-${HOME}/.config}/expertise-api"
+  fi
+fi
+
+BIN_DIR="${PREFIX}/bin"
+MODEL_DIR="${PREFIX}/models"
+SECRETS_FILE="${CONFIG_DIR}/secrets.env"
+WRAPPER_SCRIPT="${BIN_DIR}/launch-expertise-api.sh"
+
+# ---------------------------------------------------------------------------
+# Pre-flight
+# ---------------------------------------------------------------------------
+preflight() {
+  log "pre-flight: OS=${OS} RID=${RID} scope=${INSTALL_SCOPE} mode=${PUBLISH_MODE}"
+
+  if [[ "${PUBLISH_MODE}" == "fdd" ]]; then
+    command -v dotnet >/dev/null 2>&1 \
+      || err "dotnet CLI not found in PATH (required for fdd; pass --publish-mode scd to skip)"
+    if ! dotnet --list-runtimes 2>/dev/null | grep -qE '^Microsoft\.AspNetCore\.App 10\.'; then
+      err "ASP.NET Core 10 runtime not installed (need 'Microsoft.AspNetCore.App 10.x'; install via https://dot.net)"
+    fi
+    log "dotnet runtime: OK"
+  fi
+
+  local port="${BIND_ADDR##*:}"
+  if command -v lsof >/dev/null 2>&1; then
+    if lsof -iTCP:"${port}" -sTCP:LISTEN -n -P >/dev/null 2>&1; then
+      err "port ${port} already in use"
+    fi
+    log "port ${port}: free"
+  elif command -v ss >/dev/null 2>&1; then
+    if ss -ltn "sport = :${port}" 2>/dev/null | grep -q LISTEN; then
+      err "port ${port} already in use"
+    fi
+    log "port ${port}: free"
+  else
+    warn "skipping port-in-use check (no lsof or ss)"
+  fi
+
+  local pg_host="${PG_HOST:-127.0.0.1}" pg_port="${PG_PORT:-5432}"
+  if command -v nc >/dev/null 2>&1; then
+    if nc -z -w 2 "${pg_host}" "${pg_port}" 2>/dev/null; then
+      log "postgres ${pg_host}:${pg_port}: reachable"
+    else
+      warn "postgres ${pg_host}:${pg_port} NOT reachable — service will start but health checks will fail"
+    fi
+  elif (exec 3<>"/dev/tcp/${pg_host}/${pg_port}") 2>/dev/null; then
+    exec 3<&-; exec 3>&-
+    log "postgres ${pg_host}:${pg_port}: reachable (via /dev/tcp)"
+  else
+    warn "postgres reachability skipped (no nc, no bash /dev/tcp)"
+  fi
+
+  local need_mib=200 avail_kib avail_mib
+  avail_kib=$(df -P "$(dirname "${PREFIX}")" 2>/dev/null | awk 'NR==2 {print $4}' || echo 0)
+  avail_mib=$(( avail_kib / 1024 ))
+  if (( avail_mib > 0 )) && (( avail_mib < need_mib )); then
+    err "insufficient disk space at ${PREFIX}: ${avail_mib} MiB free, need ${need_mib}"
+  fi
+  log "disk space: ${avail_mib} MiB"
+}
+
+# ---------------------------------------------------------------------------
+# Publish
+# ---------------------------------------------------------------------------
+publish_app() {
+  log "publishing to ${BIN_DIR} (rid=${RID}, mode=${PUBLISH_MODE})"
+  mkdir -p "${BIN_DIR}"
+  local self_contained="false"
+  [[ "${PUBLISH_MODE}" == "scd" ]] && self_contained="true"
+  ( cd "${REPO_ROOT}" && dotnet publish src/ExpertiseApi/ExpertiseApi.csproj \
+      --configuration Release \
+      --runtime "${RID}" \
+      --self-contained "${self_contained}" \
+      -p:UseAppHost=true \
+      --output "${BIN_DIR}" )
+  log "publish: complete"
+}
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+ensure_models() {
+  if [[ -f "${MODEL_DIR}/model.onnx" && -f "${MODEL_DIR}/vocab.txt" ]]; then
+    log "ONNX models present at ${MODEL_DIR}"
+    return
+  fi
+  log "downloading ONNX models to ${MODEL_DIR}"
+  mkdir -p "${MODEL_DIR}"
+  DEST_DIR="${MODEL_DIR}" "${REPO_ROOT}/scripts/download-models.sh"
+}
+
+# ---------------------------------------------------------------------------
+# Config / secrets stub
+# ---------------------------------------------------------------------------
+ensure_config_stubs() {
+  mkdir -p "${CONFIG_DIR}" "${LOG_DIR}"
+  if [[ ! -f "${SECRETS_FILE}" ]]; then
+    log "creating secrets stub at ${SECRETS_FILE} (chmod 600) — edit before starting service"
+    cat > "${SECRETS_FILE}.tmp" <<'EOF'
+# secrets.env — sourced by launch-expertise-api.sh / EnvironmentFile= directive.
+# chmod 600. Do NOT commit. Do NOT log.
+#
+# Set the connection string after install. Example for native Postgres:
+#   ConnectionStrings__DefaultConnection=Host=127.0.0.1;Port=5432;Database=expertise;Username=expertise;Password=CHANGE_ME
+#
+# When Auth:Mode=Oidc, populate per-issuer overrides via Auth__Oidc__Issuers__N__*
+# environment variables — see appsettings.json for the shape.
+EOF
+    mv "${SECRETS_FILE}.tmp" "${SECRETS_FILE}"
+    chmod 600 "${SECRETS_FILE}"
+  else
+    log "secrets file present at ${SECRETS_FILE} (preserved)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Wrapper script — sources secrets, then exec's dotnet (or native binary)
+# ---------------------------------------------------------------------------
+write_wrapper() {
+  cat > "${WRAPPER_SCRIPT}.tmp" <<EOF
+#!/usr/bin/env bash
+# launch-expertise-api.sh — service entrypoint.
+# Sources secrets.env then exec's the API. Generated by scripts/install.sh.
+set -euo pipefail
+
+SECRETS_FILE="${SECRETS_FILE}"
+if [[ -f "\${SECRETS_FILE}" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "\${SECRETS_FILE}"
+  set +a
+fi
+
+export ASPNETCORE_URLS="http://${BIND_ADDR}"
+export ASPNETCORE_ENVIRONMENT="\${ASPNETCORE_ENVIRONMENT:-Production}"
+export DOTNET_NOLOGO=true
+export DOTNET_PRINT_TELEMETRY_MESSAGE=false
+export Onnx__ModelPath="${MODEL_DIR}/model.onnx"
+export Onnx__VocabPath="${MODEL_DIR}/vocab.txt"
+
+if [[ -x "${BIN_DIR}/ExpertiseApi" ]]; then
+  exec "${BIN_DIR}/ExpertiseApi"
+else
+  exec dotnet "${BIN_DIR}/ExpertiseApi.dll"
+fi
+EOF
+  mv "${WRAPPER_SCRIPT}.tmp" "${WRAPPER_SCRIPT}"
+  chmod 755 "${WRAPPER_SCRIPT}"
+  log "wrapper: ${WRAPPER_SCRIPT}"
+}
+
+# ---------------------------------------------------------------------------
+# Service file installation per OS
+# ---------------------------------------------------------------------------
+install_systemd_user() {
+  local unit_dir unit_path
+  unit_dir="${XDG_CONFIG_HOME:-${HOME}/.config}/systemd/user"
+  unit_path="${unit_dir}/expertise-api.service"
+  mkdir -p "${unit_dir}"
+
+  local tpl="${SCRIPT_DIR}/service-templates/expertise-api.service.tmpl"
+  [[ -f "${tpl}" ]] || err "missing template: ${tpl}"
+
+  # sed substitutions (avoid envsubst dependency)
+  sed \
+    -e "s|@@WRAPPER@@|${WRAPPER_SCRIPT}|g" \
+    -e "s|@@WORKDIR@@|${PREFIX}|g" \
+    -e "s|@@SECRETS_FILE@@|${SECRETS_FILE}|g" \
+    -e "s|@@LOG_DIR@@|${LOG_DIR}|g" \
+    "${tpl}" > "${unit_path}.tmp"
+  mv "${unit_path}.tmp" "${unit_path}"
+  log "systemd user unit: ${unit_path}"
+
+  systemctl --user daemon-reload
+  if systemctl --user is-enabled expertise-api.service >/dev/null 2>&1; then
+    systemctl --user restart expertise-api.service
+    log "systemd: restarted"
+  else
+    systemctl --user enable --now expertise-api.service
+    log "systemd: enabled + started"
+  fi
+
+  # Lingering — service survives logout
+  if command -v loginctl >/dev/null 2>&1; then
+    if ! loginctl show-user "$(id -un)" 2>/dev/null | grep -q 'Linger=yes'; then
+      warn "user lingering not enabled — service stops at logout. Enable with: sudo loginctl enable-linger \$USER"
+    fi
+  fi
+}
+
+install_launchd() {
+  local plist_dir plist_path label="com.thesemicolon.expertise-api"
+  plist_dir="${HOME}/Library/LaunchAgents"
+  plist_path="${plist_dir}/${label}.plist"
+  mkdir -p "${plist_dir}"
+
+  local tpl="${SCRIPT_DIR}/service-templates/expertise-api.plist.tmpl"
+  [[ -f "${tpl}" ]] || err "missing template: ${tpl}"
+
+  sed \
+    -e "s|@@LABEL@@|${label}|g" \
+    -e "s|@@WRAPPER@@|${WRAPPER_SCRIPT}|g" \
+    -e "s|@@WORKDIR@@|${PREFIX}|g" \
+    -e "s|@@LOG_DIR@@|${LOG_DIR}|g" \
+    "${tpl}" > "${plist_path}.tmp"
+  mv "${plist_path}.tmp" "${plist_path}"
+  log "launchd plist: ${plist_path}"
+
+  local domain
+  domain="gui/$(id -u)"
+  launchctl bootout "${domain}/${label}" 2>/dev/null || true
+  launchctl bootstrap "${domain}" "${plist_path}"
+  launchctl enable "${domain}/${label}"
+  launchctl kickstart -k "${domain}/${label}"
+  log "launchd: bootstrapped + kickstarted"
+}
+
+install_service() {
+  case "${OS}" in
+    linux|wsl)
+      [[ "${INSTALL_SCOPE}" == "user" ]] \
+        || err "--system install not yet supported by this script (use systemd unit at /etc/systemd/system/ manually)"
+      install_systemd_user ;;
+    macos)
+      install_launchd ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+  if (( SKIP_PREFLIGHT == 0 )); then preflight; fi
+  publish_app
+  ensure_models
+  ensure_config_stubs
+  write_wrapper
+  install_service
+
+  log "install complete"
+  log "  binary:   ${BIN_DIR}"
+  log "  models:   ${MODEL_DIR}"
+  log "  config:   ${CONFIG_DIR}"
+  log "  logs:     ${LOG_DIR}"
+  log "  bind:     http://${BIND_ADDR}"
+  log ""
+  log "Edit ${SECRETS_FILE} to set the database connection string,"
+  log "then check the service with: scripts/expertise-apictl status"
+}
+
+main "$@"

--- a/scripts/service-templates/expertise-api.plist.tmpl
+++ b/scripts/service-templates/expertise-api.plist.tmpl
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>@@LABEL@@</string>
+
+  <!-- Wrapper script sources secrets.env then exec's the API binary -->
+  <key>ProgramArguments</key>
+  <array>
+    <string>@@WRAPPER@@</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>@@WORKDIR@@</string>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key><false/>
+    <key>Crashed</key><true/>
+  </dict>
+
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+
+  <key>ProcessType</key>
+  <string>Interactive</string>
+
+  <key>StandardOutPath</key>
+  <string>@@LOG_DIR@@/stdout.log</string>
+  <key>StandardErrorPath</key>
+  <string>@@LOG_DIR@@/stderr.log</string>
+
+  <key>SoftResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key><integer>4096</integer>
+  </dict>
+</dict>
+</plist>

--- a/scripts/service-templates/expertise-api.service.tmpl
+++ b/scripts/service-templates/expertise-api.service.tmpl
@@ -1,0 +1,47 @@
+[Unit]
+Description=Agent Expertise API
+Documentation=https://github.com/TheSemicolon/agent-expertise-api
+# Ordering only — user units cannot Require= system targets.
+After=network-online.target
+
+[Service]
+Type=notify
+NotifyAccess=main
+WatchdogSec=30
+WorkingDirectory=@@WORKDIR@@
+ExecStart=@@WRAPPER@@
+
+# Restart policy
+Restart=on-failure
+RestartSec=10
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+# Environment file (optional — install.sh creates a chmod-600 stub)
+EnvironmentFile=-@@SECRETS_FILE@@
+
+# Hardening (user-unit subset; some are no-ops at user scope but documented
+# for system-unit promotion).
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=true
+LockPersonality=true
+SystemCallArchitectures=native
+
+# DO NOT enable MemoryDenyWriteExecute — RyuJIT writes executable pages.
+# Enabling crashes the .NET process at first JIT.
+MemoryDenyWriteExecute=false
+
+# Allow log dir writes (user-unit honors this; explicit for clarity)
+ReadWritePaths=@@LOG_DIR@@
+
+[Install]
+# User unit — default.target, NOT multi-user.target.
+WantedBy=default.target

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -1,0 +1,79 @@
+#requires -Version 7
+<#
+.SYNOPSIS
+  Uninstall agent-expertise-api Windows Service.
+
+.DESCRIPTION
+  Dry-run by default — pass -Confirm:$false plus -WhatIf:$false to apply.
+  Use -Purge to also remove user data (models, secrets, logs). Postgres data
+  is NEVER touched.
+
+.EXAMPLE
+  .\uninstall.ps1               # dry-run
+  .\uninstall.ps1 -WhatIf:$false  # apply (PowerShell SupportsShouldProcess)
+  .\uninstall.ps1 -WhatIf:$false -Purge   # apply + remove data
+#>
+[CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+param(
+    [string]$InstallPrefix = "$env:ProgramFiles\ExpertiseApi",
+    [string]$DataPrefix    = "$env:ProgramData\ExpertiseApi",
+    [string]$ServiceName   = 'expertise-api',
+    [switch]$Purge
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Write-Log { param([string]$Msg) Write-Host "[uninstall.ps1] $Msg" }
+
+# Admin check
+$identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+$principal = [System.Security.Principal.WindowsPrincipal]::new($identity)
+if (-not $principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Error '[uninstall.ps1] must be run from an elevated PowerShell prompt'
+    exit 1
+}
+
+# Stop + remove service
+$svc = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+if ($svc) {
+    if ($PSCmdlet.ShouldProcess($ServiceName, 'Stop service')) {
+        if ($svc.Status -eq 'Running') { Stop-Service $ServiceName -Force }
+    }
+    if ($PSCmdlet.ShouldProcess($ServiceName, 'sc.exe delete')) {
+        & sc.exe delete $ServiceName | Out-Null
+        Write-Log "service $ServiceName removed"
+    }
+} else {
+    Write-Log "service $ServiceName not present — skipping"
+}
+
+# Remove install tree
+$BinDir = Join-Path $InstallPrefix 'bin'
+if (Test-Path $BinDir) {
+    if ($PSCmdlet.ShouldProcess($BinDir, 'Remove install dir')) {
+        Remove-Item -Recurse -Force $BinDir
+    }
+}
+
+if (Test-Path $InstallPrefix) {
+    $remaining = Get-ChildItem $InstallPrefix -ErrorAction SilentlyContinue
+    if (-not $remaining) {
+        if ($PSCmdlet.ShouldProcess($InstallPrefix, 'Remove empty install root')) {
+            Remove-Item -Force $InstallPrefix
+        }
+    }
+}
+
+if ($Purge) {
+    Write-Log 'purge: removing user data'
+    if (Test-Path $DataPrefix) {
+        if ($PSCmdlet.ShouldProcess($DataPrefix, 'Remove data dir (purge)')) {
+            Remove-Item -Recurse -Force $DataPrefix
+        }
+    }
+} else {
+    Write-Log "preserved: $DataPrefix (use -Purge to remove)"
+}
+
+Write-Log 'uninstall complete (Postgres database NOT touched)'

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# uninstall.sh — remove agent-expertise-api native OS service install.
+#
+# Dry-run by default. Use --yes to apply, --purge to also remove user data
+# (logs, models, secrets). Postgres data is NEVER touched (out of scope).
+#
+# Usage:
+#   scripts/uninstall.sh [--yes] [--purge] [--prefix DIR] [--system] [--help]
+#
+
+set -euo pipefail
+
+log()  { printf '[uninstall] %s\n' "$1"; }
+warn() { printf '[uninstall] WARN: %s\n' "$1" >&2; }
+err()  { printf '[uninstall] ERROR: %s\n' "$1" >&2; exit 1; }
+
+APPLY=0
+PURGE=0
+INSTALL_SCOPE="user"
+PREFIX_OVERRIDE=""
+
+usage() { sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --yes)     APPLY=1; shift ;;
+    --purge)   PURGE=1; shift ;;
+    --prefix)  PREFIX_OVERRIDE="${2:?--prefix needs a path}"; shift 2 ;;
+    --system)  INSTALL_SCOPE="system"; shift ;;
+    --help|-h) usage; exit 0 ;;
+    *)         err "unknown flag: $1 (try --help)" ;;
+  esac
+done
+
+if (( PURGE == 1 && APPLY == 0 )); then
+  err "--purge requires --yes (refusing destructive op without explicit confirmation)"
+fi
+
+# OS detection (subset of install.sh)
+case "$(uname -s)" in
+  Darwin) OS=macos ;;
+  Linux)  if grep -qiE '(microsoft|wsl)' /proc/version 2>/dev/null; then OS=wsl; else OS=linux; fi ;;
+  *)      err "unsupported OS: $(uname -s) — use uninstall.ps1 on Windows" ;;
+esac
+
+# Path layout (must mirror install.sh)
+if [[ -n "${PREFIX_OVERRIDE}" ]]; then
+  PREFIX="${PREFIX_OVERRIDE}"
+elif [[ "${OS}" == "macos" ]]; then
+  PREFIX="${HOME}/Library/Application Support/expertise-api"
+  LOG_DIR="${HOME}/Library/Logs/expertise-api"
+  CONFIG_DIR="${HOME}/Library/Application Support/expertise-api"
+else
+  if [[ "${INSTALL_SCOPE}" == "system" ]]; then
+    PREFIX="/opt/expertise-api"; LOG_DIR="/var/log/expertise-api"; CONFIG_DIR="/etc/expertise-api"
+  else
+    PREFIX="${HOME}/.local/share/expertise-api"
+    LOG_DIR="${XDG_STATE_HOME:-${HOME}/.local/state}/expertise-api"
+    CONFIG_DIR="${XDG_CONFIG_HOME:-${HOME}/.config}/expertise-api"
+  fi
+fi
+
+BIN_DIR="${PREFIX}/bin"
+MODEL_DIR="${PREFIX}/models"
+
+# Action helper — print or execute depending on APPLY
+do_action() {
+  if (( APPLY == 1 )); then
+    log "exec: $*"
+    # shellcheck disable=SC2294  # intentional: callers pass a single shell string with redirection / || true.
+    eval "$@"
+  else
+    log "would: $*"
+  fi
+}
+
+if (( APPLY == 0 )); then
+  log "DRY RUN (use --yes to apply, --yes --purge to also remove user data)"
+fi
+
+# Stop service first
+case "${OS}" in
+  linux|wsl)
+    if systemctl --user list-unit-files expertise-api.service 2>/dev/null | grep -q expertise-api; then
+      do_action "systemctl --user stop expertise-api.service 2>/dev/null || true"
+      do_action "systemctl --user disable expertise-api.service 2>/dev/null || true"
+      do_action "rm -f \"${XDG_CONFIG_HOME:-${HOME}/.config}/systemd/user/expertise-api.service\""
+      do_action "systemctl --user daemon-reload"
+    else
+      log "systemd unit not present — skipping service teardown"
+    fi ;;
+  macos)
+    LABEL="com.thesemicolon.expertise-api"
+    PLIST="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+    if [[ -f "${PLIST}" ]]; then
+      do_action "launchctl bootout gui/$(id -u)/${LABEL} 2>/dev/null || true"
+      do_action "rm -f \"${PLIST}\""
+    else
+      log "launchd plist not present — skipping service teardown"
+    fi ;;
+esac
+
+# Remove binary tree
+if [[ -d "${BIN_DIR}" ]]; then
+  do_action "rm -rf \"${BIN_DIR}\""
+else
+  log "binary dir not present — skipping"
+fi
+
+# Wrapper script
+if [[ -f "${PREFIX}/bin/launch-expertise-api.sh" ]]; then
+  do_action "rm -f \"${PREFIX}/bin/launch-expertise-api.sh\""
+fi
+
+if (( PURGE == 1 )); then
+  log "purge: removing user data"
+  for d in "${MODEL_DIR}" "${LOG_DIR}" "${CONFIG_DIR}" "${PREFIX}"; do
+    [[ -d "${d}" ]] && do_action "rm -rf \"${d}\""
+  done
+else
+  log "preserved: ${MODEL_DIR}        (use --purge to remove)"
+  log "preserved: ${LOG_DIR}          (use --purge to remove)"
+  log "preserved: ${CONFIG_DIR}       (secrets — use --purge to remove)"
+fi
+
+log "uninstall complete (Postgres database NOT touched — drop manually if desired)"

--- a/src/ExpertiseApi/ExpertiseApi.csproj
+++ b/src/ExpertiseApi/ExpertiseApi.csproj
@@ -25,6 +25,15 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <!--
+      Service-host integration. Both packages are no-ops outside their host
+      environment (SystemdHelpers.IsSystemdService / WindowsServiceHelpers.IsWindowsService),
+      so Docker / Helm / `dotnet run` paths are unaffected. See README §
+      "Archetype A2: native OS service install" for the install scripts that
+      depend on these.
+    -->
+    <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.Onnx" Version="1.74.0-alpha" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageReference Include="Pgvector.EntityFrameworkCore" Version="0.3.0" />

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -21,6 +21,15 @@ Log.Logger = new LoggerConfiguration()
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Service-host integration. Both calls are no-ops when the corresponding host
+// environment is absent, so Docker / Helm / `dotnet run` paths remain unchanged.
+// Enables the Archetype A2 install scripts under scripts/ (systemd `--user`
+// unit on Linux, launchd LaunchAgent on macOS, Windows Service on Windows) to
+// integrate with the .NET host's lifecycle (Type=notify on systemd, SCM
+// signals on Windows). See README § "Archetype A2: native OS service".
+builder.Host.UseSystemd();
+builder.Host.UseWindowsService(options => options.ServiceName = "ExpertiseApi");
+
 builder.Host.UseSerilog((context, services, config) =>
     config.ReadFrom.Configuration(context.Configuration)
           .ReadFrom.Services(services));


### PR DESCRIPTION
Closes #122.

## Summary

Adds a fourth deployment topology for solo developers: run the API as a persistent OS service instead of `docker compose up`. Targets the case where Docker Desktop's ~2 GB RAM idle tax on macOS / Windows matters.

## What changed

### .NET host (commit 1, `feat(host)`)
- `src/ExpertiseApi/ExpertiseApi.csproj` \u2014 add `Microsoft.Extensions.Hosting.Systemd` 10.0.0 + `Microsoft.Extensions.Hosting.WindowsServices` 10.0.0
- `src/ExpertiseApi/Program.cs` \u2014 wire `builder.Host.UseSystemd().UseWindowsService(o => o.ServiceName = "ExpertiseApi")` immediately after `WebApplication.CreateBuilder(args)`. Both calls are no-ops outside their host environment.

### Scripts (commit 2, `feat(scripts)`)
- `scripts/install.sh` + `scripts/uninstall.sh` \u2014 bash for macOS + Linux + WSL. Pre-flight (`.NET runtime, port, postgres, disk`), publish per RID, model download, chmod-600 secrets stub, wrapper script, then install + start systemd `--user` unit (Linux) or launchd LaunchAgent (macOS). Uninstall is dry-run by default; `--yes` to apply, `--purge` for data.
- `scripts/install.ps1` + `scripts/uninstall.ps1` \u2014 PowerShell 7+, requires elevation. Creates Windows Service via `sc.exe` with Virtual Account `NT SERVICE\\expertise-api`, failure recovery 5s/5s/30s, env via REG_MULTI_SZ. Uninstall uses native `-WhatIf`.
- `scripts/expertise-apictl` + `.ps1` \u2014 daily-use wrappers (start/stop/restart/status/logs/health) that hide systemctl/launchctl/sc.exe differences.
- `scripts/service-templates/expertise-api.service.tmpl` \u2014 systemd unit, `Type=notify`, sandboxed (`ProtectSystem=strict`, `ProtectHome=read-only`, `PrivateTmp`, `NoNewPrivileges`, `MemoryDenyWriteExecute=false` with comment), `Restart=on-failure`, `StartLimitBurst=5`.
- `scripts/service-templates/expertise-api.plist.tmpl` \u2014 launchd LaunchAgent, `KeepAlive { Crashed = true }`.

### Docs (commit 3, `docs`)
- `README.md` \u2014 new 'Archetype A2: native OS service install' subsection under Deployment with quick-start commands per OS and Postgres install matrix.
- `CLAUDE.md` \u2014 brief section pointing at the README + cross-link to the design synthesis.

## Footgun catalog (addressed in templates)

1. systemd `MemoryDenyWriteExecute=true` crashes RyuJIT \u2014 explicitly `false` with comment
2. systemd user units use `WantedBy=default.target`, not `multi-user.target`
3. launchd has no `EnvironmentFile=` \u2014 wrapper script sources `secrets.env` then `exec`s the API
4. Windows Virtual Account preferred over `NetworkService` (isolated SID, precise ACLs)
5. Bind `127.0.0.1:8080`, never `0.0.0.0` \u2014 host service has no network namespace
6. Secrets never put in `Environment=` / plist `EnvironmentVariables` / Windows registry `ImagePath`
7. PgBouncer skipped locally (single-process scale)
8. Service runs as dev user \u2192 has read access to user's `~/.aws`, `~/.kube`, `~/.ssh` (documented)

## Backwards compatibility

`UseSystemd()` and `UseWindowsService()` are inert under Docker / k8s / `dotnet run`. Existing Compose, Helm, and CI paths are byte-identical to today. Two new NuGet dependencies (~30 KB combined).

## Validation

- `dotnet build ExpertiseApi.slnx` \u2014 0 warnings, 0 errors
- `dotnet test ExpertiseApi.slnx --filter 'FullyQualifiedName!~Integration'` \u2014 87/87 pass (Integration suite skipped locally because testcontainers needs Docker; will run in CI)
- `shellcheck -s bash scripts/install.sh scripts/uninstall.sh scripts/expertise-apictl` \u2014 clean
- `markdownlint-cli2 README.md CLAUDE.md` \u2014 clean
- `scripts/validate-pr.sh --title 'feat(host): add native OS service install (archetype A2)' --base dev` \u2014 PASS
- PowerShell scripts not lintable locally (no PSScriptAnalyzer); will be checked by CI's existing PowerShell job if any. Manual smoke-test is on the reviewer's Windows box.

## Out of scope (future work)

- Auto-updater (Squirrel/Velopack/MSI) \u2014 use GH Releases asset replace-and-restart for now
- Containerized-but-rootless variant (Podman quadlet) \u2014 trivial follow-up if requested
- `--system` install scope on Linux \u2014 stub present, full implementation deferred (the per-user path covers the solo-dev use case)

## References

- Design synthesis: https://github.com/TheSemicolon/pi_config/blob/main/notes/agent-expertise-api-hosting.md (PR https://github.com/TheSemicolon/pi_config/pull/61)
- Tracking issue: #122