### PR TITLE
chore(api): narrow remaining cs/catch-of-all-exceptions alerts (#29, #11, #12, #13)

### DIFF
--- a/src/ExpertiseApi/Auth/AuthExtensions.cs
+++ b/src/ExpertiseApi/Auth/AuthExtensions.cs
@@ -186,9 +186,23 @@ internal static class AuthExtensions
                         return match.Name;
                 }
             }
-            catch (Exception)
+            catch (Exception ex) when (ex is SecurityTokenException
+                                          or ArgumentException
+                                          or FormatException)
             {
+                // JWT could not be parsed (malformed, bad base64, missing claims, etc.).
                 // Fall through to first scheme; JwtBearer will reject cleanly.
+                //
+                // Narrowed from `catch (Exception)` to satisfy CodeQL
+                // cs/catch-of-all-exceptions. Process-fatal exceptions
+                // (OutOfMemoryException, AccessViolationException) propagate
+                // by exclusion — do not widen without re-triage. Covered surface:
+                //   * SecurityTokenException — base of all
+                //     Microsoft.IdentityModel.Tokens.SecurityToken*Exception
+                //     (Malformed, InvalidSignature, Expired, etc.).
+                //   * ArgumentException     — ReadJsonWebToken null/empty input.
+                //   * FormatException       — base64url decode failure on a
+                //     malformed segment that slipped past LooksLikeJwt.
             }
             return issuers[0].Name;
         }

--- a/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
@@ -1,9 +1,11 @@
+using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using ExpertiseApi.Auth;
 using ExpertiseApi.Data;
 using ExpertiseApi.Models;
 using ExpertiseApi.Services;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Pgvector;
 
 namespace ExpertiseApi.Endpoints;
@@ -249,8 +251,23 @@ internal static class ExpertiseEndpoints
 
             return Results.Json(results.ToList(), statusCode: 207);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is InvalidOperationException
+                                      or HttpRequestException
+                                      or TimeoutException
+                                      or IOException
+                                      or ArgumentException)
         {
+            // Narrowed from `catch (Exception)` to satisfy CodeQL
+            // cs/catch-of-all-exceptions. The IEmbeddingGenerator abstraction
+            // is pluggable, so we cover the realistic failure surface across
+            // both the local ONNX backend (InvalidOperationException for
+            // session/state errors, IOException for model-file issues,
+            // ArgumentException / ArgumentOutOfRangeException from BERT
+            // tokenizer pre-processing on pathological input — lone surrogates,
+            // sequences exceeding positional limits) and any HTTP-backed
+            // backend (HttpRequestException, TimeoutException).
+            // Process-fatal exceptions (OOM, AVE) and OperationCanceledException
+            // (handled by the sibling catch above) propagate by exclusion.
             logger.LogWarning(ex, "Batch embedding generation failed");
 
             foreach (var (index, _) in validItems)
@@ -271,8 +288,18 @@ internal static class ExpertiseEndpoints
 
             return Results.Json(results.ToList(), statusCode: 207);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is DbException
+                                      or DbUpdateException
+                                      or InvalidOperationException
+                                      or ArgumentException)
         {
+            // Narrowed from `catch (Exception)` to satisfy CodeQL
+            // cs/catch-of-all-exceptions. CheckBatchAsync issues bulk DB
+            // queries via the repo and may surface Npgsql/EF errors
+            // (DbException / DbUpdateException), DI/state errors
+            // (InvalidOperationException), or argument-shape mismatches
+            // (ArgumentException — thrown explicitly when embeddings.Count
+            // does not match requests.Count). Process-fatal and OCE propagate.
             logger.LogWarning(ex, "Batch deduplication failed");
 
             foreach (var (index, _) in validItems)
@@ -305,8 +332,16 @@ internal static class ExpertiseEndpoints
                     results[validItems[k].Index] = new BatchEntryResult(validItems[k].Index, BatchEntryStatus.Failed, null, "Request was cancelled.");
                 break;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is DbException
+                                          or DbUpdateException
+                                          or InvalidOperationException)
             {
+                // Narrowed from `catch (Exception)` per CodeQL
+                // cs/catch-of-all-exceptions. repo.CreateAsync ultimately calls
+                // db.SaveChangesAsync, which raises DbUpdateException for
+                // constraint violations, DbException for transport-level
+                // Npgsql errors, and InvalidOperationException for tenant-mismatch
+                // guard trips (line ~145). Process-fatal and OCE propagate.
                 logger.LogWarning(ex, "Batch entry {Index} failed", index);
                 results[index] = new BatchEntryResult(index, BatchEntryStatus.Failed, null, "Entry could not be created.");
             }


### PR DESCRIPTION
Closes #162. Closes CodeQL alerts [#29](https://github.com/TheSemicolon/agent-expertise-api/security/code-scanning/29), [#11](https://github.com/TheSemicolon/agent-expertise-api/security/code-scanning/11), [#12](https://github.com/TheSemicolon/agent-expertise-api/security/code-scanning/12), [#13](https://github.com/TheSemicolon/agent-expertise-api/security/code-scanning/13) — all `cs/catch-of-all-exceptions` (CWE-396).

> **Triage note.** GitHub classifies all four as `severity: note` with `security_severity_level: null` — CWE-396 robustness alerts, not formally security findings. Same precedent as PR #161; the narrowing posture is genuinely safer regardless of classification because process-fatal exceptions (`OutOfMemoryException`, etc.) now propagate instead of being silently mapped to recovery paths.

## Per-site narrowings

| Site | Filter | Notes |
|---|---|---|
| `Auth/AuthExtensions.cs:189` (#29) | `SecurityTokenException or ArgumentException or FormatException` | JWT scheme-selection probe. `JsonWebTokenHandler.ReadJsonWebToken` only parses JWS structure (no crypto), so the surface is parse failure. Fall-through to `issuers[0]` preserved → JwtBearer still rejects with clean 401. |
| `Endpoints/ExpertiseEndpoints.cs:252` (#11) — batch embed | `InvalidOperationException or HttpRequestException or TimeoutException or IOException or ArgumentException` | Covers both ONNX-local and HTTP-backed `IEmbeddingGenerator`. `ArgumentException` added per security-review finding to cover BERT-tokenizer edge cases (lone surrogate halves, oversized sequences). |
| `Endpoints/ExpertiseEndpoints.cs:274` (#12) — batch dedup | `DbException or DbUpdateException or InvalidOperationException or ArgumentException` | DB-bound + `CheckBatchAsync` throws ArgumentException on count mismatch. |
| `Endpoints/ExpertiseEndpoints.cs:308` (#13) — per-entry create | `DbException or DbUpdateException or InvalidOperationException` | `repo.CreateAsync` calls SaveChangesAsync + throws InvalidOperationException on tenant-mismatch guard (line 146). |

## Wire-side / logging behavior unchanged

All three batch sites still `logger.LogWarning(ex, ...)` with the typed exception and return generic strings to the caller. No info-disclosure surface change. Npgsql password-redaction posture unchanged.

## Review

3-way parallel `/review`:

| Agent | Verdict | Action |
|---|---|---|
| security-review-expert | PASS_WITH_WARNINGS | Info: add `ArgumentException` to embed catch — **applied** (closes write-scope-caller 207→500 amplification). Confirmed JWT-path 500-vs-fallthrough is the correct posture and not a DoS primitive. |
| code-review-expert | PASS | Two Info: drop redundant `_ = ex;` discard (the `when` filter counts as use) and trim inaccurate OCE remark on sync JWT path — **both applied**. Verified comments do not repeat PR #161's `DbUpdateException`-inheritance factual error. |
| linter | PASS | `dotnet format` whitespace + analyzers clean. |

## Local validation

- `dotnet build`: 0 warnings, 0 errors
- `dotnet test` (unit): 92/92 pass
- Integration tests deferred to CI (Docker not available locally)
