### PR TITLE
chore(build): pin .NET SDK band and add dotnet-tools manifest

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "10.0.4",
+      "commands": [
+        "dotnet-ef"
+      ]
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: global.json
 
       - name: Cache NuGet packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: global.json
 
       - name: Cache NuGet packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -11,3 +11,10 @@
 # Helm chart.
 ignored:
   - DL3008
+  # DL3059 — "Multiple consecutive RUN instructions" — ignored at the boundary
+  # between `dotnet restore` and `dotnet tool restore` in the build stage.
+  # Combining them would defeat the layer caching that motivates the
+  # separation: `dotnet restore` caches against csproj changes, `dotnet tool
+  # restore` caches against .config/dotnet-tools.json changes. Merging would
+  # invalidate both layers whenever either input changes.
+  - DL3059

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,9 +22,10 @@ Self-hosted .NET 10 REST API for storing and serving expertise entries consumed 
 
 ```bash
 # .NET 10 SDK (verify with: dotnet --version)
+# The repo pins the SDK band via global.json (10.0.1xx, latestFeature rollforward).
 # Docker + Docker Compose
-# EF Core CLI tool
-dotnet tool install --global dotnet-ef
+# EF Core CLI tool is pinned in .config/dotnet-tools.json — install via:
+dotnet tool restore
 ```
 
 ## Build & Run Commands

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,23 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
-# Copy project file first for layer caching of the restore step
+# Copy SDK pin + tool manifest first so the restore + tool-restore layers cache
+# against changes to those files only, not against source-tree churn. global.json
+# selects the SDK; .config/dotnet-tools.json pins dotnet-ef (used in the bundle
+# stage). Then copy the csproj to cache `dotnet restore` against package-graph
+# changes; finally copy the rest of the source.
+COPY global.json ./
+COPY .config/ .config/
 COPY src/ExpertiseApi/ExpertiseApi.csproj src/ExpertiseApi/
 
 RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
     dotnet restore src/ExpertiseApi/ExpertiseApi.csproj
+
+# Restore the EF Core CLI tool before copying source so the tool layer caches
+# against .config/dotnet-tools.json changes only, not against source churn.
+RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
+    dotnet tool restore
+ENV PATH="$PATH:/root/.dotnet/tools"
 
 # Copy the rest of the source and publish
 COPY src/ src/
@@ -21,10 +33,8 @@ RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
 
 # ── Migration bundle stage ─────────────────────────────────────────────────────
 FROM build AS bundle
-RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
-    dotnet tool install --global dotnet-ef --version 10.0.*
-ENV PATH="$PATH:/root/.dotnet/tools"
-
+# dotnet-ef is restored in the build stage above (cached against the tool
+# manifest, not against source churn). Just invoke the migration-bundle build.
 RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
     dotnet ef migrations bundle \
     --project src/ExpertiseApi/ExpertiseApi.csproj \

--- a/README.md
+++ b/README.md
@@ -64,19 +64,22 @@ cp deploy/local/.env.example deploy/local/.env
 # Edit deploy/local/.env — set POSTGRES_PASSWORD and AUTH__APIKEY
 docker compose -f deploy/local/docker-compose.yml up -d postgres pgbouncer
 
-# 2. Apply migrations
+# 2. Restore the EF Core CLI tool (pinned in .config/dotnet-tools.json)
+dotnet tool restore
+
+# 3. Apply migrations
 dotnet ef database update --project src/ExpertiseApi
 
-# 2b. Download ONNX model files (required for embeddings and semantic search)
+# 3b. Download ONNX model files (required for embeddings and semantic search)
 ./scripts/download-models.sh
 
-# 3. Run the API
+# 4. Run the API
 dotnet run --project src/ExpertiseApi
 
-# 4. Verify
+# 5. Verify
 curl http://localhost:5000/health
 
-# 5. Browse the query page (interactive UI for search and filtering)
+# 6. Browse the query page (interactive UI for search and filtering)
 # http://localhost:5000/query
 ```
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestPatch",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
Closes #126 and #127.

## Summary

Adds two repo-tooling files that pin the .NET SDK feature band and the EF Core CLI tool version:

- `global.json` \u2014 SDK 10.0.100 floor, `rollForward: latestPatch` (stays within 10.0.1xx feature band), `allowPrerelease: false` (LTS posture).
- `.config/dotnet-tools.json` \u2014 `dotnet-ef` 10.0.4, matching the `Microsoft.EntityFrameworkCore.Design` package version in `ExpertiseApi.csproj`.

Behavior changes are intentionally minimal: existing `dotnet` invocations now resolve to a deterministic SDK band; the Dockerfile bundle stage replaces an ad-hoc `dotnet tool install --global dotnet-ef --version 10.0.*` with manifest-driven `dotnet tool restore`.

## Commits

1. `chore(build): add global.json to pin .NET SDK feature band` \u2014 `global.json` + consolidates `setup-dotnet` inputs in `ci.yml` and `codeql.yml` from `dotnet-version: '10.0.x'` to `global-json-file: global.json` (single source of truth, per the [actions/setup-dotnet README](https://github.com/actions/setup-dotnet#usage)).
2. `chore(build): add dotnet-tools manifest pinning dotnet-ef` \u2014 `.config/dotnet-tools.json`, Dockerfile rewrite for layer-cache-friendly tool restore, README + CLAUDE.md doc updates, `.hadolint.yaml` DL3059 ignore with rationale.

## Dockerfile layer-cache ordering (new)

```text
COPY global.json + .config/    \u2192 SDK pin & tool manifest (rarely change)
COPY ExpertiseApi.csproj       \u2192 package graph
RUN  dotnet restore            \u2192 cached against csproj only
RUN  dotnet tool restore       \u2192 cached against .config/ only
COPY src/                      \u2192 source churn invalidates from here down
RUN  dotnet publish --no-restore
```

The bundle stage (`FROM build AS bundle`) inherits the restored tool and only runs `dotnet ef migrations bundle`. No more drifting `dotnet tool install --global`.

## Validation

- `dotnet --version` \u2192 10.0.107 (satisfies pin floor 10.0.100 in the 1xx band) \u2705
- `dotnet tool restore` \u2192 "Tool 'dotnet-ef' (version '10.0.4') was restored" \u2705
- `dotnet build src/ExpertiseApi/ExpertiseApi.csproj` \u2014 0 warnings, 0 errors \u2705
- `hadolint Dockerfile` \u2014 clean (DL3008 + DL3059 ignored with rationale in `.hadolint.yaml`) \u2705
- `markdownlint-cli2 README.md CLAUDE.md` \u2014 0 errors \u2705
- `scripts/validate-pr.sh --title ... --base dev` \u2014 PASS \u2705

## Review

Two-round 3-way fan-out (code-review-expert + docker-expert + dotnet-expert):

- **Round 1** \u2014 aggregate NEEDS_CHANGES. Critical caught by all three reviewers: original Dockerfile edit was silently rolled back (sibling edit failure), so `global.json` and `.config/` were never COPYed into the image, breaking `tool restore` at build time. Also: layer-caching ordering, README step numbering, rollForward semantics (latestFeature \u2192 latestPatch for tighter LTS pin), setup-dotnet input duplication.
- **Round 2** \u2014 aggregate **PASS**. All round-1 items verified closed; no regressions; both stages cache correctly; bundle stage now minimal.

The new ground-truth-source precondition (pi_config PR #63) demonstrably worked \u2014 all three reviewers read the actual Dockerfile and converged on the same Critical from independent angles.

## Deferred (pre-existing, out of scope)

Surfaced by docker-expert; not introduced by this PR:

- Pin base images by digest (currently floating `mcr.microsoft.com/dotnet/sdk:10.0` / `aspnet:10.0`)
- Add OCI labels (`org.opencontainers.image.source`, `.revision`, `.version`)
- Rationalize runtime-stage `curl` install vs. dropping HEALTHCHECK when targeting k8s

Happy to spin these out as separate issues on request.

## Backwards compatibility

- `dotnet` resolves to a 10.0.1xx SDK (any patch \u2265 100). Local 10.0.107 works without change.
- `dotnet ef` calls now require a one-time `dotnet tool restore` (documented in README + CLAUDE.md).
- Docker build path unchanged externally; image contents identical except for the SDK pin influencing build-time dotnet behavior.
- No runtime contract change.