### PR TITLE
feat(api): implement /health/live + /health/ready with DB, ONNX, migration checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,13 @@ flowchart LR
 | GET | `/expertise/search?q=` | Keyword full-text search (tsvector, Approved only) |
 | GET | `/expertise/search/semantic?q=` | Semantic vector search (pgvector, Approved only) |
 | GET | `/audit` | Cross-tenant audit log (cursor-paginated, requires `expertise.admin`) |
-| GET | `/health` | Liveness probe (no auth required) |
+| GET | `/health/live` | Liveness — 200 while the process responds; no dependency checks. Map this to k8s `livenessProbe` and `systemd WatchdogSec=`. No auth. |
+| GET | `/health/ready` | Readiness — 200 only when DB, ONNX model, and pending-migration checks are all healthy; 503 otherwise. Map this to k8s `readinessProbe` and load-balancer health checks. No auth. |
+| GET | `/health` | Back-compat alias for `/health/ready`. No auth. |
 | GET | `/metrics` | Prometheus scrape endpoint (no auth required) |
 | GET | `/query` | Interactive query page (read-only, no auth to load) |
 
-All endpoints except `/health`, `/query`, and `/metrics` require `Authorization: Bearer <token>` — a JWT (`Auth:Mode = Oidc`) or, in Development, an API key or LocalDev token (`Auth:Mode = Hybrid`). See [SKILL.md](.claude/skills/expertise-api-design/SKILL.md) for scopes, modes, and configuration.
+All endpoints except `/health`, `/health/live`, `/health/ready`, `/query`, and `/metrics` require `Authorization: Bearer <token>` — a JWT (`Auth:Mode = Oidc`) or, in Development, an API key or LocalDev token (`Auth:Mode = Hybrid`). See [SKILL.md](.claude/skills/expertise-api-design/SKILL.md) for scopes, modes, and configuration.
 
 ## Quick Start
 

--- a/helm/expertise-api/templates/deployment.yaml
+++ b/helm/expertise-api/templates/deployment.yaml
@@ -97,19 +97,19 @@ spec:
               mountPath: /tmp
           startupProbe:
             httpGet:
-              path: /health
+              path: /health/ready
               port: {{ .Values.service.targetPort }}
             failureThreshold: 30
             periodSeconds: 5
           livenessProbe:
             httpGet:
-              path: /health
+              path: /health/live
               port: {{ .Values.service.targetPort }}
             periodSeconds: 30
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /health
+              path: /health/ready
               port: {{ .Values.service.targetPort }}
             periodSeconds: 10
             failureThreshold: 3

--- a/helm/expertise-api/tests/test-render.sh
+++ b/helm/expertise-api/tests/test-render.sh
@@ -385,6 +385,29 @@ else
     ok "netpol-external-nil-deref" "NetworkPolicy renders cleanly when external is unset (no nil-deref)"
 fi
 
+# 38. Deployment probes: liveness uses /health/live (issue #143, T4).
+output=$(helm template test-release "$CHART" 2>&1)
+if echo "$output" | awk '/livenessProbe:/,/readinessProbe:/' | grep -qE 'path:[[:space:]]*/health/live'; then
+    ok "probe-liveness-path" "livenessProbe.httpGet.path = /health/live"
+else
+    err "probe-liveness-path" "livenessProbe.httpGet.path did not render as /health/live"
+fi
+
+# 39. Deployment probes: readiness uses /health/ready (issue #143, T4).
+if echo "$output" | awk '/readinessProbe:/,/^      volumes:/' | grep -qE 'path:[[:space:]]*/health/ready'; then
+    ok "probe-readiness-path" "readinessProbe.httpGet.path = /health/ready"
+else
+    err "probe-readiness-path" "readinessProbe.httpGet.path did not render as /health/ready"
+fi
+
+# 40. Deployment probes: startup uses /health/ready so the pod isn't declared
+# started until DB, ONNX, and migration checks all pass (issue #143, T4).
+if echo "$output" | awk '/startupProbe:/,/livenessProbe:/' | grep -qE 'path:[[:space:]]*/health/ready'; then
+    ok "probe-startup-path" "startupProbe.httpGet.path = /health/ready"
+else
+    err "probe-startup-path" "startupProbe.httpGet.path did not render as /health/ready"
+fi
+
 echo "=================================="
 if [ "$ERRORS" -eq 0 ]; then
     echo "PASS — 0 errors, $WARNINGS warning(s)"

--- a/src/ExpertiseApi/Endpoints/HealthEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/HealthEndpoints.cs
@@ -1,10 +1,84 @@
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
 namespace ExpertiseApi.Endpoints;
 
 internal static class HealthEndpoints
 {
+    /// <summary>
+    /// Status-only plaintext writer. Mirrors the framework's default behavior
+    /// (<c>HealthCheckResponseWriters.WriteMinimalPlaintext</c>, which is
+    /// internal and so cannot be referenced directly) but is defined here
+    /// explicitly so any future maintainer must consciously replace it before
+    /// any per-check descriptions can reach the wire. The descriptions in
+    /// <see cref="ExpertiseApi.Services.Health.OnnxModelHealthCheck"/>
+    /// (absolute filesystem path) and <see cref="ExpertiseApi.Services.Health.PendingMigrationHealthCheck"/>
+    /// (EF migration class names + exception messages) are operator-facing
+    /// diagnostics and must not be exposed on the unauthenticated /health/*
+    /// endpoints.
+    /// </summary>
+    private static Task WriteStatusOnlyPlainText(HttpContext context, HealthReport report)
+    {
+        context.Response.ContentType = "text/plain";
+        return context.Response.WriteAsync(report.Status.ToString());
+    }
+    /// <summary>
+    /// Wires the three health endpoints required by Phase-1 A2 (issue #143):
+    ///   /health/live  — liveness: 200 while the process responds. Predicate
+    ///                   matches no checks so the response is independent of
+    ///                   downstream dependencies. systemd <c>WatchdogSec=</c>
+    ///                   and k8s livenessProbe should point here.
+    ///   /health/ready — readiness: aggregates every check tagged "ready"
+    ///                   (DB ping via AddDbContextCheck, ONNX model presence,
+    ///                   pending migrations). 503 on Unhealthy or Degraded.
+    ///                   k8s readinessProbe and load-balancer health checks
+    ///                   should point here.
+    ///   /health       — back-compat alias for /health/ready. Pre-existing
+    ///                   probes / monitors continue to work without
+    ///                   coordinated cutover.
+    /// </summary>
     public static void MapHealthEndpoints(this WebApplication app)
     {
-        app.MapGet("/health", () => Results.Ok(new { status = "healthy" }))
+        // Pin the response writer to a status-only plaintext format. The
+        // descriptions emitted by OnnxModelHealthCheck (absolute filesystem path)
+        // and PendingMigrationHealthCheck (migration class names, EF exception)
+        // are operator-facing diagnostics and must never reach the wire on
+        // these unauthenticated endpoints. See WriteStatusOnlyPlainText doc.
+        var liveOptions = new HealthCheckOptions
+        {
+            Predicate = static _ => false,
+            ResponseWriter = WriteStatusOnlyPlainText,
+        };
+
+        // Override the framework default ResultStatusCodes mapping so
+        // HealthStatus.Degraded surfaces as 503 on /health/ready, not the
+        // default 200. PendingMigrationHealthCheck reports Degraded for
+        // unapplied migrations — if Degraded mapped to 200 here, k8s
+        // readinessProbe and the LB health check would route traffic to a
+        // pod whose schema is behind, violating issue #143 acceptance.
+        // See https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks#customize-output
+        var readyOptions = new HealthCheckOptions
+        {
+            Predicate = static check => check.Tags.Contains("ready"),
+            ResponseWriter = WriteStatusOnlyPlainText,
+            ResultStatusCodes =
+            {
+                [HealthStatus.Healthy] = StatusCodes.Status200OK,
+                [HealthStatus.Degraded] = StatusCodes.Status503ServiceUnavailable,
+                [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable,
+            },
+        };
+
+        app.MapHealthChecks("/health/live", liveOptions)
+            .WithTags("Health")
+            .AllowAnonymous();
+
+        app.MapHealthChecks("/health/ready", readyOptions)
+            .WithTags("Health")
+            .AllowAnonymous();
+
+        app.MapHealthChecks("/health", readyOptions)
             .WithTags("Health")
             .AllowAnonymous();
     }

--- a/src/ExpertiseApi/ExpertiseApi.csproj
+++ b/src/ExpertiseApi/ExpertiseApi.csproj
@@ -25,6 +25,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.0" />
     <!--
       Service-host integration. Both packages are no-ops outside their host
       environment (SystemdHelpers.IsSystemdService / WindowsServiceHelpers.IsWindowsService),

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -64,6 +64,29 @@ builder.Services.AddDbContext<ExpertiseDbContext>(options =>
         builder.Configuration.GetConnectionString("DefaultConnection"),
         o => o.UseVector()));
 
+// Health checks (issue #143). All readiness signals carry the "ready" tag so
+// HealthEndpoints.MapHealthEndpoints can filter /health/ready to dependency
+// checks while keeping /health/live as a tag-free liveness signal.
+//   - AddDbContextCheck: pings the configured Npgsql connection. Cheaper than
+//     AddNpgSql and avoids an extra DI service registration; failure mode is
+//     ~connection-timeout-bounded (Npgsql default 15s, suitable for readiness).
+//   - OnnxModelHealthCheck: model/vocab file presence + DI resolution.
+//   - PendingMigrationHealthCheck: HealthStatus.Degraded when EF Core reports
+//     unapplied migrations. The framework default maps Degraded → 200 OK; the
+//     readyOptions registration in HealthEndpoints.cs explicitly overrides
+//     ResultStatusCodes so Degraded surfaces as 503.
+string[] readyTag = ["ready"];
+builder.Services.AddHealthChecks()
+    .AddDbContextCheck<ExpertiseDbContext>(
+        name: "db",
+        tags: readyTag)
+    .AddCheck<ExpertiseApi.Services.Health.OnnxModelHealthCheck>(
+        name: "onnx",
+        tags: readyTag)
+    .AddCheck<ExpertiseApi.Services.Health.PendingMigrationHealthCheck>(
+        name: "migrations",
+        tags: readyTag);
+
 builder.Services.AddScoped<IExpertiseRepository, ExpertiseRepository>();
 builder.Services.AddScoped<ITenantContextAccessor, HttpTenantContextAccessor>();
 builder.Services.AddExpertiseAuth(builder.Configuration, builder.Environment);

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -70,7 +70,10 @@ builder.Services.AddDbContext<ExpertiseDbContext>(options =>
 //   - AddDbContextCheck: pings the configured Npgsql connection. Cheaper than
 //     AddNpgSql and avoids an extra DI service registration; failure mode is
 //     ~connection-timeout-bounded (Npgsql default 15s, suitable for readiness).
-//   - OnnxModelHealthCheck: model/vocab file presence + DI resolution.
+//   - OnnxModelHealthCheck: DI resolvability of IEmbeddingGenerator (proxy for
+//     "model/vocab files were present at startup"; the SemanticKernel
+//     registration is conditional on File.Exists and loads the model eagerly,
+//     so DI resolution is the meaningful observable at probe time).
 //   - PendingMigrationHealthCheck: HealthStatus.Degraded when EF Core reports
 //     unapplied migrations. The framework default maps Degraded → 200 OK; the
 //     readyOptions registration in HealthEndpoints.cs explicitly overrides

--- a/src/ExpertiseApi/Services/Health/OnnxModelHealthCheck.cs
+++ b/src/ExpertiseApi/Services/Health/OnnxModelHealthCheck.cs
@@ -1,0 +1,54 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace ExpertiseApi.Services.Health;
+
+/// <summary>
+/// Reports unhealthy when the ONNX embedding stack cannot serve a request.
+///
+/// Observable signal: whether <see cref="IEmbeddingGenerator{TInput,TEmbedding}"/>
+/// is registered in DI. Program.cs registers it conditionally
+/// (<c>if (File.Exists(modelPath) &amp;&amp; File.Exists(vocabPath))</c>) and
+/// <c>AddBertOnnxEmbeddingGenerator</c> opens the model file eagerly at
+/// registration time. The two consequences are:
+///
+///   * Files missing at startup ⇒ service never registered ⇒ this check
+///     returns <see cref="HealthStatus.Unhealthy"/>.
+///   * Files corrupt at startup ⇒ registration throws ⇒ Program.cs fails to
+///     boot at all, so this check is never reached. The "files corrupt mid-run"
+///     case cannot affect the loaded session (held in the singleton generator),
+///     so a probe-time file re-stat would be misleading rather than useful.
+///
+/// File-path probing is therefore intentionally NOT performed here: DI
+/// resolvability is the actual proxy for "embedding stack can serve a request".
+/// Filesystem-level diagnostics for an absent install belong in the install
+/// scripts under scripts/install.sh, not in a per-request health probe.
+/// </summary>
+internal sealed class OnnxModelHealthCheck : IHealthCheck
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public OnnxModelHealthCheck(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        // Resolve the generator from DI rather than holding a constructor reference:
+        // the service is registered conditionally in Program.cs (only when both
+        // files exist at startup), so a constructor-injected dependency would
+        // crash the entire check pipeline at activation when the model is absent.
+        var generator = _serviceProvider.GetService<IEmbeddingGenerator<string, Embedding<float>>>();
+        if (generator is null)
+        {
+            return Task.FromResult(HealthCheckResult.Unhealthy(
+                "ONNX embedding generator not registered (model/vocab files were absent at startup)."));
+        }
+
+        return Task.FromResult(HealthCheckResult.Healthy(
+            "ONNX embedding generator resolved."));
+    }
+}

--- a/src/ExpertiseApi/Services/Health/PendingMigrationHealthCheck.cs
+++ b/src/ExpertiseApi/Services/Health/PendingMigrationHealthCheck.cs
@@ -1,0 +1,75 @@
+using ExpertiseApi.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace ExpertiseApi.Services.Health;
+
+/// <summary>
+/// Reports <see cref="HealthStatus.Degraded"/> when EF Core has pending migrations.
+///
+/// Degraded — not Unhealthy — because:
+///   * The app process is functional; queries against tables that exist will succeed.
+///   * The operator's action is to run `expertise-api migrate` (Tier-1 issue #144).
+///
+/// The ASP.NET Core framework default maps <c>Degraded → 200 OK</c>; that default
+/// is explicitly overridden in <c>HealthEndpoints.MapHealthEndpoints</c> so /ready
+/// returns 503 on Degraded, giving k8s readiness / SCM start-orchestration the
+/// same observable signal as Unhealthy without muddling the diagnostic meaning
+/// of the two states. If this check is ever wired into a new endpoint, the
+/// caller must apply the same ResultStatusCodes override or the Degraded state
+/// will be silently swallowed.
+///
+/// Surfaced separately from <c>AddDbContextCheck</c> (which only proves the
+/// server is reachable) because a reachable-but-out-of-date schema is a
+/// distinct operational state from "DB down".
+/// </summary>
+internal sealed class PendingMigrationHealthCheck : IHealthCheck
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    public PendingMigrationHealthCheck(IServiceScopeFactory scopeFactory)
+    {
+        _scopeFactory = scopeFactory;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        // DbContext is scoped; resolving via IServiceScopeFactory creates a
+        // throwaway scope per probe invocation so we don't pin a connection
+        // for the lifetime of the singleton check instance. `await using`
+        // honours IAsyncDisposable on the scope so any async-disposable
+        // scoped services (including DbContext) tear down asynchronously.
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+
+        IEnumerable<string> pending;
+        try
+        {
+            pending = await db.Database.GetPendingMigrationsAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // Health check must classify, not crash, on any DB error
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            // DB unreachable / __EFMigrationsHistory missing — surface as Unhealthy so
+            // the operator distinguishes "can't tell" from "behind schema". The
+            // DbContext check will likely also be Unhealthy in this case, providing
+            // a corroborating signal.
+            return HealthCheckResult.Unhealthy(
+                "Unable to query pending migrations (DB unreachable or migration history missing).",
+                ex);
+        }
+
+        var pendingList = pending.ToList();
+        if (pendingList.Count == 0)
+        {
+            return HealthCheckResult.Healthy("Schema is up to date.");
+        }
+
+        return HealthCheckResult.Degraded(
+            $"{pendingList.Count} pending migration(s): {string.Join(", ", pendingList)}");
+    }
+}

--- a/tests/ExpertiseApi.Tests/Infrastructure/SequentialApiFactoryCollection.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/SequentialApiFactoryCollection.cs
@@ -1,0 +1,23 @@
+namespace ExpertiseApi.Tests.Infrastructure;
+
+/// <summary>
+/// xUnit collection for tests that instantiate <see cref="ApiFactory"/> WITHOUT
+/// the Postgres testcontainer fixture (i.e., DI-only tests with stub connection
+/// strings). Each ApiFactory instance triggers Program.cs to call
+/// <c>Log.Logger = new LoggerConfiguration()…CreateBootstrapLogger()</c>,
+/// which Serilog rejects with "The logger is already frozen" when multiple
+/// instances initialise concurrently in the same test process.
+///
+/// xUnit runs distinct test classes in parallel by default; placing every
+/// ApiFactory-instantiating non-Postgres test class in this collection
+/// disables intra-collection parallelism (via DisableParallelization=true)
+/// AND prevents concurrent execution with tests in any OTHER collection that
+/// also has DisableParallelization set. Tests in unrelated, parallel-enabled
+/// collections (incl. <c>Postgres</c>, which serialises only within itself
+/// via ICollectionFixture coordination of the shared PostgresFixture) can
+/// still run in parallel with this collection — the bootstrap-logger race
+/// only matters between non-Postgres ApiFactory-instantiating tests, all of
+/// which live here.
+/// </summary>
+[CollectionDefinition("SequentialApiFactory", DisableParallelization = true)]
+public sealed class SequentialApiFactoryCollection { }

--- a/tests/ExpertiseApi.Tests/Integration/HealthEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/HealthEndpointTests.cs
@@ -1,9 +1,15 @@
 using System.Net;
-using System.Net.Http.Json;
 using ExpertiseApi.Tests.Infrastructure;
 
 namespace ExpertiseApi.Tests.Integration;
 
+/// <summary>
+/// Postgres-backed integration coverage for the live/ready endpoint split
+/// introduced in issue #143 / T4. Unit-level shape regressions live in
+/// <c>tests/Unit/HealthEndpointTests.cs</c>; this class exercises the happy
+/// path against a real Postgres so we cover the <c>AddDbContextCheck</c>
+/// success branch that the unit suite (stub conn string) cannot.
+/// </summary>
 [Collection("Postgres")]
 public class HealthEndpointTests : IAsyncLifetime
 {
@@ -21,15 +27,34 @@ public class HealthEndpointTests : IAsyncLifetime
     public async Task DisposeAsync() => await _factory.DisposeAsync();
 
     [Fact]
-    public async Task Health_ReturnsHealthyStatus()
+    public async Task HealthLive_Returns200_WithHealthyStack()
     {
         var client = _factory.CreateClient();
-        var response = await client.GetAsync("/health");
-
+        var response = await client.GetAsync(new Uri("/health/live", UriKind.Relative));
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
 
-        var body = await response.Content.ReadJsonAsync<Dictionary<string, string>>();
-        body.Should().ContainKey("status");
-        body!["status"].Should().Be("healthy");
+    [Fact]
+    public async Task HealthReady_Returns200_WithHealthyStack()
+    {
+        // PostgresFixture seeds the schema via EnsureCreated/migrations before
+        // the API factory boots, so all three "ready" checks (db, onnx mock,
+        // migrations) report Healthy and /health/ready returns 200.
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync(new Uri("/health/ready", UriKind.Relative));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task HealthRoot_AliasReturnsSameStatusAsReady()
+    {
+        // /health is the back-compat alias for /health/ready. Pre-existing
+        // probes / monitors must observe identical semantics after the cutover
+        // (issue #143 acceptance criteria).
+        var client = _factory.CreateClient();
+        var rootResponse = await client.GetAsync(new Uri("/health", UriKind.Relative));
+        var readyResponse = await client.GetAsync(new Uri("/health/ready", UriKind.Relative));
+        rootResponse.StatusCode.Should().Be(readyResponse.StatusCode);
+        rootResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 }

--- a/tests/ExpertiseApi.Tests/Unit/HealthEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/HealthEndpointTests.cs
@@ -1,0 +1,111 @@
+using ExpertiseApi.Tests.Infrastructure;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System.Net;
+
+namespace ExpertiseApi.Tests.Unit;
+
+/// <summary>
+/// Endpoint-shape regression tests for the /health/live, /health/ready, and /health
+/// (back-compat alias) endpoints introduced in issue #143 / T4.
+///
+/// Uses <see cref="ApiFactory"/> with a deliberately bad Postgres connection
+/// string so AddDbContextCheck fails fast, exercising the 503 path on /ready
+/// without requiring Testcontainers / Docker. /live must remain 200 because
+/// its HealthCheckOptions.Predicate matches no checks at all.
+/// </summary>
+[Collection("SequentialApiFactory")]
+public class HealthEndpointTests
+{
+    // Port 1 is reserved (TCPMUX) and not bound on any sane host, so Npgsql's
+    // initial TCP connect fails immediately rather than waiting for the default
+    // 15s connect timeout. Keeps the test under a second.
+    private const string UnreachableConnectionString =
+        "Host=127.0.0.1;Port=1;Database=stub;Username=stub;Password=stub;Timeout=2;Command Timeout=2";
+
+    [Fact]
+    public async Task HealthLive_Returns200_EvenWithBrokenDependencies()
+    {
+        // /health/live is liveness-only: Predicate matches zero checks, so the
+        // response is independent of DB, ONNX model, and migration state.
+        // systemd WatchdogSec= and k8s livenessProbe rely on this contract.
+        using var factory = new ApiFactory(UnreachableConnectionString);
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync(new Uri("/health/live", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task HealthReady_Returns503_WhenDbUnreachable()
+    {
+        // /health/ready aggregates every check tagged "ready". With an
+        // unreachable Postgres, AddDbContextCheck reports Unhealthy, which the
+        // default HealthCheckOptions translates to 503. k8s readinessProbe
+        // observes this and removes the pod from Service endpoints.
+        using var factory = new ApiFactory(UnreachableConnectionString);
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync(new Uri("/health/ready", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+    }
+
+    [Fact]
+    public async Task HealthRoot_IsAliasFor_HealthReady()
+    {
+        // /health is the back-compat alias for /health/ready. Pre-existing
+        // probes / monitors must observe identical semantics after the cutover
+        // so no coordinated rollout is required (issue #143 acceptance).
+        using var factory = new ApiFactory(UnreachableConnectionString);
+        using var client = factory.CreateClient();
+
+        var rootResponse = await client.GetAsync(new Uri("/health", UriKind.Relative));
+        var readyResponse = await client.GetAsync(new Uri("/health/ready", UriKind.Relative));
+
+        rootResponse.StatusCode.Should().Be(readyResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task HealthReady_Returns503_WhenAnyCheckIsDegraded()
+    {
+        // Issue #143 acceptance: pending migrations → 503 on /health/ready.
+        // PendingMigrationHealthCheck returns HealthStatus.Degraded for that
+        // state, and the ASP.NET Core framework default maps Degraded → 200,
+        // so HealthEndpoints.MapHealthEndpoints overrides ResultStatusCodes
+        // to surface Degraded as 503. This test registers an additional
+        // always-Degraded health check (tagged "ready") to exercise the
+        // Degraded → 503 path independently of the real migration check,
+        // which requires a reachable DB with a populated migration table.
+        //
+        // Without the ResultStatusCodes override in HealthEndpoints.cs this
+        // test asserts 200 instead of 503; that is the regression guard.
+        using var factory = new ApiFactory("Host=127.0.0.1;Port=5432;Database=stub;Username=stub;Password=stub")
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureServices(services =>
+                {
+                    services.AddHealthChecks().AddCheck(
+                        "always-degraded-stub",
+                        new AlwaysDegradedCheck(),
+                        failureStatus: HealthStatus.Degraded,
+                        tags: ["ready"]);
+                });
+            });
+
+        using var client = factory.CreateClient();
+        var response = await client.GetAsync(new Uri("/health/ready", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+    }
+
+    private sealed class AlwaysDegradedCheck : IHealthCheck
+    {
+        public Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(HealthCheckResult.Degraded("stub: always degraded for routing assertion"));
+    }
+}

--- a/tests/ExpertiseApi.Tests/Unit/HealthEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/HealthEndpointTests.cs
@@ -75,25 +75,33 @@ public class HealthEndpointTests
         // PendingMigrationHealthCheck returns HealthStatus.Degraded for that
         // state, and the ASP.NET Core framework default maps Degraded → 200,
         // so HealthEndpoints.MapHealthEndpoints overrides ResultStatusCodes
-        // to surface Degraded as 503. This test registers an additional
-        // always-Degraded health check (tagged "ready") to exercise the
-        // Degraded → 503 path independently of the real migration check,
-        // which requires a reachable DB with a populated migration table.
+        // to surface Degraded as 503. This test isolates the Degraded → 503
+        // routing by:
+        //   (1) clearing the production health-check registrations (db, onnx,
+        //       migrations) so they cannot mask the assertion — the unit-test
+        //       env has no reachable DB, which would otherwise make the
+        //       AddDbContextCheck return Unhealthy and 503 regardless of the
+        //       ResultStatusCodes override, leaving the override untested.
+        //   (2) registering a single AlwaysDegradedCheck tagged "ready" so the
+        //       aggregate HealthReport.Status is exactly Degraded.
         //
-        // Without the ResultStatusCodes override in HealthEndpoints.cs this
-        // test asserts 200 instead of 503; that is the regression guard.
-        using var factory = new ApiFactory("Host=127.0.0.1;Port=5432;Database=stub;Username=stub;Password=stub")
-            .WithWebHostBuilder(builder =>
+        // With the ResultStatusCodes override in place, the response is 503.
+        // Without it, the framework default maps Degraded → 200 and this test
+        // fails — that is the regression guard.
+        using var outerFactory = new ApiFactory("Host=127.0.0.1;Port=5432;Database=stub;Username=stub;Password=stub");
+        using var factory = outerFactory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
             {
-                builder.ConfigureServices(services =>
-                {
-                    services.AddHealthChecks().AddCheck(
-                        "always-degraded-stub",
-                        new AlwaysDegradedCheck(),
-                        failureStatus: HealthStatus.Degraded,
-                        tags: ["ready"]);
-                });
+                services.Configure<HealthCheckServiceOptions>(options =>
+                    options.Registrations.Clear());
+                services.AddHealthChecks().AddCheck(
+                    "always-degraded-stub",
+                    new AlwaysDegradedCheck(),
+                    failureStatus: HealthStatus.Degraded,
+                    tags: ["ready"]);
             });
+        });
 
         using var client = factory.CreateClient();
         var response = await client.GetAsync(new Uri("/health/ready", UriKind.Relative));

--- a/tests/ExpertiseApi.Tests/Unit/HostOptionsConfigurationTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/HostOptionsConfigurationTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Options;
 
 namespace ExpertiseApi.Tests.Unit;
 
+[Collection("SequentialApiFactory")]
 public class HostOptionsConfigurationTests
 {
     [Fact]


### PR DESCRIPTION
Closes #143.

## Summary

Replaces the static `200 OK`-always `/health` endpoint with three endpoints whose semantics align with ASP.NET Core health-check conventions and Kubernetes / systemd / SCM probe topology.

| Endpoint | Semantics | Map to |
|---|---|---|
| `/health/live` | 200 while process responds; no dependency checks | k8s `livenessProbe`, `systemd WatchdogSec=` |
| `/health/ready` | 503 on Unhealthy or Degraded across DB ping, ONNX DI, pending migrations | k8s `readinessProbe`, LB health checks |
| `/health` | Back-compat alias for `/health/ready` — no coordinated cutover required | (existing probes) |

## Health checks

All tagged `ready`:

- **`AddDbContextCheck<ExpertiseDbContext>`** (`db`) — Npgsql reachability via `CanConnectAsync`. Adds package `Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore 10.0.0`.
- **`OnnxModelHealthCheck`** (`onnx`) — Probes DI resolvability of `IEmbeddingGenerator<string, Embedding<float>>`. Program.cs registers the generator conditionally on `File.Exists`, and `AddBertOnnxEmbeddingGenerator` opens the model file eagerly at registration, so DI resolution is the actual proxy for "embedding stack can serve a request." File-presence probing during steady-state would be misleading since the model is held in-memory by the singleton.
- **`PendingMigrationHealthCheck`** (`migrations`) — Reports `Degraded` when `GetPendingMigrationsAsync` returns non-empty. Uses `IServiceScopeFactory.CreateAsyncScope` so DbContext tears down asynchronously per probe.

## Routing override (acceptance criterion)

ASP.NET Core's framework default maps `HealthStatus.Degraded → 200 OK`, which would silently swallow the pending-migration signal and ship traffic to a pod whose schema is behind. `HealthEndpoints.MapHealthEndpoints` explicitly overrides `ResultStatusCodes`:

```csharp
ResultStatusCodes = {
    [HealthStatus.Healthy]   = StatusCodes.Status200OK,
    [HealthStatus.Degraded]  = StatusCodes.Status503ServiceUnavailable,
    [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable,
}
```

`HealthReady_Returns503_WhenAnyCheckIsDegraded` is the regression guard. It clears the production health-check registrations and registers a single `AlwaysDegradedCheck` stub so the aggregate report is exactly `Degraded`. **Verified empirically**: with the `ResultStatusCodes` block deleted the test reports 200 (failing); with it restored, 503.

## Security

Response writer pinned to a local `WriteStatusOnlyPlainText` static — semantically equivalent to the framework's internal `HealthCheckResponseWriters.WriteMinimalPlaintext` (status name only, plaintext content-type, no description, no exception). Since both `OnnxModelHealthCheck` and `PendingMigrationHealthCheck` carry operator-facing descriptions (DI rationale; migration class names), the writer pin is the wire-level guard. A code-comment forbids verbose-writer swaps without an auth gate.

## Helm

`templates/deployment.yaml` probe paths split: `livenessProbe → /health/live`; `readinessProbe + startupProbe → /health/ready`. Three new probe-path assertions in `helm/expertise-api/tests/test-render.sh`.

## Test coverage

- **`tests/Unit/HealthEndpointTests.cs`** (NEW, 4 tests): `/live=200` with broken deps; `/ready=503` on DB-unreachable; `/ready=503` on `Degraded` (regression guard for the `ResultStatusCodes` override); `/health` alias matches `/health/ready`.
- **`tests/Integration/HealthEndpointTests.cs`** (rewritten, 3 tests): happy-path live/ready/alias over the Postgres testcontainer.
- **`tests/Infrastructure/SequentialApiFactoryCollection.cs`** (NEW): xUnit collection that serialises non-Postgres `ApiFactory` tests to dodge a Serilog "logger is already frozen" race during `CreateBootstrapLogger`.

Local: 92/92 unit tests green (87 baseline + 4 health + 1 HostOptions). Integration tests require Docker — will validate via CI.

## Review

Two rounds of `/review` (3-way parallel: code-review-expert, security-review-expert, linter):

- **Round 1:** code-review found 1 Critical (Degraded mapping bug), 1 Critical (misleading comments), 1 Error (missing test), 3 Warnings, 2 Info. Security review found 1 Info (writer guard), 1 Low (DoS amplification — deferred). Linter clean.
- **Round 2:** code-review caught that the new Degraded-503 test was masked by the also-Unhealthy `db` check; fixed by clearing registrations in the test. Other items confirmed addressed. Plus 2 minor info items (stale comment, factory disposal pattern) — both fixed.
- **Round 3 (this state):** regression-guard verified empirically (test fails with override removed, passes restored). Code+security+lint clean.

## Deferred follow-up

- **Low: DoS amplification on unauthenticated `/health/ready`** — each probe drives 2 DB round-trips (`CanConnectAsync` + `GetPendingMigrationsAsync`). Will file as a separate follow-up issue. Mitigations to consider: output cache, network-allowlist on `/health/*`, or move the migration check to startup-only.

## Verdict tracker

| Round | code-review | security-review | linter |
|---|---|---|---|
| 1 | NEEDS_CHANGES | PASS_WITH_WARNINGS | PASS_WITH_WARNINGS |
| 2 | NEEDS_CHANGES | PASS | PASS |
| 3 (final) | (verified empirically) | (no new surface) | (no new surface) |
