### PR TITLE
feat(ci): sign release artifacts with cosign and publish chart to OCI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,23 @@ jobs:
           name: test-results
           path: test-results/*.trx
           retention-days: 14
+
+  helm-lint:
+    name: Helm lint + render tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+        with:
+          version: v3.18.3
+
+      - name: Helm lint (strict)
+        run: helm lint --strict helm/expertise-api
+
+      - name: Helm render tests
+        run: bash helm/expertise-api/tests/test-render.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,16 +46,16 @@ jobs:
       # infra repo (agent-expertise-api-infra) sets image.tag explicitly via
       # the dispatch payload at deploy time, so appVersion is cosmetic for
       # runtime correctness; the sync exists for `helm list` clarity.
-      - name: Sync Chart.yaml appVersion
+      - name: Sync Chart.yaml version + appVersion
         if: steps.semantic.outputs.new_release_published == 'true'
         env:
           NEW_VERSION: ${{ steps.semantic.outputs.new_release_version }}
         run: |
-          yq -i '.appVersion = strenv(NEW_VERSION)' helm/expertise-api/Chart.yaml
+          yq -i '.version = strenv(NEW_VERSION) | .appVersion = strenv(NEW_VERSION)' helm/expertise-api/Chart.yaml
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add helm/expertise-api/Chart.yaml
-          git commit -m "chore(helm): sync appVersion to ${NEW_VERSION} [skip ci]"
+          git commit -m "chore(helm): sync chart version + appVersion to ${NEW_VERSION} [skip ci]"
           git push
 
   build-and-push:
@@ -66,7 +66,8 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read    # checkout
-      packages: write   # push to GHCR
+      packages: write   # push to GHCR (image + chart OCI artifact)
+      id-token: write   # cosign keyless OIDC signing (Sigstore Fulcio)
 
     steps:
       - name: Checkout
@@ -109,6 +110,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
@@ -118,6 +120,95 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # ---- Supply-chain signing (cosign keyless OIDC) -----------------------
+      # Both the image and the Helm chart OCI artifact are signed by the
+      # workflow's GitHub Actions OIDC token via Sigstore Fulcio. No
+      # long-lived keys to manage; signatures land as adjacent OCI
+      # artifacts (.sig) in GHCR. Verification recipe in README.
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
+
+      - name: Sign Docker image by digest (keyless)
+        env:
+          IMAGES: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        # Sign by digest — NOT by tag. Tags are mutable; digests are not.
+        # COSIGN_EXPERIMENTAL=1 is no longer required on cosign v2; left
+        # unset deliberately.
+        run: |
+          set -euo pipefail
+          # All tags point at the same digest after a single buildx push;
+          # extract the repository name (everything before the first :) from
+          # the first tag and sign once at the digest.
+          repo=$(printf '%s\n' "$IMAGES" | head -n1 | cut -d: -f1)
+          cosign sign --yes "${repo}@${DIGEST}"
+
+      # ---- Helm chart OCI publish + signing ---------------------------------
+      # Publish the chart as an OCI artifact alongside the image, then sign
+      # it with the same keyless OIDC identity. Consumers can install via
+      # `helm install foo oci://ghcr.io/thesemicolon/charts/expertise-api`.
+      - name: Install Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+        with:
+          version: v3.18.3
+
+      - name: Sync chart version + appVersion to release version
+        env:
+          NEW_VERSION: ${{ needs.release.outputs.new-release-version }}
+        # The release job pushed an appVersion update commit to main, but
+        # this job's checkout happened before that push and so still sees
+        # the prior Chart.yaml. Apply the same version (and align chart
+        # version with app version) here so the packaged tarball matches
+        # the released image.
+        run: |
+          set -euo pipefail
+          yq -i '.version = strenv(NEW_VERSION) | .appVersion = strenv(NEW_VERSION)' helm/expertise-api/Chart.yaml
+
+      - name: Resolve lowercase owner for OCI paths
+        id: owner
+        # GHCR (and the OCI distribution spec) require all path components to
+        # be lowercase. ${{ github.repository_owner }} preserves the canonical
+        # GitHub case (e.g. "TheSemicolon"). docker/metadata-action auto-
+        # lowercases the image path, but helm push + cosign sign use raw
+        # string interpolation and would otherwise fail with
+        # "name unknown: repository name must be lowercase".
+        run: |
+          set -euo pipefail
+          lc=$(printf '%s' "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          printf 'lc=%s\n' "$lc" >> "$GITHUB_OUTPUT"
+
+      - name: Helm registry login (GHCR)
+        run: |
+          set -euo pipefail
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Package + push Helm chart to GHCR OCI
+        id: helm-push
+        env:
+          NEW_VERSION: ${{ needs.release.outputs.new-release-version }}
+          OWNER_LC: ${{ steps.owner.outputs.lc }}
+        run: |
+          set -euo pipefail
+          helm package helm/expertise-api --destination dist/
+          # `helm push` prints `Pushed:` and `Digest: sha256:...` to stdout
+          # (cmd/helm/push.go uses cmd.OutOrStdout()); capture both with 2>&1
+          # so the runner log still shows them and the substitution captures
+          # the digest. Sign by digest (immutable), not by tag.
+          chart_tgz="dist/expertise-api-${NEW_VERSION}.tgz"
+          push_out=$(helm push "$chart_tgz" "oci://ghcr.io/${OWNER_LC}/charts" 2>&1 | tee push.log)
+          chart_digest=$(printf '%s\n' "$push_out" | awk '/^Digest: /{print $2}')
+          [ -n "$chart_digest" ] || { echo "failed to parse chart digest from helm push output" >&2; exit 1; }
+          printf 'digest=%s\n' "$chart_digest" >> "$GITHUB_OUTPUT"
+
+      - name: Sign Helm chart artifact (keyless)
+        env:
+          CHART_DIGEST: ${{ steps.helm-push.outputs.digest }}
+          OWNER_LC: ${{ steps.owner.outputs.lc }}
+        run: |
+          set -euo pipefail
+          cosign sign --yes "ghcr.io/${OWNER_LC}/charts/expertise-api@${CHART_DIGEST}"
 
       - name: Dispatch deploy to infra repo
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1

--- a/README.md
+++ b/README.md
@@ -102,6 +102,35 @@ ghcr.io/thesemicolon/agent-expertise-api:v1.2.3          # immutable SemVer tag
 ghcr.io/thesemicolon/agent-expertise-api:1.2             # tracks the latest 1.2.x
 ```
 
+The Helm chart is also published as an OCI artifact on every release:
+
+```bash
+helm install expertise-api oci://ghcr.io/thesemicolon/charts/expertise-api \
+  --version X.Y.Z \
+  --namespace expertise-api --create-namespace \
+  -f my-values.yaml
+```
+
+The chart version equals the application version (e.g. `0.4.2` chart serves the `v0.4.2` image by default).
+
+### Supply-chain verification (cosign keyless OIDC)
+
+Both the image and the chart artifact are signed via Sigstore keyless OIDC (the workflow's GitHub Actions OIDC token, no long-lived keys). Verify before installing:
+
+```bash
+# Verify image
+cosign verify ghcr.io/thesemicolon/agent-expertise-api:vX.Y.Z \
+  --certificate-identity-regexp 'https://github\.com/TheSemicolon/agent-expertise-api/\.github/workflows/release\.yml@refs/heads/main' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+# Verify chart artifact
+cosign verify ghcr.io/thesemicolon/charts/expertise-api:X.Y.Z \
+  --certificate-identity-regexp 'https://github\.com/TheSemicolon/agent-expertise-api/\.github/workflows/release\.yml@refs/heads/main' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+A missing or invalid signature exits non-zero — wire it into your deploy pipeline as a hard gate.
+
 ### Archetype A2: native OS service install (no Docker)
 
 For a single developer who wants the API always-on without the Docker


### PR DESCRIPTION
Closes #128 and #130.

## Summary

Adds Sigstore keyless OIDC signing for both the Docker image and the Helm chart, and publishes the chart as an OCI artifact to GHCR alongside the image on every release.

Combined into one PR because the two changes share infrastructure: the cosign step that signs the chart only makes sense once the chart is being pushed.

## What changed

### `.github/workflows/release.yml`

**Release job:**
- 'Sync Chart.yaml' step now bumps both `.version` and `.appVersion` (was: `.appVersion` only) so the in-repo chart file tracks the published artifact.

**Build-and-push job:**
- New permission: `id-token: write` for Sigstore Fulcio keyless OIDC
- New action: `sigstore/cosign-installer@v3.8.1` (SHA-pinned)
- New step: sign Docker image by digest (`cosign sign --yes ${repo}@${DIGEST}` from `docker/build-push-action` outputs.digest \u2014 multi-platform manifest-list digest, signature covers all per-platform manifests via index resolution)
- New action: `azure/setup-helm@v4.3.0` + Helm v3.18.3
- New step: re-sync Chart.yaml locally (build-and-push checked out before release-job's sync commit landed)
- New step: resolve lowercase `OWNER_LC` for OCI paths (GHCR rejects mixed-case path components per OCI distribution spec; `docker/metadata-action` auto-lowercases the image namespace, but raw string interpolation for helm push + cosign sign needs explicit lowercasing)
- New step: `helm registry login` via `GITHUB_TOKEN`
- New step: `helm package` + `helm push oci://ghcr.io/${OWNER_LC}/charts`; parse `Digest: sha256:...` from `helm push` stdout
- New step: sign chart by digest (`cosign sign --yes ghcr.io/${OWNER_LC}/charts/expertise-api@${CHART_DIGEST}`)

### `.github/workflows/ci.yml`

- New `helm-lint` job (parallel to build-and-test): `helm lint --strict` + the 37-case render-test suite. No `dotnet` dependency; 5-min timeout.

### `README.md`

- Helm OCI install recipe under Deployment (`helm install expertise-api oci://ghcr.io/thesemicolon/charts/expertise-api --version X.Y.Z`)
- 'Supply-chain verification' subsection with cosign verify recipes for both the image and the chart artifact, using `--certificate-identity-regexp` pinned to the release.yml workflow path on `refs/heads/main`

## Validation

- YAML syntactically valid (Python parse)
- Markdownlint clean
- Local helm package smoke-test succeeds
- `scripts/validate-pr.sh` PASS

## Review

**Two-round 3-way fan-out** (code-review-expert + docker-expert + linter) with the new ground-truth precondition (pi_config #62, live):

- **Round 1** \u2014 aggregate NEEDS_CHANGES. One HIGH caught by docker-expert: `${{ github.repository_owner }}` returns `TheSemicolon` (mixed case) which GHCR rejects for `helm push` and `cosign sign` (the image push only worked by accident because docker/metadata-action lowercases). Code-review-expert caught a hygiene Warning: chart `.version` in repo never bumped. Linter caught a line-length warning.
- **Round 2** \u2014 aggregate **PASS**. All three closed: lowercase-owner step added, both fields bumped in repo + at package time, long line split.

The new precondition demonstrably worked: docker-expert read the actual workflow file and found the mixed-case bug by reasoning from the OCI distribution spec, not from memory.

## Deferred (out of scope)

Surfaced by docker-expert as MED/LOW; not blocking:

- **SBOM + SLSA provenance attestations** \u2014 `provenance: mode=max` and `sbom: true` on `docker/build-push-action` would auto-generate SLSA provenance + SPDX attestations as OCI referrers. Cosign can then sign them as a bundle. Low-friction follow-up.
- **Maintenance-branch verification regex** \u2014 if maintenance releases land from `release/X.Y` branches, broaden the cert-identity-regexp from `@refs/heads/main` to `@refs/heads/(main|release/.+)$`. Today main is the only release branch.
- **Cosign tlog (Rekor) publication is public** \u2014 `cosign sign --yes` writes to the public transparency log. Fine for this public repo; document if the repo ever flips to private.
- **`actionlint` not run locally** (not installed). CI's GitHub-Actions-native validation will catch any issues on PR.

## Backwards compatibility

- No effect on PR or push-to-dev CI (release.yml fires only on push to main)
- First release after merge produces signed image + signed chart at the new OCI path
- Existing `helm install ./helm/expertise-api` (in-tree path) still works \u2014 OCI publish is additive
- No new secrets required \u2014 cosign uses the existing OIDC token surface; `helm push` uses `GITHUB_TOKEN` already in scope