### PR TITLE
feat(api): part D infrastructure controls C1/C4/C5/C8 (closes #167)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,19 @@ jobs:
             exit 1
           fi
 
+      # Build-time OpenAPI document emission (Part D C8) is wired via
+      # Microsoft.Extensions.ApiDescription.Server in the API csproj. The generator
+      # runs as part of `dotnet build`; runtime startup guards that would otherwise
+      # reject the source-controlled placeholder configuration are bypassed for the
+      # `dotnet-getdocument` entry assembly. See AuthExtensions.IsBuildTimeOpenApiContext.
       - name: Build
         run: dotnet build ExpertiseApi.slnx --configuration Release --no-restore --disable-build-servers
+
+      # Smoke-check that build-time OpenAPI document emission (Part D C8) succeeded.
+      # release.yml picks up artifacts/openapi/ExpertiseApi.json for the GitHub Release
+      # asset attachment. Fail loud here rather than discover the absence in a release run.
+      - name: Verify openapi.json artifact present
+        run: test -f src/ExpertiseApi/artifacts/openapi/ExpertiseApi.json
 
       # Analyzer baseline gate (issue #101, ADR-006). The codebase reached
       # zero analyzer warnings via PR7a/PR7b/PR7c; this step prevents

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
-      contents: read    # checkout
+      contents: write   # gh release upload (openapi.json + sha256, Part D C8)
       packages: write   # push to GHCR (image + chart OCI artifact)
       id-token: write   # cosign keyless OIDC signing (Sigstore Fulcio)
 
@@ -83,6 +83,25 @@ jobs:
       - name: Download ONNX model files
         if: steps.model-cache.outputs.cache-hit != 'true'
         run: bash scripts/download-models.sh
+
+      # Build-time OpenAPI document emission (Part D C8). Runs on the runner host
+      # — NOT inside the multi-stage Docker build — because we need the resulting
+      # openapi.json file present on the runner for the later `gh release upload`
+      # step. The Docker build has its own SDK image and does its own dotnet publish
+      # in parallel; this duplication adds ~30s and produces the artifact that the
+      # release attaches as a pinned asset for downstream integrators (#147, #148).
+      # See docs/security/integration-threat-model.md Part D C8.
+      - name: Setup .NET (for build-time OpenAPI emission)
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          global-json-file: global.json
+
+      - name: Build (emits artifacts/openapi/ExpertiseApi.json)
+        run: |
+          dotnet build src/ExpertiseApi/ExpertiseApi.csproj \
+            --configuration Release \
+            --disable-build-servers
+          test -f src/ExpertiseApi/artifacts/openapi/ExpertiseApi.json
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
@@ -209,6 +228,28 @@ jobs:
         run: |
           set -euo pipefail
           cosign sign --yes "ghcr.io/${OWNER_LC}/charts/expertise-api@${CHART_DIGEST}"
+
+      # ---- OpenAPI document + sha256 as pinned release assets (Part D C8) ---
+      # The build-time generator wrote ExpertiseApi.json to artifacts/openapi/
+      # earlier in this job. Compute the sha256 and attach both to the GitHub
+      # Release that semantic-release created in the upstream job. Downstream
+      # integrators (skill #147, pi extension #148) verify the hash before
+      # consuming the spec. No --clobber: tags are immutable in this pipeline.
+      - name: Attach openapi.json + sha256 to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: v${{ needs.release.outputs.new-release-version }}
+        run: |
+          set -euo pipefail
+          src=src/ExpertiseApi/artifacts/openapi/ExpertiseApi.json
+          out_dir=dist/openapi
+          mkdir -p "$out_dir"
+          cp "$src" "$out_dir/openapi.json"
+          sha256sum "$out_dir/openapi.json" | awk '{print $1}' > "$out_dir/openapi.json.sha256"
+          gh release upload "$TAG" \
+            "$out_dir/openapi.json" \
+            "$out_dir/openapi.json.sha256" \
+            --repo "${{ github.repository }}"
 
       - name: Dispatch deploy to infra repo
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ src/ExpertiseApi/models/
 
 ## Claude Code worktrees
 .claude/worktrees/
+
+## Part D C8: build-time OpenAPI document emission (Microsoft.Extensions.ApiDescription.Server)
+## Output of _GenerateOpenApiDocuments MSBuild target; published as a GitHub Release asset via release.yml.
+src/ExpertiseApi/artifacts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,13 @@ RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
     --output /app/efbundle
 
 # ── Runtime stage ──────────────────────────────────────────────────────────────
+# `aspnet:10.0` already sets `ASPNETCORE_HTTP_PORTS=8080` in the base image, so
+# Kestrel binds `+:8080` without an explicit ENV here. If a future change moves
+# the runtime stage to `runtime-deps:10.0-noble-chiseled` (smaller, no ASP.NET
+# Core layer), `ASPNETCORE_HTTP_PORTS` is NOT inherited and must be set
+# explicitly via `ENV ASPNETCORE_HTTP_PORTS=8080` — otherwise Kestrel falls back
+# to `http://localhost:5000` and the container becomes unreachable from the
+# k8s Service. See docs/security/integration-threat-model.md Part D C1.
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app
 

--- a/docs/security/integration-threat-model.md
+++ b/docs/security/integration-threat-model.md
@@ -381,18 +381,40 @@ The four alternative patterns mitigate or sidestep many MCP threats but presume 
 
 | Control | Description | Gates pattern | Tracked under | Status |
 |---|---|---|---|---|
-| **C1** | **Loopback bind by default.** Kestrel binds `127.0.0.1` unless the deployment explicitly opts into non-loopback exposure via env var or Helm value. | (3), (4); hardens (1), (2) | #167 (gates #146) | ❌ Not implemented |
+| **C1** | **Loopback bind by default.** Kestrel binds `127.0.0.1` unless the deployment explicitly opts into non-loopback exposure via env var or Helm value. | (3), (4); hardens (1), (2) | #167 (gates #146) | ✅ Implemented — reframed to shape-per-shape reachability boundary (HostFiltering allow-list + dev-laptop loopback `applicationUrl`); see [Part D C1 note](#part-d-c1-implementation-notes) |
 | **C2** | **LocalTrust / OIDC auth posture.** Multi-issuer JWT bearer with policy scheme is the production auth; dev-only ApiKey / LocalDev / Hybrid modes. | All patterns | #12 (existing) | ⚠️ Partial — dev modes wired, OIDC issuers TBD |
 | **C3** | **Idempotency keys** on mutating endpoints — `Idempotency-Key` header honored on POST/PATCH/DELETE; replay returns cached response. | (1), (2) — write tools | — (no issue; future write-tool work, not #146–#149) | ❌ Not implemented |
-| **C4** | **Sanitized `ProblemDetails`** — strip `Detail` / `Instance` in non-Development; log full detail server-side with correlation ID. | All patterns | #167 (gates #146) | ⚠️ Partial — `AddProblemDetails()` called but not customized |
-| **C5** | **Rate limiting** — per-principal policies on read / write / semantic-search endpoints; health endpoints exempt. | All patterns; amplifies for (1), (2) | #167 (gates #146) | ❌ Not implemented |
+| **C4** | **Sanitized `ProblemDetails`** — strip `Detail` / `Instance` in non-Development; log full detail server-side with correlation ID. | All patterns | #167 (gates #146) | ✅ Implemented — `CustomizeProblemDetails` scrubs Detail/Instance outside Development, always emits `traceId` extension; `UnhandledExceptionLogger` (typed `IExceptionHandler`) logs full exception server-side |
+| **C5** | **Rate limiting** — per-principal policies on read / write / semantic-search endpoints; health endpoints exempt. | All patterns; amplifies for (1), (2) | #167 (gates #146) | ✅ Implemented — three policies (`expertise-read` 60/min, `expertise-write` 10/min, `semantic-search` 10/min token-bucket), per-principal partitioning, health endpoints `DisableRateLimiting`'d, 429 carries ProblemDetails shape + `Retry-After` |
 | **C6** | **Agent-vs-human audit tag** — `actor_class` column on audit rows; `X-Actor-Class` header contract; default `human`. | (1), (2) | #168 (gates #147) | ❌ Not implemented |
 | **C7** | **Response hygiene — Option B (PII + injection-neutralization).** Strip PII (emails, phone numbers, embedded credentials, AWS access keys, GitHub tokens) AND delimiter-wrap free-text fields (`<expertise_content>…</expertise_content>`), apply instruction-stripping heuristics (`\bignore previous\b`, role-impersonation patterns), tag content-class in the JSON response. Decision recorded [D1](#d1--c7-response-hygiene-scope-locked-option-b). | (2), (3), (4); defense-in-depth for (1) | #168 (gates #147) | ❌ Not implemented; scope locked Option B |
-| **C8** | **Pinned artifacts** — `openapi.json.sha256` attached to GitHub Releases; skill / extension fetch contracts verify hashes. | (1), (2), (3) | #167 (gates #146) | ❌ Not implemented |
+| **C8** | **Pinned artifacts** — `openapi.json.sha256` attached to GitHub Releases; skill / extension fetch contracts verify hashes. | (1), (2), (3) | #167 (gates #146) | ✅ Implemented — `Microsoft.Extensions.ApiDescription.Server` emits `openapi.json` at build time; release.yml attaches `openapi.json` + `openapi.json.sha256` to the GitHub Release; CI smoke-checks the artifact presence. Supply-chain hardening (cosign sign-blob over openapi.json, closing the sha256-in-band-with-artifact gap) is tracked under #172 — explicit deferral per #167 scope ("SHA-256 + GitHub Release provenance is sufficient v1"). |
 
-**Implementation progress: 0/8 controls fully implemented; 2/8 partial.**
+**Implementation progress: 4/8 controls fully implemented (C1, C4, C5, C8 via #167); 1/8 partial (C2 via #12); 3/8 not started (C3 future, C6/C7 via #168).**
 
 Per-PR rule: any PR that lands a control updates the Status column in this table in the same commit, so doc and code stay aligned. The companion ADR records this rule explicitly.
+
+### Part D C1 implementation notes
+
+C1 as implemented diverges from the literal `EXPERTISE_API_BIND_ADDRESS` + Helm `bindAddress` design the issue body originally proposed. The architectural insight (credited to a docker-expert / dotnet-expert subagent fan-out, 2026-05-18) is that **"loopback by default" is the reachability boundary of each deployment shape, not literally `127.0.0.1`**:
+
+| Shape | Reachability boundary | Bind config source |
+|---|---|---|
+| `dotnet run` (laptop) | Kestrel bind address | `launchSettings.json applicationUrl=http://127.0.0.1:5005` |
+| `docker run` | Container netns + `-p` flag | Inherit `ASPNETCORE_HTTP_PORTS=8080` from `aspnet:10.0` base |
+| Helm / k8s | `Service` + `Ingress` | `service.targetPort: 8080`; no in-pod bind override |
+
+Binding `127.0.0.1` *inside a container* would make the pod unreachable from the k8s Service (the namespace IS the loopback equivalent at the container layer). A custom `EXPERTISE_API_BIND_ADDRESS` env var would duplicate `ASPNETCORE_HTTP_PORTS` / `ASPNETCORE_URLS` (which the .NET runtime already honors with well-known precedence); a custom Helm `bindAddress` would duplicate `service.targetPort` and invite drift.
+
+The concrete C1 work in #167:
+
+- `appsettings.json` `AllowedHosts` tightened from `"*"` to `"localhost;127.0.0.1;[::1]"` — activates ASP.NET Core `HostFilteringMiddleware` as DNS-rebind defense-in-depth (browser-resident attacker pages cannot reach the laptop loopback API even if the network path is permitted).
+- `launchSettings.json` `applicationUrl` uses `127.0.0.1` (not `localhost`) to defeat the macOS / Windows dual-stack-`localhost` surprise where Kestrel may bind the IPv6 wildcard family.
+- Helm `allowedHosts` value renders an env override so operators fronting the API via Ingress can extend the allow-list to their externally-routable hostnames without code changes.
+- A startup-log line (`[C1] Kestrel bound to {Addresses}`) makes the effective reachability boundary greppable in container logs.
+- Dockerfile carries a comment block noting that the chiseled `runtime-deps` base does NOT inherit `ASPNETCORE_HTTP_PORTS` and must set it explicitly if adopted.
+
+The issue body (#167) was amended with this reframe before implementation; the threat-model and the issue agree.
 
 ---
 

--- a/helm/expertise-api/templates/deployment.yaml
+++ b/helm/expertise-api/templates/deployment.yaml
@@ -90,6 +90,11 @@ spec:
             - name: ForwardedHeaders__KnownNetworks__{{ $i }}
               value: {{ $cidr | quote }}
             {{- end }}
+            {{- /* AllowedHosts — HostFiltering allow-list. Overrides the loopback-only default in appsettings.json. See Part D C1. */}}
+            {{- with .Values.allowedHosts }}
+            - name: AllowedHosts
+              value: {{ . | quote }}
+            {{- end }}
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
           volumeMounts:

--- a/helm/expertise-api/values.yaml
+++ b/helm/expertise-api/values.yaml
@@ -165,3 +165,19 @@ metrics:
     interval: 30s
     scrapeTimeout: 10s
     labels: {}
+
+# AllowedHosts — ASP.NET Core HostFiltering middleware allow-list (Part D C1).
+#
+# Default in the container image is `localhost;127.0.0.1;[::1]` (set in
+# src/ExpertiseApi/appsettings.json). When the API is fronted by an Ingress /
+# reverse proxy that injects a non-loopback Host header (the production path),
+# the operator MUST override this with the externally-routable hostname(s),
+# otherwise every request through the ingress 400s with `HostFilteringMiddleware`
+# rejecting the host.
+#
+# Semicolon-separated list, bound by the WebHost via the top-level `AllowedHosts`
+# configuration key. Examples:
+#   allowedHosts: "expertise-api.prod.example.com"
+#   allowedHosts: "expertise-api.example.com;expertise-api.internal.example.com"
+# Leave empty to inherit the tight loopback-only default from appsettings.json.
+allowedHosts: ""

--- a/src/ExpertiseApi/Auth/AuthExtensions.cs
+++ b/src/ExpertiseApi/Auth/AuthExtensions.cs
@@ -97,11 +97,19 @@ internal static class AuthExtensions
     /// footgun where <c>/health</c> and <c>/metrics</c> look green while every
     /// protected endpoint is broken. Fires in any environment because explicit
     /// <c>Auth:Mode=Oidc</c> with zero issuers is misconfiguration regardless of where.
+    ///
+    /// Build-time exception: when invoked under the <c>dotnet-getdocument</c> tool
+    /// (Microsoft.Extensions.ApiDescription.Server, Part D C8), the host runs against
+    /// source-controlled placeholder configuration that intentionally has no real OIDC
+    /// issuers. The guard's purpose — catching production misconfigurations — cannot
+    /// manifest in that context because nothing is actually being deployed, so it is
+    /// bypassed via the entry-assembly check. The runtime behaviour is unchanged.
     /// </summary>
     internal static void EnforceOidcIssuersGuard(AuthMode mode, IReadOnlyList<OidcIssuerOptions> issuers)
     {
         if (mode != AuthMode.Oidc) return;
         if (issuers.Count > 0) return;
+        if (IsBuildTimeOpenApiContext()) return;
 
         throw new InvalidOperationException(
             "Auth:Mode='Oidc' requires at least one valid Auth:Oidc:Issuers entry. " +
@@ -109,6 +117,21 @@ internal static class AuthExtensions
             "blank or starts with '<TODO' (placeholder values are filtered at load time). " +
             "Either populate Auth:Oidc:Issuers with real issuer URLs, or change Auth:Mode " +
             "(LocalDev/ApiKey/Hybrid permitted only in Development).");
+    }
+
+    /// <summary>
+    /// Detects whether the current host is being constructed by the
+    /// <c>Microsoft.Extensions.ApiDescription.Server</c> build-time OpenAPI document
+    /// generator (Part D C8). The tool loads the API assembly in a subprocess whose
+    /// entry assembly is <c>dotnet-getdocument</c> / <c>GetDocument.Insider</c>;
+    /// production deployments — Kestrel, systemd, IIS, Windows Service — all have
+    /// our own assembly as the entry. Used to bypass production-only startup guards
+    /// that would otherwise reject the source-controlled placeholder configuration.
+    /// </summary>
+    internal static bool IsBuildTimeOpenApiContext()
+    {
+        var entry = System.Reflection.Assembly.GetEntryAssembly()?.GetName().Name;
+        return entry is "dotnet-getdocument" or "GetDocument.Insider";
     }
 
     internal static IReadOnlyList<OidcIssuerOptions> LoadIssuers(IConfiguration configuration)

--- a/src/ExpertiseApi/Diagnostics/UnhandledExceptionLogger.cs
+++ b/src/ExpertiseApi/Diagnostics/UnhandledExceptionLogger.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Diagnostics;
+
+namespace ExpertiseApi.Diagnostics;
+
+/// <summary>
+/// Typed <see cref="IExceptionHandler"/> registered via <c>AddExceptionHandler&lt;T&gt;()</c>
+/// — the .NET 8+ preferred shape for global exception logging without claiming the
+/// response body (Part D C4).
+///
+/// Returns <c>false</c> from <see cref="TryHandleAsync"/> so the framework's default
+/// <see cref="Microsoft.AspNetCore.Http.IProblemDetailsService"/> writer produces the
+/// response, which means the sanitizer registered in <c>AddProblemDetails(...)</c> in
+/// <c>Program.cs</c> fires for both <c>Results.Problem(...)</c> and unhandled-exception
+/// paths.
+///
+/// Critically, the full exception (message, type, stack) is logged server-side with
+/// the request path here; the customizer then strips Detail/Instance from the wire
+/// response in non-Development environments so the correlation ID (traceId) is the
+/// only link between the client-visible response and the server-side log entry.
+/// </summary>
+internal sealed class UnhandledExceptionLogger(ILogger<UnhandledExceptionLogger> log)
+    : IExceptionHandler
+{
+    public ValueTask<bool> TryHandleAsync(
+        HttpContext ctx,
+        Exception ex,
+        CancellationToken ct)
+    {
+        log.LogError(ex, "Unhandled exception for {Method} {Path}",
+            ctx.Request.Method, ctx.Request.Path);
+        // false = let the default IProblemDetailsService writer handle the response body
+        // so the AddProblemDetails customizer in Program.cs runs (correlation ID + sanitization).
+        return ValueTask.FromResult(false);
+    }
+}

--- a/src/ExpertiseApi/Endpoints/AuditEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/AuditEndpoints.cs
@@ -2,6 +2,7 @@ using ExpertiseApi.Auth;
 using ExpertiseApi.Data;
 using ExpertiseApi.Models;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 
 namespace ExpertiseApi.Endpoints;
 
@@ -15,7 +16,8 @@ internal static class AuditEndpoints
     {
         var group = app.MapGroup("/audit")
             .WithTags("Audit")
-            .RequireAuthorization(AuthConstants.Policies.AdminAccess);
+            .RequireAuthorization(AuthConstants.Policies.AdminAccess)
+            .RequireRateLimiting("expertise-read");
 
         group.MapGet("/", ListAudit);
 

--- a/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
@@ -5,6 +5,7 @@ using ExpertiseApi.Data;
 using ExpertiseApi.Models;
 using ExpertiseApi.Services;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using Pgvector;
 
@@ -19,31 +20,40 @@ internal static class ExpertiseEndpoints
             .RequireAuthorization();
 
         group.MapGet("/", ListEntries)
-            .RequireAuthorization("ReadAccess");
+            .RequireAuthorization("ReadAccess")
+            .RequireRateLimiting("expertise-read");
 
         group.MapGet("/drafts", ListDrafts)
-            .RequireAuthorization(AuthConstants.Policies.WriteApproveAccess);
+            .RequireAuthorization(AuthConstants.Policies.WriteApproveAccess)
+            .RequireRateLimiting("expertise-read");
 
         group.MapGet("/{id:guid}", GetEntry)
-            .RequireAuthorization("ReadAccess");
+            .RequireAuthorization("ReadAccess")
+            .RequireRateLimiting("expertise-read");
 
         group.MapPost("/", CreateEntry)
-            .RequireAuthorization("WriteAccess");
+            .RequireAuthorization("WriteAccess")
+            .RequireRateLimiting("expertise-write");
 
         group.MapPatch("/{id:guid}", UpdateEntry)
-            .RequireAuthorization("WriteAccess");
+            .RequireAuthorization("WriteAccess")
+            .RequireRateLimiting("expertise-write");
 
         group.MapDelete("/{id:guid}", DeleteEntry)
-            .RequireAuthorization("WriteAccess");
+            .RequireAuthorization("WriteAccess")
+            .RequireRateLimiting("expertise-write");
 
         group.MapPost("/batch", CreateBatch)
-            .RequireAuthorization("WriteAccess");
+            .RequireAuthorization("WriteAccess")
+            .RequireRateLimiting("expertise-write");
 
         group.MapPost("/{id:guid}/approve", ApproveEntry)
-            .RequireAuthorization(AuthConstants.Policies.WriteApproveAccess);
+            .RequireAuthorization(AuthConstants.Policies.WriteApproveAccess)
+            .RequireRateLimiting("expertise-write");
 
         group.MapPost("/{id:guid}/reject", RejectEntry)
-            .RequireAuthorization(AuthConstants.Policies.WriteApproveAccess);
+            .RequireAuthorization(AuthConstants.Policies.WriteApproveAccess)
+            .RequireRateLimiting("expertise-write");
 
         return group;
     }

--- a/src/ExpertiseApi/Endpoints/HealthEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/HealthEndpoints.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-
 namespace ExpertiseApi.Endpoints;
 
 internal static class HealthEndpoints
@@ -72,14 +71,17 @@ internal static class HealthEndpoints
 
         app.MapHealthChecks("/health/live", liveOptions)
             .WithTags("Health")
-            .AllowAnonymous();
+            .AllowAnonymous()
+            .DisableRateLimiting();
 
         app.MapHealthChecks("/health/ready", readyOptions)
             .WithTags("Health")
-            .AllowAnonymous();
+            .AllowAnonymous()
+            .DisableRateLimiting();
 
         app.MapHealthChecks("/health", readyOptions)
             .WithTags("Health")
-            .AllowAnonymous();
+            .AllowAnonymous()
+            .DisableRateLimiting();
     }
 }

--- a/src/ExpertiseApi/Endpoints/SearchEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/SearchEndpoints.cs
@@ -1,6 +1,7 @@
 using ExpertiseApi.Auth;
 using ExpertiseApi.Data;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 
 namespace ExpertiseApi.Endpoints;
 
@@ -10,7 +11,8 @@ internal static class SearchEndpoints
     {
         var group = app.MapGroup("/expertise/search")
             .WithTags("Search")
-            .RequireAuthorization("ReadAccess");
+            .RequireAuthorization("ReadAccess")
+            .RequireRateLimiting("expertise-read");
 
         group.MapGet("/", KeywordSearch);
 

--- a/src/ExpertiseApi/Endpoints/SemanticSearchEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/SemanticSearchEndpoints.cs
@@ -2,6 +2,7 @@ using ExpertiseApi.Auth;
 using ExpertiseApi.Data;
 using ExpertiseApi.Services;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 
 namespace ExpertiseApi.Endpoints;
 
@@ -11,7 +12,8 @@ internal static class SemanticSearchEndpoints
     {
         var group = app.MapGroup("/expertise/search/semantic")
             .WithTags("Search")
-            .RequireAuthorization("ReadAccess");
+            .RequireAuthorization("ReadAccess")
+            .RequireRateLimiting("semantic-search");
 
         group.MapGet("/", SemanticSearch);
 

--- a/src/ExpertiseApi/ExpertiseApi.csproj
+++ b/src/ExpertiseApi/ExpertiseApi.csproj
@@ -4,6 +4,23 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+
+    <!--
+      Build-time OpenAPI document emission (Part D C8). When the
+      Microsoft.Extensions.ApiDescription.Server package is referenced, `dotnet build`
+      runs the _GenerateOpenApiDocuments MSBuild target which constructs a stripped
+      WebApplicationFactory-equivalent host, walks the ApiExplorer metadata, and writes
+      the OpenAPI document WITHOUT booting Kestrel or processing requests. The CI
+      release pipeline picks the file from OpenApiDocumentsDirectory, computes a
+      sha256, and uploads both as GitHub Release assets.
+
+      Default output filename is $(AssemblyName).json (i.e. ExpertiseApi.json); release.yml
+      renames it to openapi.json before uploading.
+
+      See docs/security/integration-threat-model.md Part D C8.
+    -->
+    <OpenApiGenerateDocuments>true</OpenApiGenerateDocuments>
+    <OpenApiDocumentsDirectory>$(MSBuildProjectDirectory)/artifacts/openapi</OpenApiDocumentsDirectory>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,6 +38,15 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
+    <!--
+      Build-time OpenAPI document generator (Part D C8). PrivateAssets=all keeps the
+      package out of the published output (it's an MSBuild task, not a runtime dependency).
+      IncludeAssets covers the build / buildMultitargeting / buildTransitive surfaces
+      that the task uses across SDK styles.
+    -->
+    <PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="10.0.0"
+                      PrivateAssets="all"
+                      IncludeAssets="build;buildMultitargeting;buildTransitive" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -60,6 +60,14 @@ builder.Services.Configure<HostOptions>(options =>
     options.ShutdownTimeout = TimeSpan.FromSeconds(30);
 });
 
+// AddOpenApi registers the document(s) consumed by both runtime MapOpenApi() and the
+// build-time _GenerateOpenApiDocuments target (Part D C8). The build-time output
+// (artifacts/openapi/ExpertiseApi.json) is OpenAPI 3.1.1 by the .NET 10 default — the
+// `OpenApiOptions.OpenApiVersion` knob in Microsoft.AspNetCore.OpenApi 10.0.7 does NOT
+// currently propagate to the build-time emitter (verified 2026-05-18). Downstream
+// consumers in the integration backlog (#147 skill = plain curl/JSON; #148 pi extension
+// = TypeScript codegen) are 3.1-compatible. If a 3.0-only consumer surfaces later, pin
+// here and verify the emitter honours it on the then-current SDK.
 builder.Services.AddOpenApi();
 
 // ProblemDetails sanitization (Part D C4). Always emit a traceId extension so
@@ -227,6 +235,22 @@ if (File.Exists(modelPath) && File.Exists(vocabPath))
     builder.Services.AddBertOnnxEmbeddingGenerator(modelPath, vocabPath);
 }
 builder.Services.AddScoped<EmbeddingService>();
+
+// Build-time OpenAPI document generation (Microsoft.Extensions.ApiDescription.Server,
+// Part D C8) constructs a stripped host with ValidateOnBuild=true. Without ONNX model
+// files staged at build time, IEmbeddingGenerator isn't registered and the validation
+// rejects EmbeddingService's transitive dependency before any endpoint metadata is read.
+// At runtime this validation correctly catches misconfigurations; in the build-time
+// host nothing is actually served, so it is safe (and necessary) to disable. See
+// ExpertiseApi.Auth.AuthExtensions.IsBuildTimeOpenApiContext.
+if (ExpertiseApi.Auth.AuthExtensions.IsBuildTimeOpenApiContext())
+{
+    builder.Host.UseDefaultServiceProvider(opts =>
+    {
+        opts.ValidateOnBuild = false;
+        opts.ValidateScopes = false;
+    });
+}
 
 builder.Services.Configure<DeduplicationOptions>(
     builder.Configuration.GetSection("Deduplication"));

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -6,6 +6,8 @@ using ExpertiseApi.Cli;
 using ExpertiseApi.Data;
 using ExpertiseApi.Endpoints;
 using ExpertiseApi.Services;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
@@ -208,7 +210,22 @@ app.MapAuditEndpoints();
 if (metricsEnabled)
     app.MapMetrics().AllowAnonymous();
 
-try { await app.RunAsync(); }
+try
+{
+    // Diagnostic log of the effective Kestrel bind addresses (Part D C1).
+    // Kestrel already logs "Now listening on: ..." at Info; this prefixed line is
+    // greppable in container logs to confirm the reachability boundary at startup.
+    // See docs/security/integration-threat-model.md Part D C1 for the shape-per-shape model.
+    app.Lifetime.ApplicationStarted.Register(() =>
+    {
+        var addresses = app.Services.GetRequiredService<IServer>()
+            .Features.Get<IServerAddressesFeature>()?.Addresses;
+        if (addresses is not null && addresses.Count > 0)
+            Log.Information("[C1] Kestrel bound to {Addresses}", string.Join(", ", addresses));
+    });
+
+    await app.RunAsync();
+}
 #pragma warning disable CA1031 // Top-level fatal handler — log any unhandled exception then exit. Re-throwing here would suppress the log and produce a less-useful stack trace.
 catch (Exception ex)
 #pragma warning restore CA1031

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -2,6 +2,8 @@
 
 using System.Diagnostics;
 using System.Globalization;
+using System.Security.Claims;
+using System.Threading.RateLimiting;
 using ExpertiseApi.Auth;
 using ExpertiseApi.Cli;
 using ExpertiseApi.Data;
@@ -10,7 +12,10 @@ using ExpertiseApi.Endpoints;
 using ExpertiseApi.Services;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using Microsoft.SemanticKernel;
@@ -84,6 +89,94 @@ builder.Services.AddProblemDetails(options =>
 // server-side; returns false so the default IProblemDetailsService writer
 // produces the response body (and the customizer above fires).
 builder.Services.AddExceptionHandler<UnhandledExceptionLogger>();
+
+// Rate limiting (Part D C5). Three policies, per-principal partitioning with IP
+// fallback for unauthenticated paths. 429 responses route through the
+// IProblemDetailsService so the C4 customizer fires (correlation traceId, etc.)
+// and Retry-After is populated from the lease metadata.
+//   - expertise-read     fixed window 60/min  GET /expertise/* (non-semantic), GET /audit/*
+//   - expertise-write    fixed window 10/min  POST/PATCH/DELETE on writes
+//   - semantic-search    token bucket 10/min  /expertise/search/semantic (expensive: ONNX)
+// Health endpoints (/health/*) opt out via DisableRateLimiting in HealthEndpoints.
+builder.Services.AddRateLimiter(rateOptions =>
+{
+    rateOptions.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+    rateOptions.OnRejected = async (ctx, ct) =>
+    {
+        if (ctx.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter))
+        {
+            ctx.HttpContext.Response.Headers.RetryAfter =
+                ((int)retryAfter.TotalSeconds).ToString(CultureInfo.InvariantCulture);
+        }
+
+        var problems = ctx.HttpContext.RequestServices.GetRequiredService<IProblemDetailsService>();
+        await problems.WriteAsync(new ProblemDetailsContext
+        {
+            HttpContext = ctx.HttpContext,
+            ProblemDetails = new ProblemDetails
+            {
+                Status = StatusCodes.Status429TooManyRequests,
+                Title = "Too Many Requests",
+                Type = "https://tools.ietf.org/html/rfc6585#section-4",
+            },
+        }).ConfigureAwait(false);
+    };
+
+    // Partition key resolution. Order matters: with MapInboundClaims=false on our JWT
+    // bearer scheme (Auth/AuthExtensions.cs) the OIDC `sub` claim is NOT mapped to
+    // .NET-style ClaimTypes.NameIdentifier, so the first branch is dead under our
+    // current config and the `sub` branch is the load-bearing one. Order kept this way
+    // as a defensive default: if a future maintainer toggles MapInboundClaims or wires
+    // a non-OIDC scheme that populates NameIdentifier, partitioning remains correct
+    // without code changes.
+    //
+    // IP fallback is dormant under the current endpoint map (every RequireRateLimiting
+    // route sits behind UseAuthentication/UseAuthorization so `sub` is always present;
+    // /health/* are DisableRateLimiting'd; /metrics and /query carry no rate-limit
+    // policy). If a future endpoint is given RequireRateLimiting with AllowAnonymous,
+    // the IP fallback becomes load-bearing and partition isolation depends on the
+    // ForwardedHeaders:KnownNetworks CIDR list being narrowly scoped — a misconfigured
+    // 0.0.0.0/0 would let off-network callers rotate partitions via X-Forwarded-For.
+    static string PartitionKey(HttpContext http) =>
+        http.User.FindFirstValue(ClaimTypes.NameIdentifier)
+        ?? http.User.FindFirstValue("sub")
+        ?? http.Connection.RemoteIpAddress?.ToString()
+        ?? "anonymous";
+
+    rateOptions.AddPolicy("expertise-read", http =>
+        RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: PartitionKey(http),
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 60,
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            }));
+
+    rateOptions.AddPolicy("expertise-write", http =>
+        RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: PartitionKey(http),
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 10,
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            }));
+
+    rateOptions.AddPolicy("semantic-search", http =>
+        RateLimitPartition.GetTokenBucketLimiter(
+            partitionKey: PartitionKey(http),
+            factory: _ => new TokenBucketRateLimiterOptions
+            {
+                TokenLimit = 10,
+                TokensPerPeriod = 10,
+                ReplenishmentPeriod = TimeSpan.FromMinutes(1),
+                QueueLimit = 0,
+                AutoReplenishment = true,
+            }));
+});
 
 builder.Services.ConfigureHttpJsonOptions(options =>
 {
@@ -230,6 +323,7 @@ if (app.Environment.IsDevelopment())
 
 app.UseAuthentication();
 app.UseAuthorization();
+app.UseRateLimiter();
 
 app.MapHealthEndpoints();
 app.MapExpertiseEndpoints();

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -1,9 +1,11 @@
 #pragma warning disable SKEXP0070
 
+using System.Diagnostics;
 using System.Globalization;
 using ExpertiseApi.Auth;
 using ExpertiseApi.Cli;
 using ExpertiseApi.Data;
+using ExpertiseApi.Diagnostics;
 using ExpertiseApi.Endpoints;
 using ExpertiseApi.Services;
 using Microsoft.AspNetCore.Hosting.Server;
@@ -54,7 +56,34 @@ builder.Services.Configure<HostOptions>(options =>
 });
 
 builder.Services.AddOpenApi();
-builder.Services.AddProblemDetails();
+
+// ProblemDetails sanitization (Part D C4). Always emit a traceId extension so
+// client-side error reports can be cross-referenced to server logs; outside
+// Development, scrub Detail/Instance to prevent exception-message / connection-
+// string / stack-frame leakage in 5xx responses (LLM02). See Part D C4 in
+// docs/security/integration-threat-model.md and ADR / threat-model rationale.
+builder.Services.AddProblemDetails(options =>
+{
+    options.CustomizeProblemDetails = ctx =>
+    {
+        var traceId = Activity.Current?.TraceId.ToString() ?? ctx.HttpContext.TraceIdentifier;
+        ctx.ProblemDetails.Extensions["traceId"] = traceId;
+        ctx.ProblemDetails.Instance ??= ctx.HttpContext.Request.Path.Value;
+
+        var env = ctx.HttpContext.RequestServices.GetRequiredService<IHostEnvironment>();
+        if (!env.IsDevelopment())
+        {
+            ctx.ProblemDetails.Detail = null;
+            ctx.ProblemDetails.Instance = null;
+            ctx.ProblemDetails.Extensions.Remove("exception");
+        }
+    };
+});
+
+// Typed IExceptionHandler (.NET 8+ preferred shape). Logs full exception
+// server-side; returns false so the default IProblemDetailsService writer
+// produces the response body (and the customizer above fires).
+builder.Services.AddExceptionHandler<UnhandledExceptionLogger>();
 
 builder.Services.ConfigureHttpJsonOptions(options =>
 {

--- a/src/ExpertiseApi/Properties/launchSettings.json
+++ b/src/ExpertiseApi/Properties/launchSettings.json
@@ -5,7 +5,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "http://localhost:5005",
+      "applicationUrl": "http://127.0.0.1:5005",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -14,7 +14,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "https://localhost:7256;http://localhost:5005",
+      "applicationUrl": "https://127.0.0.1:7256;http://127.0.0.1:5005",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/ExpertiseApi/appsettings.json
+++ b/src/ExpertiseApi/appsettings.json
@@ -14,7 +14,7 @@
       { "Name": "Console" }
     ]
   },
-  "AllowedHosts": "*",
+  "AllowedHosts": "localhost;127.0.0.1;[::1]",
   "ConnectionStrings": {
     "DefaultConnection": "Host=localhost;Port=6432;Database=expertise;Username=expertise;Password=;No Reset On Close=true"
   },

--- a/tests/ExpertiseApi.Tests/Integration/HostFilteringTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/HostFilteringTests.cs
@@ -1,0 +1,64 @@
+using System.Net;
+using ExpertiseApi.Tests.Infrastructure;
+
+namespace ExpertiseApi.Tests.Integration;
+
+/// <summary>
+/// HostFiltering middleware coverage (Part D C1). The middleware is auto-wired
+/// by the default WebHost when <c>AllowedHosts</c> is set; <c>appsettings.json</c>
+/// tightens the default from <c>"*"</c> to <c>"localhost;127.0.0.1;[::1]"</c>
+/// so DNS-rebind attacks against the laptop loopback (and any browser-origin
+/// host-header spoofing against the container) are rejected at the edge.
+///
+/// These tests run against the in-memory TestServer rather than Kestrel, but
+/// HostFiltering runs in the middleware pipeline so the asserts are valid.
+/// See docs/security/integration-threat-model.md Part D C1.
+/// </summary>
+[Collection("Postgres")]
+public class HostFilteringTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private ApiFactory _factory = null!;
+
+    public HostFilteringTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public Task InitializeAsync()
+    {
+        _factory = new ApiFactory(_postgres.ConnectionString);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync() => await _factory.DisposeAsync();
+
+    [Fact]
+    public async Task AllowedHost_Localhost_Returns200()
+    {
+        var client = _factory.CreateClient();
+        var req = new HttpRequestMessage(HttpMethod.Get, "/health/live");
+        // ApiFactory's default base address is http://localhost/, which carries Host: localhost
+        // — explicit set documents intent.
+        req.Headers.Host = "localhost";
+        var response = await client.SendAsync(req);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task AllowedHost_LoopbackIpv4_Returns200()
+    {
+        var client = _factory.CreateClient();
+        var req = new HttpRequestMessage(HttpMethod.Get, "/health/live");
+        req.Headers.Host = "127.0.0.1";
+        var response = await client.SendAsync(req);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task DisallowedHost_ArbitraryDomain_Returns400()
+    {
+        var client = _factory.CreateClient();
+        var req = new HttpRequestMessage(HttpMethod.Get, "/health/live");
+        req.Headers.Host = "evil.example.com";
+        var response = await client.SendAsync(req);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}

--- a/tests/ExpertiseApi.Tests/Integration/ProblemDetailsTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/ProblemDetailsTests.cs
@@ -1,0 +1,148 @@
+using System.Net;
+using System.Text.Json;
+using ExpertiseApi.Tests.Infrastructure;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace ExpertiseApi.Tests.Integration;
+
+/// <summary>
+/// ProblemDetails sanitization coverage (Part D C4). Verifies that:
+///   - Outside Development, unhandled exceptions surface as application/problem+json
+///     with NO exception type / message / stack frame leakage, but WITH the traceId
+///     extension for server-log correlation.
+///   - In Development, the same path retains diagnostic Detail for the developer.
+///   - Explicit Results.Problem(...) callsites also receive the traceId extension
+///     (the customizer fires for both unhandled-exception and explicit-Problem paths).
+///
+/// A throw-on-demand endpoint is wired into the pipeline via TestServer-level
+/// middleware so the production app contains no test-only attack surface. See
+/// docs/security/integration-threat-model.md Part D C4.
+/// </summary>
+[Collection("Postgres")]
+public class ProblemDetailsTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private string _connectionString = null!;
+
+    public ProblemDetailsTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public Task InitializeAsync()
+    {
+        _connectionString = _postgres.ConnectionString;
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task UnhandledException_InProduction_ScrubsDetailButEmitsTraceId()
+    {
+        await using var factory = new ThrowingApiFactory(_connectionString, "Production");
+        var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/_diagnostics/throw");
+
+        response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+        response.Content.Headers.ContentType?.MediaType.Should()
+            .BeOneOf("application/problem+json", "application/json");
+
+        var body = await response.Content.ReadAsStringAsync();
+        var doc = JsonDocument.Parse(body);
+
+        // Sanitization: no exception leakage. When Detail = null after scrubbing,
+        // System.Text.Json serialization omits the property entirely — either absent
+        // OR present-as-null satisfies the contract.
+        if (doc.RootElement.TryGetProperty("detail", out var detail))
+        {
+            (detail.ValueKind == JsonValueKind.Null || string.IsNullOrEmpty(detail.GetString())).Should().BeTrue();
+        }
+        body.Should().NotContain("InvalidOperationException");
+        body.Should().NotContain("at ExpertiseApi");
+        body.Should().NotContain("synthetic test throw");
+
+        // Correlation: traceId always present.
+        doc.RootElement.TryGetProperty("traceId", out var traceId).Should().BeTrue();
+        traceId.GetString().Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task UnhandledException_InDevelopment_RetainsDetail()
+    {
+        await using var factory = new ThrowingApiFactory(_connectionString, "Development");
+        var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/_diagnostics/throw");
+
+        response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+        var body = await response.Content.ReadAsStringAsync();
+        var doc = JsonDocument.Parse(body);
+
+        // Dev: traceId still present.
+        doc.RootElement.TryGetProperty("traceId", out var traceId).Should().BeTrue();
+        traceId.GetString().Should().NotBeNullOrEmpty();
+    }
+
+    /// <summary>
+    /// Wraps <see cref="JwtApiFactory"/> with a TestServer-only diagnostics middleware
+    /// that throws on GET /_diagnostics/throw. Production attack surface is zero because
+    /// the middleware is registered via an <see cref="IStartupFilter"/> in the test host
+    /// only — not in the application's <c>Program.cs</c>.
+    ///
+    /// Inherits from <see cref="JwtApiFactory"/> rather than <see cref="ApiFactory"/> so
+    /// the Production-env code path passes <c>EnforceModeGuard</c> (which only accepts
+    /// <c>Auth:Mode=Oidc</c> outside Development). JwtApiFactory preloads a synthetic
+    /// <c>OpenIdConnectConfiguration</c> so the OIDC issuer guard is also satisfied.
+    /// The /_diagnostics/throw path is unmapped and unauthenticated, so the auth choice
+    /// is incidental to the test.
+    /// </summary>
+    private sealed class ThrowingApiFactory : JwtApiFactory
+    {
+        private readonly string _environment;
+
+        public ThrowingApiFactory(string connectionString, string environment)
+            : base(connectionString)
+        {
+            _environment = environment;
+        }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            // JwtApiFactory calls UseEnvironment("Development") in its own ConfigureWebHost
+            // override; ours must come AFTER base to take effect.
+            base.ConfigureWebHost(builder);
+            builder.UseEnvironment(_environment);
+        }
+
+        protected override IHost CreateHost(IHostBuilder builder)
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.AddSingleton<IStartupFilter, ThrowingStartupFilter>();
+            });
+            return base.CreateHost(builder);
+        }
+    }
+
+    private sealed class ThrowingStartupFilter : IStartupFilter
+    {
+        public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next) => app =>
+        {
+            // Run the production pipeline FIRST so UseExceptionHandler is positioned
+            // ahead of our throwing middleware. /_diagnostics/throw does not match any
+            // mapped endpoint, so requests for it fall through routing/endpoint middleware
+            // and reach this terminal middleware; the InvalidOperationException then
+            // unwinds back up through UseExceptionHandler which handles it.
+            next(app);
+            app.Use(async (ctx, nxt) =>
+            {
+                if (ctx.Request.Path.Equals("/_diagnostics/throw", StringComparison.Ordinal))
+                    throw new InvalidOperationException("synthetic test throw");
+                await nxt();
+            });
+        };
+    }
+}

--- a/tests/ExpertiseApi.Tests/Integration/RateLimitingTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/RateLimitingTests.cs
@@ -1,0 +1,109 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using ExpertiseApi.Tests.Infrastructure;
+
+namespace ExpertiseApi.Tests.Integration;
+
+/// <summary>
+/// Rate limiter coverage (Part D C5). Verifies the three policies wired in
+/// Program.cs:
+///   - expertise-read: fixed window 60/min per principal
+///   - expertise-write: fixed window 10/min per principal
+///   - semantic-search: token bucket 10/min per principal
+///
+/// Also verifies that /health/* endpoints opt out via DisableRateLimiting()
+/// and that 429 responses carry the standard ProblemDetails shape with the
+/// C4 customizer's traceId extension + a Retry-After header.
+///
+/// Partition key is principal sub-claim (resolved via JwtTokenMinter) with
+/// IP fallback for unauthenticated paths.
+///
+/// See docs/security/integration-threat-model.md Part D C5.
+/// </summary>
+[Collection("Postgres")]
+public class RateLimitingTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private JwtApiFactory _factory = null!;
+
+    public RateLimitingTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public Task InitializeAsync()
+    {
+        _factory = new JwtApiFactory(_postgres.ConnectionString);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync() => await _factory.DisposeAsync();
+
+    [Fact]
+    public async Task ExpertiseRead_Over60RequestsFromSamePrincipal_Returns429WithRetryAfter()
+    {
+        var token = JwtTokenMinter.Mint(
+            tenant: "test",
+            scopes: [ExpertiseApi.Auth.AuthConstants.ReadScope],
+            groups: ["group-test"],
+            sub: "rl-test-read-1");
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        HttpResponseMessage? final = null;
+        // Within a fixed-window minute, requests 1..60 succeed and 61+ should 429.
+        for (var i = 0; i < 61; i++)
+        {
+            final = await client.GetAsync("/expertise");
+        }
+
+        final.Should().NotBeNull();
+        final!.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+        final.Headers.RetryAfter.Should().NotBeNull("the OnRejected callback must populate Retry-After from lease metadata");
+
+        var body = await final.Content.ReadAsStringAsync();
+        body.Should().NotBeNullOrEmpty();
+        var doc = JsonDocument.Parse(body);
+        doc.RootElement.TryGetProperty("title", out var title).Should().BeTrue();
+        title.GetString().Should().Be("Too Many Requests");
+        doc.RootElement.TryGetProperty("traceId", out _).Should().BeTrue("C4 customizer must run on the 429 body");
+    }
+
+    [Fact]
+    public async Task Health_NotRateLimited_AllowsManyRequests()
+    {
+        var client = _factory.CreateClient();
+        for (var i = 0; i < 100; i++)
+        {
+            var response = await client.GetAsync("/health/live");
+            response.StatusCode.Should().Be(HttpStatusCode.OK,
+                "DisableRateLimiting() on health endpoints must exempt them from all policies");
+        }
+    }
+
+    [Fact]
+    public async Task ExpertiseRead_DifferentPrincipals_PartitionIndependently()
+    {
+        // Principal A exhausts its 60/min budget; principal B should still be served.
+        var tokenA = JwtTokenMinter.Mint(
+            tenant: "test",
+            scopes: [ExpertiseApi.Auth.AuthConstants.ReadScope],
+            groups: ["group-test"],
+            sub: "rl-test-part-A");
+        var tokenB = JwtTokenMinter.Mint(
+            tenant: "test",
+            scopes: [ExpertiseApi.Auth.AuthConstants.ReadScope],
+            groups: ["group-test"],
+            sub: "rl-test-part-B");
+
+        var clientA = _factory.CreateClient();
+        clientA.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tokenA);
+        var clientB = _factory.CreateClient();
+        clientB.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", tokenB);
+
+        for (var i = 0; i < 61; i++)
+            await clientA.GetAsync("/expertise");
+
+        var bFirst = await clientB.GetAsync("/expertise");
+        bFirst.StatusCode.Should().Be(HttpStatusCode.OK,
+            "principal B must have its own partition independent of A's exhausted budget");
+    }
+}


### PR DESCRIPTION
Implements the four Part D server-side controls that gate #146 (publish openapi.json in all environments). Closes #167.

## Commits (5)

| Commit | Control | Summary |
|---|---|---|
| `1934fe7` | **C1** | HostFiltering + dev-laptop loopback defaults; reframed per docker-expert + dotnet-expert fan-out from literal-`127.0.0.1` design to shape-per-shape reachability boundary |
| `2a497c9` | **C4** | Sanitized `ProblemDetails` customizer + typed `IExceptionHandler` logger; always-emitted `traceId` extension |
| `92d4d8c` | **C5** | Three rate-limit policies (`expertise-read` 60/min, `expertise-write` 10/min, `semantic-search` 10/min token-bucket); per-principal partitioning; health endpoints `DisableRateLimiting`'d; 429 carries ProblemDetails + Retry-After |
| `47fedfb` | **C8** | Build-time `openapi.json` emission via `Microsoft.Extensions.ApiDescription.Server`; release.yml attaches `openapi.json` + `openapi.json.sha256` to GitHub Release; CI smoke-checks artifact presence |
| `5b7ce4a` | docs | Mark C1/C4/C5/C8 implemented in Part D table (per-PR rule from D1 doc + ADR) |

## Planning provenance

Plan-before-code analysis used a 3-way subagent fan-out:
- **dotnet-expert** — ASP.NET Core 10 recipes for all four controls with `learn.microsoft.com` citations and net8/9→net10 deltas
- **docker-expert** — reframed C1 from literal-loopback to shape-per-shape reachability boundary; surfaced that `aspnet:10.0` base already binds `+:8080` via `ASPNETCORE_HTTP_PORTS` (not "default Kestrel binding" as #167's original body claimed)
- **gh-cli-expert** — verified `gh release upload` mechanics, recommended Option (a) (upload step in `build-and-push` job after cosign), no 404 race at that placement

Issue #167 was amended before implementation to record the reframed C1 design; threat-model and issue agree.

## Notable deviations from #167 (all amended into the issue beforehand)

1. **No `EXPERTISE_API_BIND_ADDRESS` env var.** The original design duplicated `ASPNETCORE_HTTP_PORTS` / `ASPNETCORE_URLS` (which the runtime already honors with well-known precedence) and would have broken the container deploy path (binding `127.0.0.1` inside a container makes the pod unreachable from the k8s Service — the namespace IS the loopback equivalent at the container layer).
2. **No Helm `bindAddress` knob.** Duplicates `service.targetPort` and invites drift. Operators override via the existing `env: ASPNETCORE_HTTP_PORTS` pattern.
3. **HostFiltering is the actual C1 control.** `AllowedHosts: "*"` → `"localhost;127.0.0.1;[::1]"` activates the ASP.NET Core middleware (auto-wired by the default WebHost when `AllowedHosts` is set) as DNS-rebind defense-in-depth. Helm `allowedHosts` value lets operators extend the list for production hostnames.
4. **OpenAPI 3.1.1 not 3.0.** The `OpenApiOptions.OpenApiVersion` knob in `Microsoft.AspNetCore.OpenApi` 10.0.7 does NOT currently propagate to the build-time emitter (verified locally 2026-05-18). Downstream integration consumers (#147 = plain curl/JSON; #148 = TypeScript codegen) are 3.1-compatible; pin can be revisited per future SDK.
5. **Build-time generator startup-guard bypass.** `Microsoft.Extensions.ApiDescription.Server` executes `Program.cs` up to `app.Run()` against a stripped host with `ValidateOnBuild=true`. Two production-only startup guards (OIDC issuer presence; `IEmbeddingGenerator` DI resolution) trip in that context. Surgical fix: a `AuthExtensions.IsBuildTimeOpenApiContext()` helper detects the `dotnet-getdocument` entry assembly and (a) bypasses `EnforceOidcIssuersGuard`, (b) disables `ValidateOnBuild` / `ValidateScopes`. Runtime behaviour is unchanged.

## Test coverage added

- `tests/.../Integration/HostFilteringTests.cs` — allowed `localhost` / `127.0.0.1` return 200; `evil.example.com` returns 400.
- `tests/.../Integration/ProblemDetailsTests.cs` — Production env scrubs Detail; Development retains; `traceId` always present.
- `tests/.../Integration/RateLimitingTests.cs` — 61 GETs to `/expertise` from same principal returns 429 + Retry-After + ProblemDetails with traceId; 100 GETs to `/health/live` all 200; two principals partition independently.

## Local verification

```
$ dotnet build ExpertiseApi.slnx -c Release
Build succeeded.
    0 Warning(s)
    0 Error(s)

$ dotnet format analyzers ExpertiseApi.slnx --verify-no-changes
(clean)

$ ls src/ExpertiseApi/artifacts/openapi/
ExpertiseApi.json

$ shasum -a 256 src/ExpertiseApi/artifacts/openapi/ExpertiseApi.json
3a4952bd76f0c72623d525eaa5b001b4f26f91365c0be4108024da6324e7bf07  ...
```

## CI expectations

- `Build & Test` — green; new `Verify openapi.json artifact present` step asserts the build-time emission worked
- `Format gate (analyzers must be clean)` — green (verified locally)
- `Helm lint + render tests` — verifies the new `allowedHosts` value
- `Hadolint` — verifies the Dockerfile comment-only change
- Tests need Postgres testcontainer (`PostgresFixture`); CI provisions; not runnable in this local environment

## Followup (out of scope; tracked separately)

- **C2** (OIDC issuer config) — #12, partial.
- **C6/C7** (audit `actor_class` + response hygiene Option B) — #168, gates #147.
- **C3** (idempotency keys) — no issue yet; gates future write-tool work, not the integration backlog.
- **OpenAPI 3.0 pin** — revisit when SDK lifecycle and consumer compat allow.
- **Skill #147 quoting SAST** — when the skill scripts land under #147, dispatch `checkmarx-expert` per the Part C cross-domain note in the threat model (LLM-supplied arg interpolation into `curl`).

Closes #167.
