### PR TITLE
feat(api): harden /openapi/v1.json discovery (cache + per-op security override + comment fixes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ The live OpenAPI document is served from `/openapi/v1.json` in **all** environme
 curl https://<host>/openapi/v1.json | jq '.info, .paths | keys'
 ```
 
-The document advertises the JWT Bearer security scheme (`components.securitySchemes.Bearer`, `bearerFormat: JWT`) and a document-level `security` requirement. Operations that allow anonymous access (`/health/*`, `/openapi/*`) are excluded from the security requirement by ApiExplorer.
+The document advertises the JWT Bearer security scheme (`components.securitySchemes.Bearer`, `bearerFormat: JWT`) and a document-level `security` requirement. The endpoints currently exposed anonymously (`/openapi/v1.json`, `/health/*`, `/metrics`) are absent from the document entirely because `MapOpenApi`, `MapHealthChecks`, and the prometheus-net middleware do not register ApiExplorer descriptors. The transformer also iterates `context.DescriptionGroups` and emits an empty `security: []` on any operation that carries `IAllowAnonymous` metadata, so future `MapGet(...).AllowAnonymous()` routes will be correctly reported as anonymous in the spec.
+
+Responses are cached for 5 minutes via `OutputCache` (policy `openapi-discovery`, vary-by-host) so anonymous spec-fetch loops cannot drive sustained CPU through repeated schema generation.
 
 A version-pinned copy is also attached as a release asset (`openapi.json` + `openapi.json.sha256`) on every GitHub Release for offline consumers and codegen pipelines that need byte-stable input. See the [release page](https://github.com/TheSemicolon/agent-expertise-api/releases) and Part D C8 in `docs/security/integration-threat-model.md`. The interactive Scalar UI remains gated to Development (`/scalar/v1`) because the in-browser bearer-token storage pattern carries the same XSS exposure as `/query` (issue #124).
 

--- a/src/ExpertiseApi/Endpoints/HealthEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/HealthEndpoints.cs
@@ -69,42 +69,26 @@ internal static class HealthEndpoints
             },
         };
 
-        // Note: MapHealthChecks returns IEndpointConventionBuilder (not RouteHandlerBuilder),
-        // so the typed .Produces<T>() / .ProducesProblem() extensions do not apply. We rely
-        // on .WithMetadata(new ProducesResponseTypeAttribute(...)) for OpenAPI discovery.
-        var ok200 = new Microsoft.AspNetCore.Mvc.ProducesResponseTypeAttribute(
-            typeof(string), StatusCodes.Status200OK);
-        var unavailable503 = new Microsoft.AspNetCore.Mvc.ProducesResponseTypeAttribute(
-            typeof(string), StatusCodes.Status503ServiceUnavailable);
+        // NOTE: Health endpoints are intentionally absent from the generated OpenAPI
+        // document. MapHealthChecks does not register API-Explorer descriptors
+        // (no MethodInfo / ParameterDescriptions), so summary / Produces metadata
+        // attached here would be dead weight. The endpoints are documented in the
+        // README "API Surface" table and exercised by HealthEndpointTests — those
+        // are the actual contract surface for operators.
 
         app.MapHealthChecks("/health/live", liveOptions)
             .WithTags("Health")
             .AllowAnonymous()
-            .DisableRateLimiting()
-            .WithSummary("Liveness probe (200 while the process responds)")
-            .WithDescription("Returns 200 with the literal text `Healthy` while the process is responsive. Independent of " +
-                             "downstream dependencies (no checks evaluated). systemd `WatchdogSec=` and k8s `livenessProbe` " +
-                             "should point here.")
-            .WithMetadata(ok200);
+            .DisableRateLimiting();
 
         app.MapHealthChecks("/health/ready", readyOptions)
             .WithTags("Health")
             .AllowAnonymous()
-            .DisableRateLimiting()
-            .WithSummary("Readiness probe (200 when all `ready`-tagged checks pass)")
-            .WithDescription("Aggregates the DB ping, ONNX model presence, and pending-migrations checks. 200 with `Healthy` when " +
-                             "all pass; 503 with `Degraded` or `Unhealthy` otherwise. k8s `readinessProbe` and load-balancer " +
-                             "health checks should point here.")
-            .WithMetadata(ok200)
-            .WithMetadata(unavailable503);
+            .DisableRateLimiting();
 
         app.MapHealthChecks("/health", readyOptions)
             .WithTags("Health")
             .AllowAnonymous()
-            .DisableRateLimiting()
-            .WithSummary("Back-compat alias for /health/ready")
-            .WithDescription("Identical behaviour to /health/ready. Retained for pre-existing probes and monitors.")
-            .WithMetadata(ok200)
-            .WithMetadata(unavailable503);
+            .DisableRateLimiting();
     }
 }

--- a/src/ExpertiseApi/OpenApi/BearerSecuritySchemeTransformer.cs
+++ b/src/ExpertiseApi/OpenApi/BearerSecuritySchemeTransformer.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.OpenApi;
 
@@ -6,15 +7,25 @@ namespace ExpertiseApi.OpenApi;
 
 /// <summary>
 /// Document transformer that advertises the API's JWT Bearer authentication scheme
-/// in the generated OpenAPI document. Without this, the spec lists secured operations
-/// but provides no hint to clients (Scalar UI, codegen, LLM agents) about how to
-/// authenticate.
+/// in the generated OpenAPI document and suppresses the inherited document-level
+/// security requirement on any endpoint marked <c>.AllowAnonymous()</c>.
+///
+/// Without this transformer the spec lists secured operations but provides no hint
+/// to clients (Scalar UI, codegen, LLM agents) about how to authenticate. Without
+/// the per-operation override, any future <c>MapGet("/foo", ...).AllowAnonymous()</c>
+/// would silently inherit the document-level Bearer requirement and incorrectly
+/// advertise auth-required to clients and audit tooling. (The endpoints that exist
+/// today &#8212; <c>/openapi/*</c>, <c>/health/*</c>, <c>/metrics</c> &#8212; are absent from
+/// the document entirely because <c>MapOpenApi</c>, <c>MapHealthChecks</c> and the
+/// prometheus-net middleware do not register ApiExplorer descriptors. The override
+/// keeps the transformer correct for routes that DO register descriptors, future
+/// or otherwise.)
 ///
 /// Wired via <c>builder.Services.AddOpenApi(opts =&gt;
 /// opts.AddDocumentTransformer&lt;BearerSecuritySchemeTransformer&gt;())</c> in Program.cs.
 ///
 /// Targets Microsoft.OpenApi 2.x (the dependency shipped with
-/// Microsoft.AspNetCore.OpenApi 10.0.7) — types live directly under
+/// Microsoft.AspNetCore.OpenApi 10.0.7) &#8212; types live directly under
 /// <c>Microsoft.OpenApi</c>, not the legacy <c>Microsoft.OpenApi.Models</c> namespace,
 /// and security-scheme references use <see cref="OpenApiSecuritySchemeReference"/>.
 ///
@@ -48,21 +59,58 @@ internal sealed class BearerSecuritySchemeTransformer : IOpenApiDocumentTransfor
             In = ParameterLocation.Header,
             BearerFormat = "JWT",
             Description = "JWT bearer token obtained from the configured OIDC issuer. " +
-                          "Required scopes per operation are not yet advertised in the spec — " +
-                          "see the README \"Auth scopes\" section for the read/write/admin matrix.",
+                          "In production (Auth:Mode=Oidc, enforced by EnforceModeGuard) this is the only " +
+                          "accepted credential. In Development Auth:Mode=Hybrid additionally accepts a " +
+                          "static API key via the `X-Api-Key` header or `Authorization: Bearer <api-key>` " +
+                          "and a `dev:{tenant}:{scope}` LocalDev token \u2014 those modes are not advertised " +
+                          "in this document. Required scopes per operation are not yet in the spec; see " +
+                          "the README \"Auth scopes\" section for the read/write/admin matrix.",
         };
 
         document.Components ??= new OpenApiComponents();
         document.Components.SecuritySchemes ??= new Dictionary<string, IOpenApiSecurityScheme>();
         document.Components.SecuritySchemes["Bearer"] = bearerScheme;
 
-        // Apply the requirement at the document root so every operation inherits it.
-        // Operations that allow anonymous access (/health/*, /openapi/*) are filtered
-        // out by ApiExplorer before this transformer runs.
         document.Security ??= new List<OpenApiSecurityRequirement>();
         document.Security.Add(new OpenApiSecurityRequirement
         {
             [new OpenApiSecuritySchemeReference("Bearer", document)] = new List<string>(),
         });
+
+        // Per-operation override: any endpoint that carries IAllowAnonymous metadata
+        // (typically from .AllowAnonymous()) gets an empty `security: []` so the
+        // document-level Bearer requirement does not apply. Without this, a future
+        // .MapGet("/foo", ...).AllowAnonymous() (without .ExcludeFromDescription())
+        // would inherit Bearer-required in the spec and mislead clients / break
+        // codegen.
+        foreach (var group in context.DescriptionGroups)
+        {
+            foreach (var apiDesc in group.Items)
+            {
+                var endpointMetadata = apiDesc.ActionDescriptor.EndpointMetadata;
+                var isAnonymous = endpointMetadata.OfType<IAllowAnonymous>().Any()
+                    && !endpointMetadata.OfType<IAuthorizeData>().Any();
+                if (!isAnonymous)
+                    continue;
+
+                if (document.Paths is null)
+                    continue;
+
+                var path = "/" + (apiDesc.RelativePath?.TrimStart('/') ?? string.Empty);
+                if (!document.Paths.TryGetValue(path, out var pathItem))
+                    continue;
+
+                var verb = apiDesc.HttpMethod;
+                if (string.IsNullOrEmpty(verb))
+                    continue;
+                var method = HttpMethod.Parse(verb);
+                if (pathItem.Operations is null || !pathItem.Operations.TryGetValue(method, out var operation))
+                    continue;
+
+                // Empty list (not null) = "no security applies to this operation".
+                // null would inherit the document-level requirement.
+                operation.Security = new List<OpenApiSecurityRequirement>();
+            }
+        }
     }
 }

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -60,6 +60,20 @@ builder.Services.Configure<HostOptions>(options =>
     options.ShutdownTimeout = TimeSpan.FromSeconds(30);
 });
 
+// Output caching for the OpenAPI document. AddOpenApi does NOT cache by default
+// (each request walks the schema graph and runs every IOpenApiDocumentTransformer),
+// and the endpoint is anonymous + un-rate-limited per the discovery contract — a
+// 5-minute output cache stops anonymous spec-fetch loops from becoming a CPU
+// amplifier without compromising downstream tooling that polls infrequently.
+// Reference: https://learn.microsoft.com/aspnet/core/performance/caching/output
+builder.Services.AddOutputCache(options =>
+{
+    options.AddPolicy("openapi-discovery", policy => policy
+        .Cache()
+        .Expire(TimeSpan.FromMinutes(5))
+        .SetVaryByHost(true));
+});
+
 // AddOpenApi registers the document(s) consumed by both runtime MapOpenApi() and the
 // build-time _GenerateOpenApiDocuments target (Part D C8). The build-time output
 // (artifacts/openapi/ExpertiseApi.json) is OpenAPI 3.1.1 by the .NET 10 default — the
@@ -338,10 +352,13 @@ app.UseSerilogRequestLogging();
 // downstream agents/codegen can pin a version offline; the runtime endpoint serves
 // the live deployment's surface for ad-hoc discovery. Anonymous + not rate-limited
 // because (1) the spec is non-sensitive (already public via Release assets) and
-// (2) downstream tools must discover the API before holding a bearer token.
+// (2) downstream tools must discover the API before holding a bearer token. The
+// 5-minute OutputCache (policy "openapi-discovery") backstops DoS by amortising
+// the per-request schema walk + transformer execution across spec-fetch loops.
 app.MapOpenApi()
     .AllowAnonymous()
-    .DisableRateLimiting();
+    .DisableRateLimiting()
+    .CacheOutput("openapi-discovery");
 
 if (app.Environment.IsDevelopment())
 {
@@ -367,6 +384,7 @@ if (app.Environment.IsDevelopment())
 app.UseAuthentication();
 app.UseAuthorization();
 app.UseRateLimiter();
+app.UseOutputCache();
 
 app.MapHealthEndpoints();
 app.MapExpertiseEndpoints();

--- a/tests/ExpertiseApi.Tests/Integration/OpenApiTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/OpenApiTests.cs
@@ -83,17 +83,15 @@ public class OpenApiTests : IAsyncLifetime
 
         // Spot-check three representative endpoints across the route groups; full
         // matrix coverage would just shadow the per-endpoint .Produces decorations
-        // we can read directly in source.
+        // we can read directly in source. Summary checks are non-empty rather than
+        // substring-match so harmless copy-edits don't break the suite.
         AssertOperation(paths, "/expertise", "get",
-            expectedSummaryContains: "List approved expertise entries",
             expectedStatuses: ["200", "401", "403", "429"]);
 
         AssertOperation(paths, "/expertise", "post",
-            expectedSummaryContains: "Create a new expertise entry",
             expectedStatuses: ["201", "400", "401", "403", "409", "429"]);
 
         AssertOperation(paths, "/expertise/search/semantic", "get",
-            expectedSummaryContains: "Vector similarity search",
             expectedStatuses: ["200", "400", "401", "403", "429"]);
     }
 
@@ -101,13 +99,13 @@ public class OpenApiTests : IAsyncLifetime
         JsonElement paths,
         string path,
         string verb,
-        string expectedSummaryContains,
         string[] expectedStatuses)
     {
         paths.TryGetProperty(path, out var pathItem).Should().BeTrue($"path {path} should be documented");
         pathItem.TryGetProperty(verb, out var operation).Should().BeTrue($"{verb.ToUpperInvariant()} {path} should be documented");
 
-        operation.GetProperty("summary").GetString().Should().Contain(expectedSummaryContains);
+        operation.GetProperty("summary").GetString().Should().NotBeNullOrWhiteSpace(
+            $"{verb.ToUpperInvariant()} {path} should carry a non-empty summary");
 
         var responses = operation.GetProperty("responses");
         foreach (var status in expectedStatuses)


### PR DESCRIPTION
Follow-up to PR #173 (closed #146). Addresses warnings raised by the post-merge `/review` pass that the auto-merge picked up the original PR before the fixups could land.

## Why this is a separate PR

PR #173 was auto-merged at 23:01Z immediately after CI went green, while the orchestrator was preparing fixups for the `PASS_WITH_WARNINGS` `/review` verdict. All hard acceptance criteria from #146 were already satisfied by #173; this PR addresses the advisory findings.

## Findings addressed

| Source | Severity | Resolution |
|---|---|---|
| security-review-expert | Medium | `/openapi/v1.json` was anonymous, un-rate-limited, AND `AddOpenApi` does not cache by default — every request walked the schema graph and re-ran transformers. Added a 5-minute `OutputCache` policy (`openapi-discovery`, vary-by-host) and wired `app.UseOutputCache()` into the pipeline. |
| code-review-expert + security-review-expert | Warning (both converged) | The `BearerSecuritySchemeTransformer` comment + the README "OpenAPI discovery" subsection claimed ApiExplorer "filters anonymous operations." Factually wrong — `/health/*`, `/openapi/*`, `/metrics` are absent from the spec because their registrars don't produce ApiExplorer descriptors at all. Hardened the transformer to iterate `context.DescriptionGroups` and emit `security: []` on any operation carrying `IAllowAnonymous` metadata, so a future `MapGet(...).AllowAnonymous()` route won't silently advertise Bearer-required. |
| code-review-expert | Warning | `HealthEndpoints.cs` carried `.WithSummary` / `.WithDescription` / `.WithMetadata` decorations that ApiExplorer ignored (MapHealthChecks doesn't produce an endpoint with `MethodInfo`). Removed the dead metadata, replaced with an accurate NOTE comment. README API Surface table + HealthEndpointTests remain the operator contract. |
| code-review-expert | Info | `OpenApiTests` summary-substring assertions were brittle (copy-edits would break the suite). Loosened to `NotBeNullOrWhiteSpace`; status-code presence assertions retained as the durable check. |
| security-review-expert | Low | `bearerFormat: "JWT"` description didn't note that Development `Auth:Mode=Hybrid` accepts static API key / LocalDev tokens. Tightened the description string. |
| code-review-expert | Info | Deferred oasdiff CI gate filed under #174 (per #146 acceptance "separate issue"). |

## Commits

1. `feat(api): cache and DoS-protect /openapi/v1.json discovery endpoint` — `AddOutputCache` + `UseOutputCache` + `.CacheOutput("openapi-discovery")`. 5min TTL, vary-by-host.
2. `feat(api): future-proof Bearer transformer with per-operation security override` — Iterates `context.DescriptionGroups`, emits empty `security: []` on `IAllowAnonymous` operations. Corrects the XML doc comment. Tightens the Bearer scheme `Description` to note Hybrid-mode caveat.
3. `docs+test: correct OpenAPI discovery wording, drop dead Health metadata, loosen assertions` — README, HealthEndpoints, OpenApiTests.

## Verification

```text
$ dotnet build ExpertiseApi.slnx -c Release  ⇒  0 warnings, 0 errors
$ jq '.security, .paths | keys | length' src/ExpertiseApi/artifacts/openapi/ExpertiseApi.json
[ { "Bearer": [] } ]
9
$ jq '[.paths | to_entries[] | .value | to_entries[] | .value | select(.security)] | length' src/ExpertiseApi/artifacts/openapi/ExpertiseApi.json
0   # no per-op overrides today; transformer ready for future anonymous routes
```

## Refs

- Closes the advisory backlog from PR #173 `/review`
- Tracks #174 (oasdiff gate) as separate follow-up per #146 deferral
