### PR TITLE
feat(api): publish openapi.json + decorate endpoints (closes #146)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,22 @@ flowchart LR
 | GET | `/health/ready` | Readiness — 200 only when DB, ONNX model, and pending-migration checks are all healthy; 503 otherwise. Map this to k8s `readinessProbe` and load-balancer health checks. No auth. |
 | GET | `/health` | Back-compat alias for `/health/ready`. No auth. |
 | GET | `/metrics` | Prometheus scrape endpoint (no auth required) |
+| GET | `/openapi/v1.json` | OpenAPI 3.x document for this deployment (anonymous, all environments). Also attached as a release asset — see ["OpenAPI discovery"](#openapi-discovery) below |
 | GET | `/query` | Interactive query page (read-only, no auth to load) |
 
-All endpoints except `/health`, `/health/live`, `/health/ready`, `/query`, and `/metrics` require `Authorization: Bearer <token>` — a JWT (`Auth:Mode = Oidc`) or, in Development, an API key or LocalDev token (`Auth:Mode = Hybrid`). See [SKILL.md](.claude/skills/expertise-api-design/SKILL.md) for scopes, modes, and configuration.
+All endpoints except `/health`, `/health/live`, `/health/ready`, `/query`, `/metrics`, and `/openapi/v1.json` require `Authorization: Bearer <token>` — a JWT (`Auth:Mode = Oidc`) or, in Development, an API key or LocalDev token (`Auth:Mode = Hybrid`). See [SKILL.md](.claude/skills/expertise-api-design/SKILL.md) for scopes, modes, and configuration.
+
+### OpenAPI discovery
+
+The live OpenAPI document is served from `/openapi/v1.json` in **all** environments. The endpoint is anonymous (no bearer required) and not rate-limited so downstream tooling — LLM agents, codegen, third-party clients — can discover the API surface before holding a token.
+
+```bash
+curl https://<host>/openapi/v1.json | jq '.info, .paths | keys'
+```
+
+The document advertises the JWT Bearer security scheme (`components.securitySchemes.Bearer`, `bearerFormat: JWT`) and a document-level `security` requirement. Operations that allow anonymous access (`/health/*`, `/openapi/*`) are excluded from the security requirement by ApiExplorer.
+
+A version-pinned copy is also attached as a release asset (`openapi.json` + `openapi.json.sha256`) on every GitHub Release for offline consumers and codegen pipelines that need byte-stable input. See the [release page](https://github.com/TheSemicolon/agent-expertise-api/releases) and Part D C8 in `docs/security/integration-threat-model.md`. The interactive Scalar UI remains gated to Development (`/scalar/v1`) because the in-browser bearer-token storage pattern carries the same XSS exposure as `/query` (issue #124).
 
 ## Quick Start
 

--- a/src/ExpertiseApi/Endpoints/AuditEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/AuditEndpoints.cs
@@ -19,7 +19,15 @@ internal static class AuditEndpoints
             .RequireAuthorization(AuthConstants.Policies.AdminAccess)
             .RequireRateLimiting("expertise-read");
 
-        group.MapGet("/", ListAudit);
+        group.MapGet("/", ListAudit)
+            .WithSummary("List audit log entries (admin-only, cross-tenant)")
+            .WithDescription("Cross-tenant audit log query for admins. Filters: `entryId`, `principal`, `action`, `from`, `to`, `limit`. " +
+                             "Pagination uses a keyset cursor of `(afterTimestamp, afterId)` \u2014 both must be supplied together; " +
+                             "providing only one is treated as cursor absent.")
+            .Produces<List<ExpertiseAuditLog>>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         return group;
     }

--- a/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
@@ -21,39 +21,121 @@ internal static class ExpertiseEndpoints
 
         group.MapGet("/", ListEntries)
             .RequireAuthorization("ReadAccess")
-            .RequireRateLimiting("expertise-read");
+            .RequireRateLimiting("expertise-read")
+            .WithSummary("List approved expertise entries")
+            .WithDescription("Returns approved entries scoped to the caller's tenant plus any `shared` entries. " +
+                             "Optional filters: `domain`, `tags` (CSV), `entryType`, `severity`, `includeDeprecated`. " +
+                             "Drafts and rejected entries are excluded \u2014 reviewers see those via GET /expertise/drafts.")
+            .Produces<List<ExpertiseEntry>>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         group.MapGet("/drafts", ListDrafts)
             .RequireAuthorization(AuthConstants.Policies.WriteApproveAccess)
-            .RequireRateLimiting("expertise-read");
+            .RequireRateLimiting("expertise-read")
+            .WithSummary("List draft + rejected entries for review")
+            .WithDescription("Reviewer-only queue (`expertise.write.approve` scope). Returns Draft and Rejected entries " +
+                             "in the caller's tenant; shared entries are never surfaced (they bypass the draft state).")
+            .Produces<List<ExpertiseEntry>>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         group.MapGet("/{id:guid}", GetEntry)
             .RequireAuthorization("ReadAccess")
-            .RequireRateLimiting("expertise-read");
+            .RequireRateLimiting("expertise-read")
+            .WithSummary("Fetch a single entry by id")
+            .WithDescription("Returns 200 with the entry if it is visible to the caller's tenant (own tenant or shared); " +
+                             "404 otherwise. Drafts are not surfaced through this endpoint.")
+            .Produces<ExpertiseEntry>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         group.MapPost("/", CreateEntry)
             .RequireAuthorization("WriteAccess")
-            .RequireRateLimiting("expertise-write");
+            .RequireRateLimiting("expertise-write")
+            .Accepts<CreateExpertiseRequest>("application/json")
+            .WithSummary("Create a new expertise entry (Draft by default)")
+            .WithDescription("Creates an entry in Draft state in the caller's tenant. Optional `tenant: \"shared\"` requires " +
+                             "`expertise.write.approve` and bypasses the draft queue (created as Approved). " +
+                             "Returns 409 if a near-duplicate is detected by the dedup service.")
+            .Produces<ExpertiseEntry>(StatusCodes.Status201Created)
+            .Produces<ExpertiseEntry>(StatusCodes.Status409Conflict)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         group.MapPatch("/{id:guid}", UpdateEntry)
             .RequireAuthorization("WriteAccess")
-            .RequireRateLimiting("expertise-write");
+            .RequireRateLimiting("expertise-write")
+            .Accepts<UpdateExpertiseRequest>("application/json")
+            .WithSummary("Partially update an entry")
+            .WithDescription("Only the supplied fields are modified. If `title` or `body` change the embedding is regenerated. " +
+                             "Returns 409 (ConcurrentConflict) when the entry was modified by another request between read and write.")
+            .Produces<ExpertiseEntry>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         group.MapDelete("/{id:guid}", DeleteEntry)
             .RequireAuthorization("WriteAccess")
-            .RequireRateLimiting("expertise-write");
+            .RequireRateLimiting("expertise-write")
+            .WithSummary("Soft-delete an entry")
+            .WithDescription("Marks the entry as deprecated. Soft-deleting a `shared` entry requires `expertise.write.approve`.")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         group.MapPost("/batch", CreateBatch)
             .RequireAuthorization("WriteAccess")
-            .RequireRateLimiting("expertise-write");
+            .RequireRateLimiting("expertise-write")
+            .Accepts<List<CreateExpertiseRequest>>("application/json")
+            .WithSummary("Batch ingest up to 100 entries with per-item failure isolation")
+            .WithDescription("Returns 200 with `BatchEntryResult[]` when every item is Created, or 207 (Multi-Status) when any item is " +
+                             "Duplicate / Rejected / Failed. Embedding generation and deduplication are batched into a single ONNX call " +
+                             "and bulk DB query respectively, so partial failures in one phase do not roll back successful items.")
+            .Produces<List<BatchEntryResult>>(StatusCodes.Status200OK)
+            .Produces<List<BatchEntryResult>>(StatusCodes.Status207MultiStatus)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         group.MapPost("/{id:guid}/approve", ApproveEntry)
             .RequireAuthorization(AuthConstants.Policies.WriteApproveAccess)
-            .RequireRateLimiting("expertise-write");
+            .RequireRateLimiting("expertise-write")
+            .Accepts<ApproveExpertiseRequest>("application/json")
+            .WithSummary("Approve a draft entry (reviewer-only)")
+            .WithDescription("Transitions the entry from Draft to Approved with the supplied `Visibility` " +
+                             "(defaults to Private). Returns 409 if the entry is not currently in Draft state.")
+            .Produces<ExpertiseEntry>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         group.MapPost("/{id:guid}/reject", RejectEntry)
             .RequireAuthorization(AuthConstants.Policies.WriteApproveAccess)
-            .RequireRateLimiting("expertise-write");
+            .RequireRateLimiting("expertise-write")
+            .Accepts<RejectExpertiseRequest>("application/json")
+            .WithSummary("Reject a draft entry (reviewer-only)")
+            .WithDescription("Transitions the entry from Draft to Rejected. A non-empty `rejectionReason` (\u2264 2000 chars) is required.")
+            .Produces<ExpertiseEntry>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         return group;
     }

--- a/src/ExpertiseApi/Endpoints/HealthEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/HealthEndpoints.cs
@@ -69,19 +69,42 @@ internal static class HealthEndpoints
             },
         };
 
+        // Note: MapHealthChecks returns IEndpointConventionBuilder (not RouteHandlerBuilder),
+        // so the typed .Produces<T>() / .ProducesProblem() extensions do not apply. We rely
+        // on .WithMetadata(new ProducesResponseTypeAttribute(...)) for OpenAPI discovery.
+        var ok200 = new Microsoft.AspNetCore.Mvc.ProducesResponseTypeAttribute(
+            typeof(string), StatusCodes.Status200OK);
+        var unavailable503 = new Microsoft.AspNetCore.Mvc.ProducesResponseTypeAttribute(
+            typeof(string), StatusCodes.Status503ServiceUnavailable);
+
         app.MapHealthChecks("/health/live", liveOptions)
             .WithTags("Health")
             .AllowAnonymous()
-            .DisableRateLimiting();
+            .DisableRateLimiting()
+            .WithSummary("Liveness probe (200 while the process responds)")
+            .WithDescription("Returns 200 with the literal text `Healthy` while the process is responsive. Independent of " +
+                             "downstream dependencies (no checks evaluated). systemd `WatchdogSec=` and k8s `livenessProbe` " +
+                             "should point here.")
+            .WithMetadata(ok200);
 
         app.MapHealthChecks("/health/ready", readyOptions)
             .WithTags("Health")
             .AllowAnonymous()
-            .DisableRateLimiting();
+            .DisableRateLimiting()
+            .WithSummary("Readiness probe (200 when all `ready`-tagged checks pass)")
+            .WithDescription("Aggregates the DB ping, ONNX model presence, and pending-migrations checks. 200 with `Healthy` when " +
+                             "all pass; 503 with `Degraded` or `Unhealthy` otherwise. k8s `readinessProbe` and load-balancer " +
+                             "health checks should point here.")
+            .WithMetadata(ok200)
+            .WithMetadata(unavailable503);
 
         app.MapHealthChecks("/health", readyOptions)
             .WithTags("Health")
             .AllowAnonymous()
-            .DisableRateLimiting();
+            .DisableRateLimiting()
+            .WithSummary("Back-compat alias for /health/ready")
+            .WithDescription("Identical behaviour to /health/ready. Retained for pre-existing probes and monitors.")
+            .WithMetadata(ok200)
+            .WithMetadata(unavailable503);
     }
 }

--- a/src/ExpertiseApi/Endpoints/SearchEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/SearchEndpoints.cs
@@ -1,5 +1,6 @@
 using ExpertiseApi.Auth;
 using ExpertiseApi.Data;
+using ExpertiseApi.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 
@@ -14,7 +15,15 @@ internal static class SearchEndpoints
             .RequireAuthorization("ReadAccess")
             .RequireRateLimiting("expertise-read");
 
-        group.MapGet("/", KeywordSearch);
+        group.MapGet("/", KeywordSearch)
+            .WithSummary("Keyword search over entry title + body")
+            .WithDescription("PostgreSQL full-text search (`to_tsvector`) over Approved entries visible to the caller's tenant. " +
+                             "Query string `q` is required. Set `includeDeprecated=true` to surface soft-deleted entries.")
+            .Produces<List<ExpertiseEntry>>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         return group;
     }

--- a/src/ExpertiseApi/Endpoints/SemanticSearchEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/SemanticSearchEndpoints.cs
@@ -1,5 +1,6 @@
 using ExpertiseApi.Auth;
 using ExpertiseApi.Data;
+using ExpertiseApi.Models;
 using ExpertiseApi.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
@@ -15,7 +16,16 @@ internal static class SemanticSearchEndpoints
             .RequireAuthorization("ReadAccess")
             .RequireRateLimiting("semantic-search");
 
-        group.MapGet("/", SemanticSearch);
+        group.MapGet("/", SemanticSearch)
+            .WithSummary("Vector similarity search using cosine distance over title+body embeddings")
+            .WithDescription("Generates an embedding for `q` via the configured ONNX/SBERT model and returns the top `limit` (clamped 1\u2013100) " +
+                             "Approved entries by cosine similarity. Tenant-scoped (own tenant + shared). Subject to the `semantic-search` " +
+                             "rate-limit policy (token bucket, 10/min) because each call runs ONNX inference.")
+            .Produces<List<ExpertiseEntry>>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         return group;
     }

--- a/src/ExpertiseApi/OpenApi/BearerSecuritySchemeTransformer.cs
+++ b/src/ExpertiseApi/OpenApi/BearerSecuritySchemeTransformer.cs
@@ -1,0 +1,68 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+
+namespace ExpertiseApi.OpenApi;
+
+/// <summary>
+/// Document transformer that advertises the API's JWT Bearer authentication scheme
+/// in the generated OpenAPI document. Without this, the spec lists secured operations
+/// but provides no hint to clients (Scalar UI, codegen, LLM agents) about how to
+/// authenticate.
+///
+/// Wired via <c>builder.Services.AddOpenApi(opts =&gt;
+/// opts.AddDocumentTransformer&lt;BearerSecuritySchemeTransformer&gt;())</c> in Program.cs.
+///
+/// Targets Microsoft.OpenApi 2.x (the dependency shipped with
+/// Microsoft.AspNetCore.OpenApi 10.0.7) — types live directly under
+/// <c>Microsoft.OpenApi</c>, not the legacy <c>Microsoft.OpenApi.Models</c> namespace,
+/// and security-scheme references use <see cref="OpenApiSecuritySchemeReference"/>.
+///
+/// Reference: <see href="https://learn.microsoft.com/aspnet/core/fundamentals/openapi/customize-openapi#use-document-transformers" />.
+/// </summary>
+internal sealed class BearerSecuritySchemeTransformer : IOpenApiDocumentTransformer
+{
+    private readonly IAuthenticationSchemeProvider _authenticationSchemeProvider;
+
+    public BearerSecuritySchemeTransformer(IAuthenticationSchemeProvider authenticationSchemeProvider)
+    {
+        _authenticationSchemeProvider = authenticationSchemeProvider;
+    }
+
+    public async Task TransformAsync(
+        OpenApiDocument document,
+        OpenApiDocumentTransformerContext context,
+        CancellationToken cancellationToken)
+    {
+        var authSchemes = await _authenticationSchemeProvider.GetAllSchemesAsync();
+        var hasBearer = authSchemes.Any(s =>
+            string.Equals(s.Name, "Bearer", StringComparison.OrdinalIgnoreCase));
+
+        if (!hasBearer)
+            return;
+
+        var bearerScheme = new OpenApiSecurityScheme
+        {
+            Type = SecuritySchemeType.Http,
+            Scheme = "bearer",
+            In = ParameterLocation.Header,
+            BearerFormat = "JWT",
+            Description = "JWT bearer token obtained from the configured OIDC issuer. " +
+                          "Required scopes per operation are not yet advertised in the spec — " +
+                          "see the README \"Auth scopes\" section for the read/write/admin matrix.",
+        };
+
+        document.Components ??= new OpenApiComponents();
+        document.Components.SecuritySchemes ??= new Dictionary<string, IOpenApiSecurityScheme>();
+        document.Components.SecuritySchemes["Bearer"] = bearerScheme;
+
+        // Apply the requirement at the document root so every operation inherits it.
+        // Operations that allow anonymous access (/health/*, /openapi/*) are filtered
+        // out by ApiExplorer before this transformer runs.
+        document.Security ??= new List<OpenApiSecurityRequirement>();
+        document.Security.Add(new OpenApiSecurityRequirement
+        {
+            [new OpenApiSecuritySchemeReference("Bearer", document)] = new List<string>(),
+        });
+    }
+}

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -68,7 +68,13 @@ builder.Services.Configure<HostOptions>(options =>
 // consumers in the integration backlog (#147 skill = plain curl/JSON; #148 pi extension
 // = TypeScript codegen) are 3.1-compatible. If a 3.0-only consumer surfaces later, pin
 // here and verify the emitter honours it on the then-current SDK.
-builder.Services.AddOpenApi();
+//
+// BearerSecuritySchemeTransformer advertises the JWT Bearer scheme on every secured
+// operation so Scalar UI, codegen, and LLM agents know how to authenticate (#146).
+builder.Services.AddOpenApi(options =>
+{
+    options.AddDocumentTransformer<ExpertiseApi.OpenApi.BearerSecuritySchemeTransformer>();
+});
 
 // ProblemDetails sanitization (Part D C4). Always emit a traceId extension so
 // client-side error reports can be cross-referenced to server logs; outside
@@ -327,9 +333,22 @@ if (metricsEnabled)
     app.UseHttpMetrics();
 app.UseSerilogRequestLogging();
 
+// OpenAPI document discovery: exposed in ALL environments (#146). The spec is also
+// published as a GitHub Release asset (openapi.json + .sha256) via release.yml so
+// downstream agents/codegen can pin a version offline; the runtime endpoint serves
+// the live deployment's surface for ad-hoc discovery. Anonymous + not rate-limited
+// because (1) the spec is non-sensitive (already public via Release assets) and
+// (2) downstream tools must discover the API before holding a bearer token.
+app.MapOpenApi()
+    .AllowAnonymous()
+    .DisableRateLimiting();
+
 if (app.Environment.IsDevelopment())
 {
-    app.MapOpenApi();
+    // Scalar interactive UI stays Development-only — it's a browser-rendered HTML
+    // page that, like the /query debug UI below, would invite token-handling
+    // anti-patterns in a deployed environment. Downstream consumers should fetch
+    // the JSON document from /openapi/v1.json or the Release asset.
     app.MapScalarApiReference();
 
     // Static-file serving and the /query debug UI are Development-only because

--- a/tests/ExpertiseApi.Tests/Integration/OpenApiTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/OpenApiTests.cs
@@ -1,0 +1,119 @@
+using System.Net;
+using System.Text.Json;
+using ExpertiseApi.Tests.Infrastructure;
+
+namespace ExpertiseApi.Tests.Integration;
+
+/// <summary>
+/// Integration coverage for the runtime OpenAPI document endpoint (#146).
+///
+/// Validates:
+/// - /openapi/v1.json is reachable WITHOUT a bearer token (anonymous discovery is
+///   required because downstream tools must read the spec before they hold credentials).
+/// - The document declares the Bearer security scheme via the
+///   <see cref="ExpertiseApi.OpenApi.BearerSecuritySchemeTransformer"/>.
+/// - The document covers the documented endpoint surface (Expertise / Search / Audit
+///   route groups) with per-status responses, proving the per-endpoint
+///   <c>.WithSummary</c>/<c>.Produces</c>/<c>.ProducesProblem</c> decorations land.
+///
+/// The test does NOT verify that ApiExplorer correctly enumerates health checks
+/// (the framework excludes <c>MapHealthChecks</c> from the API surface by default;
+/// see <see cref="ExpertiseApi.Endpoints.HealthEndpoints"/>).
+/// </summary>
+[Collection("Postgres")]
+public class OpenApiTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private ApiFactory _factory = null!;
+
+    public OpenApiTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public Task InitializeAsync()
+    {
+        _factory = new ApiFactory(_postgres.ConnectionString);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync() => await _factory.DisposeAsync();
+
+    [Fact]
+    public async Task OpenApi_IsReachableWithoutAuth_AndAdvertisesBearerScheme()
+    {
+        var client = _factory.CreateClient();
+
+        // No Authorization header. The endpoint is .AllowAnonymous() and .DisableRateLimiting().
+        var response = await client.GetAsync("/openapi/v1.json");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().NotBeNullOrWhiteSpace();
+
+        using var doc = JsonDocument.Parse(body);
+        var root = doc.RootElement;
+
+        // OpenAPI 3.0/3.1: top-level "openapi" version string is required.
+        root.TryGetProperty("openapi", out var versionEl).Should().BeTrue();
+        versionEl.GetString().Should().StartWith("3.");
+
+        // Bearer scheme advertised under components.securitySchemes.
+        root.TryGetProperty("components", out var components).Should().BeTrue();
+        components.TryGetProperty("securitySchemes", out var schemes).Should().BeTrue();
+        schemes.TryGetProperty("Bearer", out var bearer).Should().BeTrue();
+        bearer.GetProperty("type").GetString().Should().Be("http");
+        bearer.GetProperty("scheme").GetString().Should().Be("bearer");
+        bearer.GetProperty("bearerFormat").GetString().Should().Be("JWT");
+
+        // Document-level security requirement references the Bearer scheme.
+        root.TryGetProperty("security", out var security).Should().BeTrue();
+        security.ValueKind.Should().Be(JsonValueKind.Array);
+        var hasBearerRequirement = security.EnumerateArray()
+            .Any(r => r.TryGetProperty("Bearer", out _));
+        hasBearerRequirement.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task OpenApi_DocumentsDecoratedEndpoints_WithSummariesAndStatusCodes()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync("/openapi/v1.json");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var paths = doc.RootElement.GetProperty("paths");
+
+        // Spot-check three representative endpoints across the route groups; full
+        // matrix coverage would just shadow the per-endpoint .Produces decorations
+        // we can read directly in source.
+        AssertOperation(paths, "/expertise", "get",
+            expectedSummaryContains: "List approved expertise entries",
+            expectedStatuses: ["200", "401", "403", "429"]);
+
+        AssertOperation(paths, "/expertise", "post",
+            expectedSummaryContains: "Create a new expertise entry",
+            expectedStatuses: ["201", "400", "401", "403", "409", "429"]);
+
+        AssertOperation(paths, "/expertise/search/semantic", "get",
+            expectedSummaryContains: "Vector similarity search",
+            expectedStatuses: ["200", "400", "401", "403", "429"]);
+    }
+
+    private static void AssertOperation(
+        JsonElement paths,
+        string path,
+        string verb,
+        string expectedSummaryContains,
+        string[] expectedStatuses)
+    {
+        paths.TryGetProperty(path, out var pathItem).Should().BeTrue($"path {path} should be documented");
+        pathItem.TryGetProperty(verb, out var operation).Should().BeTrue($"{verb.ToUpperInvariant()} {path} should be documented");
+
+        operation.GetProperty("summary").GetString().Should().Contain(expectedSummaryContains);
+
+        var responses = operation.GetProperty("responses");
+        foreach (var status in expectedStatuses)
+        {
+            responses.TryGetProperty(status, out _).Should().BeTrue(
+                $"{verb.ToUpperInvariant()} {path} should declare response {status}");
+        }
+    }
+}


### PR DESCRIPTION
Closes #146. Unblocks the integration backlog (#147 skill / #148 pi extension / #149 docs).

## Summary

The OpenAPI document is now (a) reachable on every deployment via `/openapi/v1.json` without a bearer token and (b) populated with summaries, request/response types, and per-status problem responses on every documented route. Combined with the existing Part D C8 release-asset attach this gives downstream LLM-agent integrations both a live discovery URL and a version-pinned offline artifact.

## Commits

| | |
|---|---|
| `feat(api): publish openapi.json in all environments with bearer security scheme` | Moves `MapOpenApi()` out of the `IsDevelopment()` gate; marks it `.AllowAnonymous()` + `.DisableRateLimiting()`. Adds `BearerSecuritySchemeTransformer` (`IOpenApiDocumentTransformer`) wired through `AddOpenApi(...)` — emits `components.securitySchemes.Bearer` (`type=http`, `scheme=bearer`, `bearerFormat=JWT`) and a document-level `security` requirement. Targets Microsoft.OpenApi 2.x (`OpenApiSecuritySchemeReference`, types directly under `Microsoft.OpenApi` namespace, no legacy `.Models`). Scalar interactive UI stays Development-only (same XSS exposure as `/query`, #124). |
| `feat(api): decorate endpoints with OpenAPI metadata for LLM-consumable spec` | 12 routes across Expertise / Search / SemanticSearch / Audit groups now carry `.WithSummary()` / `.WithDescription()` / `.Produces<T>()` / `.ProducesProblem()` / `.Accepts<TRequest>()`. Build-time emitter confirms 16 component schemas land. Health endpoints carry summary + plaintext `ProducesResponseTypeAttribute` metadata via `.WithMetadata(...)` (`MapHealthChecks` returns `IEndpointConventionBuilder`, not `RouteHandlerBuilder`); ApiExplorer excludes them from the document by framework default, acceptable since they are platform-conventional. |
| `test(api): integration coverage for /openapi/v1.json reachability and bearer scheme` | Two-test suite asserting (1) anonymous reachability + Bearer scheme + document-level security requirement, (2) per-endpoint summary text and full status-code surface for three representative endpoints (GET /expertise, POST /expertise, GET /expertise/search/semantic). Spot-check rather than exhaustive matrix because the per-endpoint surface is readable directly in `*Endpoints.cs`. |
| `docs(readme): document /openapi/v1.json discovery URL` | API Surface table row + new "OpenAPI discovery" subsection covering both the runtime endpoint and the release-asset path. Cross-references Part D C8 and the Scalar gating rationale. |

## Acceptance criteria (from #146)

- [x] `curl https://<host>/openapi/v1.json` returns a valid OpenAPI 3.x document in any deployment mode (verified by `OpenApiTests`; HostFiltering enforcement remains operator-controlled via Part D C1's `AllowedHosts` knob, unchanged from this PR).
- [x] A signed `openapi.json` asset is attached to every GitHub Release. (already delivered in #167 via Part D C8; this PR doesn't regress that path.) Cosign hardening tracked under #172.
- [x] `dotnet build` emits the file deterministically.
- [x] All endpoints in `Endpoints/ExpertiseEndpoints.cs` carry summary, description, and per-status `Produces` declarations.

## Out of scope (per issue)

- `oasdiff` CI gate / breaking-change detection
- Hosted Scalar UI in production
- `Idempotency-Key` parameter docs (separate hardening pass; tracked alongside #168)

## Verification

```text
$ dotnet build ExpertiseApi.slnx -c Release  ⇒  0 warnings, 0 errors
$ jq '.paths | keys, .components.securitySchemes | keys' src/ExpertiseApi/artifacts/openapi/ExpertiseApi.json
[
  "/audit","/expertise","/expertise/drafts","/expertise/search","/expertise/search/semantic",
  "/expertise/batch","/expertise/{id}","/expertise/{id}/approve","/expertise/{id}/reject"
]
[ "Bearer" ]
```
