### PR TITLE
fix(host): bump HostOptions.ShutdownTimeout to 30s and align service templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,14 @@ as a native OS service:
 - **Windows**: Windows Service via `sc.exe` with Virtual Account
   `NT SERVICE\expertise-api`, failure recovery 5s/5s/30s
 
+**Graceful stop budgets** (#142): the host configures
+`HostOptions.ShutdownTimeout = 30s` to drain in-flight HTTP, close the
+Npgsql pool, and dispose the ONNX session before the service manager
+escalates to SIGKILL. The systemd unit (`TimeoutStopSec=45`) and the launchd
+plist (`ExitTimeOut=45`) add a 15s OS-level margin on top — stop the service
+and the .NET host has 30s to drain, after which systemd/launchd will fire
+SIGKILL at the 45s mark.
+
 Quick start (macOS / Linux / WSL):
 
 ```bash

--- a/scripts/service-templates/expertise-api.plist.tmpl
+++ b/scripts/service-templates/expertise-api.plist.tmpl
@@ -27,6 +27,13 @@
   <key>ThrottleInterval</key>
   <integer>10</integer>
 
+  <!-- Stop budget. Must exceed HostOptions.ShutdownTimeout (30s) configured
+       in src/ExpertiseApi/Program.cs. launchd default is 20s, which would
+       SIGKILL the .NET host mid-drain under load. 45s = 30s app drain + 15s
+       OS-level dispose / log flush. See #142. -->
+  <key>ExitTimeOut</key>
+  <integer>45</integer>
+
   <key>ProcessType</key>
   <string>Interactive</string>
 

--- a/scripts/service-templates/expertise-api.service.tmpl
+++ b/scripts/service-templates/expertise-api.service.tmpl
@@ -17,6 +17,11 @@ RestartSec=10
 StartLimitIntervalSec=60
 StartLimitBurst=5
 
+# Stop budget. Must exceed HostOptions.ShutdownTimeout (30s) configured in
+# src/ExpertiseApi/Program.cs. systemd sends SIGTERM, waits this long, then
+# SIGKILL. 45s = 30s app drain + 15s OS-level dispose / log flush. See #142.
+TimeoutStopSec=45
+
 # Environment file (optional — install.sh creates a chmod-600 stub)
 EnvironmentFile=-@@SECRETS_FILE@@
 

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -8,6 +8,7 @@ using ExpertiseApi.Endpoints;
 using ExpertiseApi.Services;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
 using Microsoft.SemanticKernel;
 using Prometheus;
 using Serilog;
@@ -33,6 +34,22 @@ builder.Host.UseWindowsService(options => options.ServiceName = "ExpertiseApi");
 builder.Host.UseSerilog((context, services, config) =>
     config.ReadFrom.Configuration(context.Configuration)
           .ReadFrom.Services(services));
+
+// Default HostOptions.ShutdownTimeout is 5s — insufficient under load to drain
+// in-flight HTTP requests, close the Npgsql connection pool, and dispose the
+// ONNX inference session before systemd / launchd / SCM escalates to SIGKILL.
+// 30s matches the explicit TimeoutStopSec=45 / ExitTimeOut=45 budgets in the
+// service templates under scripts/service-templates/ (issue #142).
+//
+// MUST be registered AFTER UseSystemd() / UseWindowsService() above: the
+// Windows lifetime internally registers an IConfigureOptions<HostOptions>
+// that overwrites ShutdownTimeout with the SCM-reported stop timeout (~20s),
+// and DI options-pattern resolution honours last-writer-wins. Moving this
+// block above those lines will silently regress the Windows service path.
+builder.Services.Configure<HostOptions>(options =>
+{
+    options.ShutdownTimeout = TimeSpan.FromSeconds(30);
+});
 
 builder.Services.AddOpenApi();
 builder.Services.AddProblemDetails();

--- a/tests/ExpertiseApi.Tests/Unit/HostOptionsConfigurationTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/HostOptionsConfigurationTests.cs
@@ -1,0 +1,26 @@
+using ExpertiseApi.Tests.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace ExpertiseApi.Tests.Unit;
+
+public class HostOptionsConfigurationTests
+{
+    [Fact]
+    public void HostOptions_ShutdownTimeout_Is30Seconds()
+    {
+        // Regression guard for #142. The default 5s is insufficient under load
+        // to drain in-flight HTTP, close the Npgsql pool, and dispose the ONNX
+        // inference session before systemd / launchd / SCM escalates to SIGKILL.
+        //
+        // ApiFactory is reused so the IEmbeddingGenerator mock and DbContext
+        // override are in place, but no endpoint is invoked — the DbContext is
+        // never resolved, so the stub connection string never opens a socket.
+        // This avoids the Testcontainers / Docker dependency for a DI-only test.
+        using var factory = new ApiFactory(
+            "Host=127.0.0.1;Port=1;Database=stub;Username=stub;Password=stub");
+        var options = factory.Services.GetRequiredService<IOptions<HostOptions>>().Value;
+        options.ShutdownTimeout.Should().Be(TimeSpan.FromSeconds(30));
+    }
+}


### PR DESCRIPTION
Closes #142.

First of 6 PRs implementing the Phase-1 A2 Tier-1 plan (issues #140–#145).

## Summary

Raise `HostOptions.ShutdownTimeout` from the 5s default to 30s, and align
the systemd / launchd / SCM stop budgets so the service manager allows the
.NET host to finish draining before escalating to SIGKILL.

| Surface | Was | Now | Note |
|---|---|---|---|
| `HostOptions.ShutdownTimeout` | 5s (.NET default) | **30s** | App-side drain budget. |
| systemd `TimeoutStopSec` | unset → 90s default | **45s** | 30s + 15s OS margin. *Tightens* the implicit default — intentional, surfaces failures faster and matches the launchd budget. |
| launchd `ExitTimeOut` | unset → 20s default | **45s** | 30s + 15s OS margin. Closes the 20s-default gap that would SIGKILL mid-drain. |
| Windows `sc.exe` stop | inherits `HostOptions` | inherits **30s** | SCM stop timeout honours `HostOptions.ShutdownTimeout` via `UseWindowsService`. |

## Why

Per #142: under sustained load the 5s budget is insufficient to (a) drain
in-flight HTTP, (b) close the Npgsql connection pool, (c) dispose the ONNX
inference session. Service managers escalate to SIGKILL, producing dirty
shutdowns visible as `Stop-Process` warnings on Windows, `bus error` /
`SIGKILL` in journald on Linux, and hung launchctl bootouts on macOS.

## Decision points resolved from the Phase-1 plan

- **D1 (launchd ExitTimeOut explicit):** applied — set to 45s. Issue body said
  "leave (default ample)" but launchd's actual default is 20s; the bracketed
  assumption was wrong. Setting it explicitly satisfies T3 AC#2
  (`apictl stop < 35s under load`).

## Tests

- `tests/ExpertiseApi.Tests/Unit/HostOptionsConfigurationTests.cs` — DI-only
  regression guard. Reuses `ApiFactory` with a stub connection string so the
  test does **not** require Docker / Testcontainers; the `DbContext` is never
  resolved, no socket opens.
- Verified locally: `dotnet test --filter Unit` — **87/87 pass** (1 new).
- Build clean with no warnings.
- Operator validation (out of CI scope per #142 ACs): `systemctl stop` under
  load — clean exit, no SIGKILL in journal; `expertise-apictl stop` on macOS
  returns within 35s.

## Pre-merge review trail

Routed through `/review` (code-review-expert + security-review-expert + linter).
- **code-review:** PASS_WITH_WARNINGS — addressed: ordering-note comment added
  to Program.cs; README operational note added (issue scope #3);
  `TimeoutStopSec` deviation called out above (this PR body).
- **security-review:** PASS — no new attack surface. Longer drain window is
  bounded by the 45s OS-level cap; Kestrel stops accepting new connections at
  drain start.
- **linter:** PASS — `dotnet format`, `plutil -lint`, manual systemd-unit
  inspection all clean.

## Phase-1 plan sequence

This is PR 1/6:

| # | Issue(s) | Status |
|---|---|---|
| **1** | #142 (this PR) | ← |
| 2 | #143 (HealthChecks live/ready + Helm probes) | pending |
| 3 | #144 (.NET `migrate` CLI verb) | pending |
| 4 | #141 (macOS `expertise-apictl restart` race fix) | pending |
| 5 | #140 + #144 install-side (Windows DLL lock + migrate wiring) | pending |
| 6 | #145 (headless-boot survival) | pending |
