### PR TITLE
fix(auth): gate /query debug UI to Development environment (XSS hardening)

### DIFF
--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -125,18 +125,23 @@ if (metricsEnabled)
     app.UseHttpMetrics();
 app.UseSerilogRequestLogging();
 
-app.UseStaticFiles();
-
 if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
     app.MapScalarApiReference();
-}
 
-app.MapGet("/query", (IWebHostEnvironment env) =>
-        Results.File(Path.Combine(env.WebRootPath, "query.html"), "text/html"))
-    .AllowAnonymous()
-    .ExcludeFromDescription();
+    // Static-file serving and the /query debug UI are Development-only because
+    // wwwroot/query.html stores the bearer token in localStorage, making it
+    // exfiltratable via any same-origin XSS (issue #124). wwwroot/ currently
+    // contains only query.html; if other static assets are added later they
+    // should live outside wwwroot/ or this gate must be revisited.
+    app.UseStaticFiles();
+
+    app.MapGet("/query", (IWebHostEnvironment env) =>
+            Results.File(Path.Combine(env.WebRootPath, "query.html"), "text/html"))
+        .AllowAnonymous()
+        .ExcludeFromDescription();
+}
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/tests/ExpertiseApi.Tests/Integration/QueryEndpointGatingTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/QueryEndpointGatingTests.cs
@@ -1,0 +1,73 @@
+using System.Net;
+using ExpertiseApi.Tests.Infrastructure;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace ExpertiseApi.Tests.Integration;
+
+/// <summary>
+/// Verifies that the /query debug UI and its backing static files are gated to the
+/// Development environment per issue #124 (the page stores the bearer token in
+/// localStorage and would be XSS-exfiltratable if shipped to production).
+/// </summary>
+[Collection("Postgres")]
+public class QueryEndpointGatingTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private ApiFactory _devFactory = null!;
+    private WebApplicationFactory<Program> _prodFactory = null!;
+
+    public QueryEndpointGatingTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public Task InitializeAsync()
+    {
+        // WebApplicationFactory<TEntryPoint> defaults to ASPNETCORE_ENVIRONMENT=Development;
+        // we explicitly override to Production for the gating assertion.
+        //
+        // The Production environment activates the API's startup guards
+        // (EnforceOidcIssuersGuard in particular). Auth:Mode defaults to Oidc outside
+        // Development and requires at least one issuer whose Issuer URL does not
+        // start with '<TODO'. We're not exercising auth here — only /query routing —
+        // so we supply a syntactically-valid placeholder issuer just to satisfy the
+        // startup guard.
+        _devFactory = new ApiFactory(_postgres.ConnectionString);
+        _prodFactory = _devFactory.WithWebHostBuilder(b =>
+        {
+            b.UseEnvironment("Production");
+            b.UseSetting("Auth:Mode", "Oidc");
+            b.UseSetting("Auth:Oidc:Issuers:0:Name", "test-issuer");
+            b.UseSetting("Auth:Oidc:Issuers:0:Issuer", "https://example.test/");
+            b.UseSetting("Auth:Oidc:Issuers:0:Audience", "test-audience");
+        });
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync() => await _devFactory.DisposeAsync();
+
+    [Fact]
+    public async Task Query_Route_Returns404_InProduction()
+    {
+        var client = _prodFactory.CreateClient();
+        var response = await client.GetAsync("/query");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task QueryHtml_StaticFile_Returns404_InProduction()
+    {
+        // wwwroot/query.html must NOT be reachable via UseStaticFiles either.
+        // Both the /query route AND the underlying /query.html asset must be gated.
+        var client = _prodFactory.CreateClient();
+        var response = await client.GetAsync("/query.html");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Query_Route_ReturnsHtml_InDevelopment()
+    {
+        var client = _devFactory.CreateClient();
+        var response = await client.GetAsync("/query");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("text/html");
+    }
+}


### PR DESCRIPTION
Closes #124.

## Summary

Moves `app.UseStaticFiles()` and `app.MapGet("/query", ...)` inside the existing `if (app.Environment.IsDevelopment())` block alongside `MapOpenApi()` / `MapScalarApiReference()`. The debug UI \u2014 which stores the bearer token in `localStorage` and is therefore XSS-exfiltratable \u2014 is unreachable in any non-Development environment. `wwwroot/` currently contains only `query.html` so gating `UseStaticFiles()` causes no collateral.

Issue #124 listed three options; this is Option A (preferred, smallest diff).

## Tests (3 new in `QueryEndpointGatingTests.cs`)

| Test | Asserts |
|---|---|
| `Query_Route_Returns404_InProduction` | `GET /query` returns 404 when `ASPNETCORE_ENVIRONMENT=Production` |
| `QueryHtml_StaticFile_Returns404_InProduction` | `GET /query.html` (the underlying asset) also returns 404 \u2014 catches regression where someone re-enables `UseStaticFiles` outside the gate |
| `Query_Route_ReturnsHtml_InDevelopment` | Positive control: `GET /query` returns 200 + `text/html` under Development, proving the route is wired and would be reachable absent the gate |

The factory pair (`ApiFactory` for Dev, derived via `WithWebHostBuilder(b => b.UseEnvironment("Production"))` for Prod) reuses the existing PostgresFixture, so the gating assertions cost only the testcontainer warmup already shared with the integration suite.

## Validation

- `dotnet build` clean
- `dotnet test --filter 'FullyQualifiedName!~Integration'` \u2014 87/87 pass (full integration suite runs in CI)
- `scripts/validate-pr.sh` PASS
- `/review` 3-way fan-out (code-review-expert + security-review-expert + linter) \u2014 aggregate **PASS_WITH_WARNINGS**; no blocking findings; Warnings are Info-level defense-in-depth opportunities documented below

## Defense-in-depth opportunities (deferred, out of scope per #124)

These were raised by `security-review-expert` as Info findings and are valuable follow-ups but explicitly outside this PR's scope:

1. **Explicit opt-in alongside `IsDevelopment()`** \u2014 a `DebugUi:Enabled` (default `false`) flag would prevent a misconfigured deployment shipping `ASPNETCORE_ENVIRONMENT=Development` from re-exposing the page.
2. **Replace `localStorage` token storage** \u2014 even in dev, `localStorage` is risky (devs reuse real tokens). `sessionStorage`, in-memory variable, or short-lived dev-minted token would be safer.
3. **CSP header on `/query` response** \u2014 `default-src 'self'; script-src 'self' 'unsafe-inline'; frame-ancestors 'none'` would harden the dev page against script injection.

Happy to spin any of these out as separate issues if desired.

## Backwards compatibility

- Production deployments lose access to a debug UI that should never have shipped there
- Development deployments unchanged (route + page still work)
- No API contract change, no schema change, no config change required