### PR TITLE
fix(scripts): atomic apictl restart + readiness wait + cross-platform race regression test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,3 +100,72 @@ jobs:
 
       - name: Helm render tests
         run: bash helm/expertise-api/tests/test-render.sh
+
+  apictl-restart-race-macos:
+    name: apictl restart race regression (macOS)
+    runs-on: macos-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run apictl restart race regression test
+        run: bash scripts/test/test-apictl-restart.sh
+
+  apictl-restart-race-debian13:
+    name: apictl restart race regression (Debian 13 / systemd)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Privileged container; restrict to same-repo PRs and pushes to avoid
+    # running --privileged docker for arbitrary fork-PR content. Fork PRs
+    # still get coverage from the macos and build-and-test jobs.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Build Debian 13 systemd-enabled image
+        run: docker build -t apictl-debian13 -f scripts/test/Dockerfile.debian13 scripts/test
+
+      - name: Start container (systemd as PID 1)
+        run: |
+          docker run -d --name apictl-test \
+            --privileged \
+            --cgroupns=host \
+            --tmpfs /tmp --tmpfs /run --tmpfs /run/lock \
+            -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+            -v "$PWD:/workspace:ro" \
+            apictl-debian13
+          # Surface container state immediately so a dead PID 1 shows up in
+          # logs rather than as a silent wait-loop timeout.
+          sleep 2
+          docker ps -a --filter name=apictl-test
+          docker logs apictl-test || true
+          # Wait for systemd to settle inside the container.
+          for _ in $(seq 1 30); do
+            if docker exec apictl-test systemctl is-system-running --wait 2>/dev/null; then
+              break
+            fi
+            sleep 1
+          done
+          docker exec apictl-test systemctl --no-pager status >/dev/null || true
+
+      - name: Run apictl restart race regression test (in container, as user 'apictl')
+        run: |
+          docker exec -u apictl apictl-test bash -lc '
+            cp -r /workspace /home/apictl/repo &&
+            cd /home/apictl/repo &&
+            bash scripts/test/test-apictl-restart.sh
+          '
+
+      - name: Container logs on failure
+        if: failure()
+        run: |
+          docker logs apictl-test || true
+          docker exec apictl-test journalctl --no-pager -n 200 || true
+
+      - name: Tear down container
+        if: always()
+        run: docker rm -f apictl-test || true

--- a/scripts/expertise-apictl
+++ b/scripts/expertise-apictl
@@ -55,7 +55,25 @@ cmd_stop() {
   esac
 }
 
-cmd_restart() { cmd_stop; sleep 1; cmd_start; }
+cmd_restart() {
+  case "${OS}" in
+    macos)
+      # launchctl bootout is asynchronous: a cmd_stop+sleep+cmd_start sequence
+      # races and surfaces "Service is already loaded" or duplicate-spawns.
+      # `kickstart -k -p` is the atomic primitive (kill existing, then print
+      # the new PID, which blocks until the supervised process is spawned).
+      # See: man launchctl (Sonoma+).
+      launchctl kickstart -k -p "gui/$(id -u)/${LABEL}" ;;
+    linux)
+      # `systemctl --user restart` is itself atomic and synchronous; no need
+      # to compose stop+sleep+start.
+      systemctl --user restart "${SERVICE}.service" ;;
+    wsl_to_windows)
+      # No atomic restart primitive exposed by sc.exe over the WSL interop
+      # boundary; the stop+sleep+start pattern remains correct here.
+      cmd_stop; sleep 1; cmd_start ;;
+  esac
+}
 
 cmd_status() {
   case "${OS}" in

--- a/scripts/expertise-apictl
+++ b/scripts/expertise-apictl
@@ -18,6 +18,8 @@ set -euo pipefail
 SERVICE="expertise-api"
 LABEL="com.thesemicolon.expertise-api"
 HEALTH_URL="${EXPERTISE_API_URL:-http://127.0.0.1:8080}/health"
+READY_URL="${EXPERTISE_API_URL:-http://127.0.0.1:8080}/health/ready"
+READY_TIMEOUT="${EXPERTISE_API_READY_TIMEOUT:-30}"
 
 log() { printf '[expertise-apictl] %s\n' "$1"; }
 err() { printf '[expertise-apictl] ERROR: %s\n' "$1" >&2; exit 1; }
@@ -73,6 +75,29 @@ cmd_restart() {
       # boundary; the stop+sleep+start pattern remains correct here.
       cmd_stop; sleep 1; cmd_start ;;
   esac
+  wait_for_ready
+}
+
+wait_for_ready() {
+  # Block until /health/ready returns 200 or READY_TIMEOUT elapses.
+  # Skippable for stub-service tests where no HTTP listener is wired up.
+  if [[ "${EXPERTISE_API_SKIP_READY:-0}" == "1" ]]; then
+    log "ready: skipped (EXPERTISE_API_SKIP_READY=1)"
+    return 0
+  fi
+  if ! command -v curl >/dev/null 2>&1; then
+    log "ready: WARNING — curl not found; readiness NOT verified (install curl, or set EXPERTISE_API_SKIP_READY=1 to silence)"
+    return 0
+  fi
+  local deadline=$(( SECONDS + READY_TIMEOUT ))
+  while (( SECONDS < deadline )); do
+    if curl -fsS --max-time 2 "${READY_URL}" >/dev/null 2>&1; then
+      log "ready: OK (${READY_URL})"
+      return 0
+    fi
+    sleep 1
+  done
+  err "service did not reach ready state within ${READY_TIMEOUT}s at ${READY_URL}"
 }
 
 cmd_status() {

--- a/scripts/expertise-apictl
+++ b/scripts/expertise-apictl
@@ -15,8 +15,8 @@
 
 set -euo pipefail
 
-SERVICE="expertise-api"
-LABEL="com.thesemicolon.expertise-api"
+SERVICE="${EXPERTISE_API_SERVICE:-expertise-api}"
+LABEL="${EXPERTISE_API_LABEL:-com.thesemicolon.expertise-api}"
 HEALTH_URL="${EXPERTISE_API_URL:-http://127.0.0.1:8080}/health"
 READY_URL="${EXPERTISE_API_URL:-http://127.0.0.1:8080}/health/ready"
 READY_TIMEOUT="${EXPERTISE_API_READY_TIMEOUT:-30}"

--- a/scripts/test/Dockerfile.debian13
+++ b/scripts/test/Dockerfile.debian13
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1
+#
+# Minimal Debian 13 (Trixie) systemd-enabled container for exercising the
+# apictl restart race regression test against systemctl --user.
+#
+# Run with:
+#   docker run -d --name apictl-test --privileged --tmpfs /tmp --tmpfs /run \
+#     --tmpfs /run/lock -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v "$PWD:/workspace" \
+#     apictl-debian13
+#
+# Then exec the harness:
+#   docker exec -u apictl apictl-test bash -lc 'cd /workspace && bash scripts/test/test-apictl-restart.sh'
+
+FROM debian:13-slim
+
+# systemd, dbus, and the runtime tools the harness needs.
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        systemd systemd-sysv dbus dbus-user-session \
+        python3 curl ca-certificates bash sudo \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Non-root user matching the GitHub Actions runner's uid (1000) so the
+# bind-mounted workspace is readable without ownership games.
+RUN useradd -m -u 1000 -s /bin/bash apictl \
+    && mkdir -p /run/user/1000 \
+    && chown apictl:apictl /run/user/1000 \
+    && chmod 700 /run/user/1000
+
+# Pre-enable linger so systemd --user is up the moment the user logs in.
+RUN mkdir -p /var/lib/systemd/linger \
+    && touch /var/lib/systemd/linger/apictl
+
+# Sane signals for systemd-in-container.
+STOPSIGNAL SIGRTMIN+3
+
+ENV container=docker
+
+# `/sbin/init` is the systemd-sysv-provided symlink that the systemd-in-container
+# documentation recommends as the explicit PID 1; it sets the right defaults for
+# running inside a container (no kernel modules, no console).
+CMD ["/sbin/init"]

--- a/scripts/test/stub-server.py
+++ b/scripts/test/stub-server.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""
+Minimal HTTP stub for the apictl restart race regression test.
+
+Returns 200 OK on any /health* path, 404 elsewhere. Bound to 127.0.0.1.
+Designed to be the *supervised* process inside the launchd/systemd unit so
+that `expertise-apictl restart` genuinely exercises the readiness probe
+end-to-end (kill + respawn → /health/ready returns).
+
+Usage:
+  stub-server.py [PORT]   # default: 18080
+"""
+import http.server
+import socketserver
+import sys
+
+
+PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 18080
+
+
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802 — base-class API
+        if self.path.startswith("/health"):
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"OK")
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, *_args, **_kwargs):  # silence access log
+        return
+
+
+class S(socketserver.TCPServer):
+    allow_reuse_address = True
+
+
+def main() -> int:
+    with S(("127.0.0.1", PORT), H) as srv:
+        srv.serve_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test/test-apictl-restart-linux.sh
+++ b/scripts/test/test-apictl-restart-linux.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+#
+# test-apictl-restart-linux.sh — exercises `expertise-apictl restart` against
+# a stub systemd-user service to validate atomic-restart-primitive parity
+# with the macOS fix for #141.
+#
+# The supervised process IS the HTTP stub (scripts/test/stub-server.py), so
+# /health/ready returns 200 only when the post-restart process is actually
+# running — this means `wait_for_ready` is genuinely exercised end-to-end.
+#
+# Asserts per iteration:
+#   - exit 0 from `expertise-apictl restart`
+#   - systemctl --user is-active = active
+#   - MainPID changes from previous iteration (proves the restart killed)
+#   - /health/ready returns 200 post-restart (proves wait_for_ready worked
+#     against the freshly spawned listener, not a stale one)
+#
+# Requirements (caller must arrange):
+#   - systemd as PID 1
+#   - linger enabled for the invoking user (loginctl enable-linger),
+#     or a logged-in user session
+#   - XDG_RUNTIME_DIR set or createable by pam_systemd
+#
+# Test artifacts are cleaned up by trap regardless of pass/fail.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+APICTL="${ROOT}/scripts/expertise-apictl"
+STUB="${ROOT}/scripts/test/stub-server.py"
+
+TEST_SERVICE="expertise-api-test"
+TEST_PORT="18080"
+TEST_URL="http://127.0.0.1:${TEST_PORT}"
+UNIT_DIR="${HOME}/.config/systemd/user"
+UNIT_PATH="${UNIT_DIR}/${TEST_SERVICE}.service"
+ITERATIONS=10
+PYTHON_BIN="$(command -v python3 || true)"
+
+export EXPERTISE_API_SERVICE="${TEST_SERVICE}"
+export EXPERTISE_API_URL="${TEST_URL}"
+export EXPERTISE_API_READY_TIMEOUT=10
+
+log() { printf '[test-apictl-restart-linux] %s\n' "$1"; }
+fail() { printf '[test-apictl-restart-linux] FAIL: %s\n' "$1" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+cleanup() {
+  local rc=$?
+  log "cleanup (rc=${rc})"
+  systemctl --user stop "${TEST_SERVICE}.service" 2>/dev/null || true
+  rm -f "${UNIT_PATH}"
+  systemctl --user daemon-reload 2>/dev/null || true
+  exit "${rc}"
+}
+trap cleanup EXIT INT TERM
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+command -v systemctl >/dev/null || fail "systemctl not found"
+command -v curl      >/dev/null || fail "curl not found"
+[[ -n "${PYTHON_BIN}" ]]         || fail "python3 not found on PATH"
+[[ -r "${STUB}" ]]               || fail "stub server not found at ${STUB}"
+
+: "${XDG_RUNTIME_DIR:=/run/user/$(id -u)}"
+export XDG_RUNTIME_DIR
+
+systemctl --user is-system-running 2>/dev/null \
+  || log "warning: systemctl --user reports degraded state (proceeding)"
+
+# Verify nothing is already bound to TEST_PORT.
+if command -v ss >/dev/null && ss -ltn "sport = :${TEST_PORT}" | grep -q LISTEN; then
+  fail "port ${TEST_PORT} already in use; aborting"
+fi
+
+# ---------------------------------------------------------------------------
+# Setup — install the stub unit whose ExecStart IS the HTTP stub.
+# ---------------------------------------------------------------------------
+
+mkdir -p "${UNIT_DIR}"
+cat > "${UNIT_PATH}" <<EOF
+[Unit]
+Description=expertise-api stub for apictl restart race regression test
+# Disable systemd's default StartLimitBurst (5 starts / 10s) so the test
+# can drive 10 restarts in rapid succession without tripping rate-limit.
+StartLimitIntervalSec=0
+
+[Service]
+ExecStart=${PYTHON_BIN} ${STUB} ${TEST_PORT}
+Restart=no
+EOF
+
+systemctl --user daemon-reload
+systemctl --user start "${TEST_SERVICE}.service"
+
+for _ in $(seq 1 20); do
+  if curl -fsS --max-time 1 "${TEST_URL}/health/ready" >/dev/null 2>&1; then
+    log "stub service up; HTTP stub serving on ${TEST_URL}"
+    break
+  fi
+  sleep 0.25
+done
+curl -fsS --max-time 2 "${TEST_URL}/health/ready" >/dev/null \
+  || fail "stub HTTP server did not respond after setup"
+
+state=$(systemctl --user is-active "${TEST_SERVICE}.service" || true)
+[[ "${state}" == "active" ]] || fail "stub service not active (state=${state})"
+
+# ---------------------------------------------------------------------------
+# Test loop
+# ---------------------------------------------------------------------------
+
+prev_pid=""
+for i in $(seq 1 "${ITERATIONS}"); do
+  log "iteration ${i}/${ITERATIONS}"
+
+  if ! bash "${APICTL}" restart >/dev/null; then
+    fail "restart failed on iteration ${i}"
+  fi
+
+  state=$(systemctl --user is-active "${TEST_SERVICE}.service" || true)
+  [[ "${state}" == "active" ]] || fail "iter ${i}: is-active='${state}', expected 'active'"
+
+  pid=$(systemctl --user show -p MainPID --value "${TEST_SERVICE}.service")
+  [[ -n "${pid}" && "${pid}" != "0" ]] || fail "iter ${i}: invalid MainPID='${pid}'"
+
+  if [[ -n "${prev_pid}" && "${pid}" == "${prev_pid}" ]]; then
+    fail "iter ${i}: pid did not change (${pid}); restart may not have killed"
+  fi
+  prev_pid="${pid}"
+
+  curl -fsS --max-time 2 "${TEST_URL}/health/ready" >/dev/null \
+    || fail "iter ${i}: /health/ready not responding post-restart"
+
+  log "  ok: state=active pid=${pid} ready=200"
+done
+
+log "PASS — ${ITERATIONS}/${ITERATIONS} iterations succeeded"

--- a/scripts/test/test-apictl-restart-macos.sh
+++ b/scripts/test/test-apictl-restart-macos.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# test-apictl-restart-macos.sh — exercises `expertise-apictl restart` against
+# a stub launchd service to validate the race fix for #141.
+#
+# The supervised process IS the HTTP stub (scripts/test/stub-server.py), so
+# /health/ready returns 200 only when the post-restart process is actually
+# running. This means `wait_for_ready` (the readiness gate added by this PR)
+# is genuinely exercised end-to-end on each iteration — not just the kill+
+# respawn primitive.
+#
+# Asserts per iteration:
+#   - exit 0 from `expertise-apictl restart`
+#   - launchctl state = running
+#   - launchctl pid changes from previous iteration (proves the kill happened)
+#   - /health/ready returns 200 after restart (proves wait_for_ready worked
+#     against the freshly spawned listener, not a stale one)
+#
+# Test artifacts are cleaned up by trap regardless of pass/fail.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+APICTL="${ROOT}/scripts/expertise-apictl"
+STUB="${ROOT}/scripts/test/stub-server.py"
+
+TEST_LABEL="com.thesemicolon.expertise-api-test"
+TEST_SERVICE="expertise-api-test"
+TEST_PORT="18080"
+TEST_URL="http://127.0.0.1:${TEST_PORT}"
+PLIST_PATH="${HOME}/Library/LaunchAgents/${TEST_LABEL}.plist"
+DOMAIN="gui/$(id -u)"
+ITERATIONS=10
+PYTHON_BIN="$(command -v python3)"
+
+export EXPERTISE_API_LABEL="${TEST_LABEL}"
+export EXPERTISE_API_SERVICE="${TEST_SERVICE}"
+export EXPERTISE_API_URL="${TEST_URL}"
+export EXPERTISE_API_READY_TIMEOUT=10
+
+log() { printf '[test-apictl-restart-macos] %s\n' "$1"; }
+fail() { printf '[test-apictl-restart-macos] FAIL: %s\n' "$1" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+cleanup() {
+  local rc=$?
+  log "cleanup (rc=${rc})"
+  launchctl bootout "${DOMAIN}/${TEST_LABEL}" 2>/dev/null || true
+  rm -f "${PLIST_PATH}"
+  exit "${rc}"
+}
+trap cleanup EXIT INT TERM
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+[[ -x "${STUB}" || -r "${STUB}" ]] || fail "stub server not found at ${STUB}"
+[[ -n "${PYTHON_BIN}" ]]            || fail "python3 not found on PATH"
+command -v curl >/dev/null          || fail "curl not found"
+
+# Verify nothing is already bound to TEST_PORT.
+if lsof -nP -iTCP:"${TEST_PORT}" -sTCP:LISTEN >/dev/null 2>&1; then
+  fail "port ${TEST_PORT} already in use; aborting"
+fi
+
+# ---------------------------------------------------------------------------
+# Setup — install the stub plist whose supervised program IS the HTTP stub.
+# ---------------------------------------------------------------------------
+
+log "writing stub plist to ${PLIST_PATH}"
+mkdir -p "$(dirname "${PLIST_PATH}")"
+cat > "${PLIST_PATH}" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>${TEST_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${PYTHON_BIN}</string>
+    <string>${STUB}</string>
+    <string>${TEST_PORT}</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+</dict>
+</plist>
+EOF
+
+launchctl bootout "${DOMAIN}/${TEST_LABEL}" 2>/dev/null || true
+launchctl bootstrap "${DOMAIN}" "${PLIST_PATH}"
+launchctl enable "${DOMAIN}/${TEST_LABEL}"
+launchctl kickstart "${DOMAIN}/${TEST_LABEL}"
+
+# Wait for the stub HTTP server to respond before starting the loop.
+for _ in $(seq 1 20); do
+  if curl -fsS --max-time 1 "${TEST_URL}/health/ready" >/dev/null 2>&1; then
+    log "stub service up; HTTP stub serving on ${TEST_URL}"
+    break
+  fi
+  sleep 0.25
+done
+curl -fsS --max-time 2 "${TEST_URL}/health/ready" >/dev/null \
+  || fail "stub HTTP server did not respond after setup"
+
+# ---------------------------------------------------------------------------
+# Test loop
+# ---------------------------------------------------------------------------
+
+prev_pid=""
+for i in $(seq 1 "${ITERATIONS}"); do
+  log "iteration ${i}/${ITERATIONS}"
+
+  if ! bash "${APICTL}" restart >/dev/null; then
+    fail "restart failed on iteration ${i}"
+  fi
+
+  # launchd briefly reports state=spawn between kickstart and the supervised
+  # process being fully running. Poll for the steady-state transition.
+  state=""
+  for _ in $(seq 1 30); do
+    state=$(launchctl print "${DOMAIN}/${TEST_LABEL}" 2>/dev/null \
+      | awk '/^[[:space:]]*state = / {print $3; exit}')
+    case "${state}" in
+      running) break ;;
+      spawn|"") sleep 0.1 ;;
+      *) fail "iter ${i}: unexpected state='${state}'" ;;
+    esac
+  done
+  [[ "${state}" == "running" ]] || fail "iter ${i}: state='${state}' after settle, expected 'running'"
+
+  pid=$(launchctl print "${DOMAIN}/${TEST_LABEL}" \
+    | awk '/^[[:space:]]*pid = / {print $3; exit}')
+  [[ -n "${pid}" ]] || fail "iter ${i}: could not extract pid"
+
+  if [[ -n "${prev_pid}" && "${pid}" == "${prev_pid}" ]]; then
+    fail "iter ${i}: pid did not change (${pid}); kill may not have happened"
+  fi
+  prev_pid="${pid}"
+
+  # Verify wait_for_ready actually worked: the freshly spawned listener
+  # must respond to /health/ready right now (without us re-polling).
+  curl -fsS --max-time 2 "${TEST_URL}/health/ready" >/dev/null \
+    || fail "iter ${i}: /health/ready not responding post-restart"
+
+  log "  ok: state=running pid=${pid} ready=200"
+done
+
+log "PASS — ${ITERATIONS}/${ITERATIONS} iterations succeeded"

--- a/scripts/test/test-apictl-restart.sh
+++ b/scripts/test/test-apictl-restart.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# test-apictl-restart.sh — dispatcher for the cross-platform apictl restart
+# race regression test. Selects the per-OS harness or exits 0 with a
+# "skipped" message on unsupported hosts.
+#
+# Validates issue #141: launchctl bootout race on macOS and, by extension,
+# atomic-restart-primitive parity on Linux (systemctl --user restart).
+#
+# Usage:
+#   bash scripts/test/test-apictl-restart.sh
+#
+# Exit codes:
+#   0  — test passed, or skipped on unsupported OS
+#   1+ — test failed (per-iteration failure or cleanup failure)
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+case "$(uname -s)" in
+  Darwin) exec bash "${ROOT}/scripts/test/test-apictl-restart-macos.sh" ;;
+  Linux)  exec bash "${ROOT}/scripts/test/test-apictl-restart-linux.sh" ;;
+  *)
+    echo "[test-apictl-restart] skipped: unsupported OS ($(uname -s))"
+    exit 0
+    ;;
+esac


### PR DESCRIPTION
Closes #141.

## What

Four-commit logical decomposition (will squash on merge):

1. **`fix(scripts): atomic restart via launchctl kickstart -k -p (macOS) and systemctl --user restart (Linux)`** — primary fix. The previous `cmd_stop; sleep 1; cmd_start` composition raced on macOS (`launchctl bootout` is async) and was sub-optimal on Linux. Each platform now uses its canonical atomic restart primitive. WSL→Windows unchanged (no atomic primitive exposed by `sc.exe` over the interop boundary).

2. **`feat(scripts): wait for /health/ready after expertise-apictl restart`** — the restart command now only returns 0 when the service is actually serving requests. Configurable via `EXPERTISE_API_READY_TIMEOUT` (default 30s) and `EXPERTISE_API_SKIP_READY=1`. Louder warning when curl is absent (does not silently mask the readiness gap).

3. **`chore(scripts): allow SERVICE/LABEL override via env (test affordance)`** — `SERVICE`/`LABEL` become `EXPERTISE_API_SERVICE`/`EXPERTISE_API_LABEL` overridable, defaults unchanged. Lets the test harness install a stub service under a separate identifier without colliding with any real install.

4. **`test(scripts): cross-platform apictl restart race regression (macOS + Debian 13)`** — stub-service test harness exercising the apictl ↔ launchd/systemd interaction:
   - `scripts/test/test-apictl-restart.sh` — dispatcher
   - `scripts/test/test-apictl-restart-macos.sh` — launchd path
   - `scripts/test/test-apictl-restart-linux.sh` — systemd-user path
   - `scripts/test/stub-server.py` — minimal HTTP stub returning 200 on /health/*
   - `scripts/test/Dockerfile.debian13` — minimal Debian 13 systemd-enabled container
   - Two new CI jobs in `.github/workflows/ci.yml`:
     - `apictl-restart-race-macos` on `macos-latest`
     - `apictl-restart-race-debian13` on `ubuntu-latest` via privileged container (gated to same-repo PRs/pushes per security review)

The supervised process in each stub *is* the HTTP server, so `/health/ready` returning 200 genuinely proves the post-restart listener — not a stale one — is up. PID-change + state assertions cover the kill primitive itself.

## How verified

- **Local macOS** (this host): 10/10 iterations PASS end-to-end (state=running, pid changes, /health/ready 200 each iteration).
- **Linux/Debian 13 container**: not validatable locally (no Docker), pending CI feedback. Expected first-run iteration if container plumbing needs tweaks.

## Existing test suite

The 151-test dotnet suite (`build-and-test` job) + helm lint/render jobs are unchanged and continue to run on every PR.

## Pre-merge review

3-way `/review` (code-review-expert + security-review-expert + linter) ran on the initial push; verdicts: PASS_WITH_WARNINGS × 3. All actionable warnings addressed via fixup commits before this PR was opened:

- (code-review) Test harness HTTP server was decoupled from supervised process → restructured to supervise the HTTP stub itself
- (security) `--privileged` container ran on fork PRs → gated with `if: github.event_name == 'push' || ...head.repo.full_name == github.repository`
- (linter) Unused loop var `for i in $(seq 1 30)` → `for _`
- (code-review) Curl-missing branch silently passed → now louder WARNING

## Follow-up issues (filed, not blocking)

- ci: cross-platform build/test matrix (macos-latest + windows-latest)
- ci: end-to-end install.sh smoke test (per-platform, with Postgres service container)