### PR TITLE
fix(api): narrow catch-of-all-exceptions in migrate verb + pending-migration health check

### DIFF
--- a/src/ExpertiseApi/Cli/MigrateCommand.cs
+++ b/src/ExpertiseApi/Cli/MigrateCommand.cs
@@ -1,5 +1,6 @@
 using ExpertiseApi.Data;
 using Microsoft.EntityFrameworkCore;
+using System.Data.Common;
 
 namespace ExpertiseApi.Cli;
 
@@ -63,27 +64,44 @@ internal static class MigrateCommand
             logger.LogInformation("Migrate: applied {Count} migration(s) successfully.", pending.Count);
             return 0;
         }
-#pragma warning disable CA1031 // Do not catch general exception types.
-        // Migrate is an install-pipeline entrypoint whose contract is
-        // "return 0 on success, return 1 on any failure" — install.sh /
-        // install.ps1 inspect the exit code to decide whether to restart the
-        // service. Letting an exception escape would crash the .NET host with
-        // an unwieldy stack trace and bypass the install-script abort branch.
-        // The full exception is logged at Critical for postmortem.
-        catch (Exception ex)
-#pragma warning restore CA1031
+        // Narrowed from `catch (Exception)` to satisfy CodeQL cs/catch-of-all-exceptions
+        // and to align with the safer-by-default posture: process-fatal exceptions
+        // (OutOfMemoryException, AccessViolationException, StackOverflowException)
+        // and OperationCanceledException intentionally propagate. The catch list
+        // below covers every realistic failure of MigrateAsync():
+        //
+        //   * DbException             — base class for Npgsql.PostgresException,
+        //                               Npgsql.NpgsqlException, and any future
+        //                               provider; covers connection-refused,
+        //                               authentication-failed, schema conflict,
+        //                               and timeout.
+        //   * DbUpdateException       — EF Core wraps a DB error during apply.
+        //                               Derives DIRECTLY from System.Exception
+        //                               (NOT from InvalidOperationException);
+        //                               listed explicitly because no other arm
+        //                               subsumes it. Do not prune. Reference:
+        //                               https://learn.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.dbupdateexception
+        //   * InvalidOperationException — EF/DI configuration errors
+        //                               ("No database provider has been configured",
+        //                               "The 'X' service is not registered", ...).
+        //
+        // Install-pipeline contract is preserved: any of these returns 1 so
+        // install.sh / install.ps1 abort the install before service restart.
+        //
+        // Connection-string leakage: Npgsql's NpgsqlConnectionStringBuilder marks
+        // Password with [PasswordPropertyText] and redacts it when any
+        // NpgsqlException serializes the conn string into its Message. This
+        // relies on the Npgsql data-source builder NOT having
+        // `IncludeErrorDetail=true` set (which would surface raw parameter
+        // values from failing SQL). Program.cs does not set that flag; do not
+        // enable it without re-evaluating this log path.
+        catch (Exception ex) when (ex is DbException
+                                      or DbUpdateException
+                                      or InvalidOperationException)
         {
             // Single LogCritical entry: the exception parameter carries Type +
             // Message + StackTrace, so a separate LogError would just duplicate
             // the headline.
-            //
-            // Connection-string leakage: Npgsql's NpgsqlConnectionStringBuilder
-            // marks Password with [PasswordPropertyText] and redacts it when
-            // any NpgsqlException serializes the conn string into its Message.
-            // This relies on the Npgsql data-source builder NOT having
-            // `IncludeErrorDetail=true` set (which would surface raw parameter
-            // values from failing SQL). Program.cs does not set that flag;
-            // do not enable it without re-evaluating this log path.
             logger.LogCritical(ex, "Migrate: failed (full exception detail follows).");
             return 1;
         }

--- a/src/ExpertiseApi/Services/Health/PendingMigrationHealthCheck.cs
+++ b/src/ExpertiseApi/Services/Health/PendingMigrationHealthCheck.cs
@@ -1,6 +1,7 @@
 using ExpertiseApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System.Data.Common;
 
 namespace ExpertiseApi.Services.Health;
 
@@ -50,14 +51,29 @@ internal sealed class PendingMigrationHealthCheck : IHealthCheck
             pending = await db.Database.GetPendingMigrationsAsync(cancellationToken)
                 .ConfigureAwait(false);
         }
-#pragma warning disable CA1031 // Health check must classify, not crash, on any DB error
-        catch (Exception ex)
-#pragma warning restore CA1031
+        // Narrowed from `catch (Exception)` to satisfy CodeQL cs/catch-of-all-exceptions
+        // and to align with the safer-by-default posture:
+        //
+        //   * OperationCanceledException propagates by exclusion — ASP.NET Core
+        //     health-check framework relies on cancellation propagation to
+        //     respect HealthCheckOptions.Timeout. Swallowing it here would let
+        //     a runaway probe pin a DB connection past the configured budget.
+        //   * Process-fatal exceptions (OOM, AVE, stack overflow) propagate so
+        //     the host can crash deterministically rather than masquerading
+        //     as "DB unreachable."
+        //   * DbException covers Npgsql.PostgresException / NpgsqlException
+        //     (connection refused, auth failed, schema missing __EFMigrationsHistory).
+        //   * InvalidOperationException covers EF/DI misconfiguration
+        //     (e.g., DbContext disposed, no provider configured).
+        catch (Exception ex) when (ex is DbException or InvalidOperationException)
         {
             // DB unreachable / __EFMigrationsHistory missing — surface as Unhealthy so
             // the operator distinguishes "can't tell" from "behind schema". The
             // DbContext check will likely also be Unhealthy in this case, providing
-            // a corroborating signal.
+            // a corroborating signal. The ex argument is consumed by the framework
+            // for its diagnostics payload; the response writer
+            // (WriteStatusOnlyPlainText in HealthEndpoints.cs) ensures the message
+            // and stack trace never reach the wire.
             return HealthCheckResult.Unhealthy(
                 "Unable to query pending migrations (DB unreachable or migration history missing).",
                 ex);


### PR DESCRIPTION
Closes CodeQL alerts [#31](https://github.com/TheSemicolon/agent-expertise-api/security/code-scanning/31) and [#32](https://github.com/TheSemicolon/agent-expertise-api/security/code-scanning/32) — both `cs/catch-of-all-exceptions` (CWE-396).

> **Triage note.** GitHub classifies both alerts as `severity: note` with `security_severity_level: null`. They are not formally security findings; they are CWE-396 code-quality alerts on robustness. They surfaced as a bot review-comment on PR #159 and the user elevated them to a security gate, which is the right call — narrowing is genuinely safer because process-fatal exceptions now propagate instead of being silently mapped to "exit 1" / "Unhealthy."

## Changes

### `Cli/MigrateCommand.cs` (alert #32)

```csharp
catch (Exception ex) when (ex is DbException
                              or DbUpdateException
                              or InvalidOperationException)
```

Covers every realistic failure of `Database.MigrateAsync()`:

| Type | Reaches us via |
|---|---|
| `DbException` | `Npgsql.NpgsqlException` / `Npgsql.PostgresException` — connect refused, auth failed, schema conflict, command timeout |
| `DbUpdateException` | EF Core wrapper; **derives directly from `Exception`** (not `InvalidOperationException`), so it requires its own arm — comment explicitly says "Do not prune" |
| `InvalidOperationException` | EF/DI config errors ("No database provider configured", DbContext disposed, ...) |

`OperationCanceledException` and process-fatal exceptions now propagate. The `#pragma warning disable CA1031` is removed (the `when`-filter satisfies both CA1031 and CodeQL).

### `Services/Health/PendingMigrationHealthCheck.cs` (alert #31)

```csharp
catch (Exception ex) when (ex is DbException or InvalidOperationException)
```

OCE now propagates per ASP.NET Core health-check contract: `DefaultHealthCheckService` enforces `HealthCheckRegistration.Timeout` via a linked `CancellationTokenSource` and treats the resulting OCE as the canonical timeout signal. No `DbUpdateException` arm — `GetPendingMigrationsAsync` is a read-only metadata query and cannot raise it.

## Wire-side safety unchanged

`HealthEndpoints.WriteStatusOnlyPlainText` continues to write only the aggregate status. The `ex` argument passed to `HealthCheckResult.Unhealthy` is consumed only by in-process diagnostics (`HealthReportEntry.Exception`) and never reaches `/health/*`. Npgsql password-redaction posture unchanged (still no `IncludeErrorDetail=true` on the data source).

## Review

2-way parallel `/review` (`security-review-expert` + `code-review-expert`). Both verdicts **PASS_WITH_WARNINGS**, both flagging the same warning — a comment incorrectly stating `DbUpdateException` inherits from `InvalidOperationException`. Fixed by citing the MS Learn doc in the comment and adding "Do not prune."

## Out of scope — follow-up filed

Four pre-existing `cs/catch-of-all-exceptions` alerts remain:

- `Auth/AuthExtensions.cs:189` (#29)
- `Endpoints/ExpertiseEndpoints.cs:252` (#11)
- `Endpoints/ExpertiseEndpoints.cs:274` (#12)
- `Endpoints/ExpertiseEndpoints.cs:308` (#13)

Will file as a separate triage issue immediately after merge.

## Local validation

- `dotnet build`: clean
- `dotnet test` (unit): 92/92 pass
- Integration tests deferred to CI (Docker not available locally)
