### PR TITLE
chore(security): triage 16 open codeql alerts (log-forging fix + test-code clarifications + generator-noise silencing)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -4,10 +4,24 @@ name: CodeQL config
 # analysis. Source-generator output (notably from
 # Microsoft.AspNetCore.OpenApi.SourceGenerators under obj/Release/.../generated/)
 # is third-party code we don't author and can't reasonably fix; including it
-# produces ~6 false-positive alerts (cs/constant-condition, cs/linq/missed-select,
+# produces ~8 false-positive alerts (cs/constant-condition, cs/linq/missed-select,
 # cs/nested-if-statements, cs/useless-assignment-to-local) that drown the real
 # findings.
+#
+# NB: for compiled languages (C#) the autobuild emits source-generated files into
+# `obj/Release/.../generated/...`. CodeQL's `paths-ignore` filtering operates on
+# the database-relative path, so we list every plausible spelling that's been
+# observed in alerts:
+#   - `**/obj/**`            — catches the build-artifact tree
+#   - `**/bin/**`            — catches the output tree
+#   - `**/generated/**`      — catches the generator-output subdirectory directly
+#   - `**/*.generated.cs`    — catches generated files by name suffix
+# Alerts that pre-date this widening (numbers 4, 5, 14, 15, 16, 23, 24, 25) were
+# dismissed via the REST API with reason='won't_fix' and an explanatory comment
+# pointing back to this file; they will not re-open on subsequent scans unless
+# CodeQL re-detects the same instance with a new fingerprint.
 paths-ignore:
   - '**/obj/**'
   - '**/bin/**'
+  - '**/generated/**'
   - '**/*.generated.cs'

--- a/src/ExpertiseApi/Auth/ActorClassResolver.cs
+++ b/src/ExpertiseApi/Auth/ActorClassResolver.cs
@@ -114,11 +114,8 @@ internal static class ActorClassResolver
         if (string.IsNullOrWhiteSpace(ua) || patterns.Count == 0)
             return false;
 
-        foreach (var pattern in patterns)
+        foreach (var pattern in patterns.Where(p => !string.IsNullOrWhiteSpace(p)))
         {
-            if (string.IsNullOrWhiteSpace(pattern))
-                continue;
-
             if (pattern.EndsWith('*'))
             {
                 var prefix = pattern[..^1];

--- a/src/ExpertiseApi/Auth/JwtTenantContextEvents.cs
+++ b/src/ExpertiseApi/Auth/JwtTenantContextEvents.cs
@@ -89,10 +89,10 @@ internal static class JwtTenantContextEvents
                 .Select(c => c.Value)
                 .Where(v => !string.IsNullOrWhiteSpace(v));
 
-            foreach (var value in values)
+            foreach (var scope in values.SelectMany(v =>
+                v.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)))
             {
-                foreach (var scope in value.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-                    yield return scope;
+                yield return scope;
             }
         }
     }

--- a/src/ExpertiseApi/Diagnostics/UnhandledExceptionLogger.cs
+++ b/src/ExpertiseApi/Diagnostics/UnhandledExceptionLogger.cs
@@ -17,6 +17,17 @@ namespace ExpertiseApi.Diagnostics;
 /// the request path here; the customizer then strips Detail/Instance from the wire
 /// response in non-Development environments so the correlation ID (traceId) is the
 /// only link between the client-visible response and the server-side log entry.
+///
+/// <para>
+/// <strong>Log-forging defence (CWE-117):</strong> request method and path are
+/// attacker-controlled and may carry CR/LF (or other C0 control bytes) that would
+/// otherwise inject synthetic log lines into the structured-logging sink. We pass
+/// both through <see cref="SanitizeForLog"/> before they reach the message
+/// template. The replacement char (<c>?</c>) is deliberately visible so a
+/// sanitized log line still surfaces the tampering attempt. Any future field
+/// added to this message template (e.g. <c>QueryString</c>, request headers) MUST
+/// also be routed through <see cref="SanitizeForLog"/>.
+/// </para>
 /// </summary>
 internal sealed class UnhandledExceptionLogger(ILogger<UnhandledExceptionLogger> log)
     : IExceptionHandler
@@ -27,9 +38,31 @@ internal sealed class UnhandledExceptionLogger(ILogger<UnhandledExceptionLogger>
         CancellationToken ct)
     {
         log.LogError(ex, "Unhandled exception for {Method} {Path}",
-            ctx.Request.Method, ctx.Request.Path);
+            SanitizeForLog(ctx.Request.Method),
+            SanitizeForLog(ctx.Request.Path.Value));
         // false = let the default IProblemDetailsService writer handle the response body
         // so the AddProblemDetails customizer in Program.cs runs (correlation ID + sanitization).
         return ValueTask.FromResult(false);
+    }
+
+    /// <summary>
+    /// Replace ASCII C0 control characters (including CR, LF, NUL, tab) with <c>?</c>.
+    /// Bounded at 2048 chars to cap log-line length when an attacker supplies a very
+    /// long synthetic path.
+    /// </summary>
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return string.Empty;
+
+        const int max = 2048;
+        var src = value.Length > max ? value.AsSpan(0, max) : value.AsSpan();
+        var buf = new char[src.Length];
+        for (var i = 0; i < src.Length; i++)
+        {
+            var c = src[i];
+            buf[i] = c < 0x20 || c == 0x7F ? '?' : c;
+        }
+        return new string(buf);
     }
 }

--- a/tests/ExpertiseApi.Tests/Integration/HostFilteringTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/HostFilteringTests.cs
@@ -33,7 +33,7 @@ public class HostFilteringTests : IAsyncLifetime
     [Fact]
     public async Task AllowedHost_Localhost_Returns200()
     {
-        var client = _factory.CreateClient();
+        using var client = _factory.CreateClient();
         var req = new HttpRequestMessage(HttpMethod.Get, "/health/live");
         // ApiFactory's default base address is http://localhost/, which carries Host: localhost
         // — explicit set documents intent.
@@ -45,7 +45,7 @@ public class HostFilteringTests : IAsyncLifetime
     [Fact]
     public async Task AllowedHost_LoopbackIpv4_Returns200()
     {
-        var client = _factory.CreateClient();
+        using var client = _factory.CreateClient();
         var req = new HttpRequestMessage(HttpMethod.Get, "/health/live");
         req.Headers.Host = "127.0.0.1";
         var response = await client.SendAsync(req);
@@ -55,7 +55,7 @@ public class HostFilteringTests : IAsyncLifetime
     [Fact]
     public async Task DisallowedHost_ArbitraryDomain_Returns400()
     {
-        var client = _factory.CreateClient();
+        using var client = _factory.CreateClient();
         var req = new HttpRequestMessage(HttpMethod.Get, "/health/live");
         req.Headers.Host = "evil.example.com";
         var response = await client.SendAsync(req);

--- a/tests/ExpertiseApi.Tests/Integration/RateLimitingTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/RateLimitingTests.cs
@@ -57,9 +57,9 @@ public class RateLimitingTests : IAsyncLifetime
 
         final.Should().NotBeNull();
         final!.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
-        final.Headers.RetryAfter.Should().NotBeNull("the OnRejected callback must populate Retry-After from lease metadata");
+        final!.Headers.RetryAfter.Should().NotBeNull("the OnRejected callback must populate Retry-After from lease metadata");
 
-        var body = await final.Content.ReadAsStringAsync();
+        var body = await final!.Content.ReadAsStringAsync();
         body.Should().NotBeNullOrEmpty();
         var doc = JsonDocument.Parse(body);
         doc.RootElement.TryGetProperty("title", out var title).Should().BeTrue();


### PR DESCRIPTION
## Summary

CodeQL alert triage \u2014 16 open alerts \u2192 1 expected after merge (a single `cs/linq/missed-select` note on a generator file that the new path filter should also catch).

## Findings addressed

### Real signal \u2014 medium severity

| Alert | Rule | Location | Fix |
|---|---|---|---|
| #33, #34 | `cs/log-forging` (error/medium) | `UnhandledExceptionLogger.cs:30` | `SanitizeForLog` helper strips C0 control bytes (CR/LF/NUL/DEL) from `Method` and `Path` before they reach the structured-logging template. Replacement char is `?` (visible \u2014 surfaces tampering). Bounded at 2048 chars. CWE-117. |

### Real signal \u2014 test-code warnings

| Alert | Rule | Location | Fix |
|---|---|---|---|
| #35, #36, #37 | `cs/local-not-disposed` | `HostFilteringTests.cs:37,49,59` | `using var client = _factory.CreateClient()`. Client is owned by the factory either way; explicit `using` documents lifetime for CodeQL. |
| #38 | `cs/dereferenced-value-may-be-null` | `RateLimitingTests.cs:58` | Propagate `!` to subsequent dereferences (CodeQL doesn't track null-forgiving across statements). |

### Real signal \u2014 style notes

| Alert | Rule | Location | Fix |
|---|---|---|---|
| #30 | `cs/linq/missed-select` | `JwtTenantContextEvents.cs:84` | Nested `foreach` over split values \u2192 `SelectMany`. |
| #39 | `cs/linq/missed-where` | `ActorClassResolver.cs:117` | Hoist `if (IsNullOrWhiteSpace) continue` into `.Where()`. |

### Noise \u2014 8 generator-code alerts

Alerts #4, #5, #14, #15, #16, #23, #24, #25 against `obj/Release/net10.0/generated/Microsoft.AspNetCore.OpenApi.SourceGenerators/.../OpenApiXmlCommentSupport.generated.cs`. The existing `paths-ignore` config didn't silence them. This PR:
1. Widens `.github/codeql/codeql-config.yml` to also exclude `**/generated/**`.
2. Dismisses the 8 alerts via REST API with `dismissed_reason=won't_fix` (see comments on each alert pointing back to the config file).

## Test plan

- `dotnet build` \u2192 0 errors.
- `dotnet test --filter Unit` \u2192 170/170 pass locally.
- Full CI run (unit + integration + lint + CodeQL + Trivy + Hadolint + Helm + apictl restart matrix) on push.

## Commits

1. `fix(security): strip CR/LF from request method/path before logging`
2. `chore(test): help codeql see HttpClient lifetime + final non-null`
3. `style(auth): apply codeql linq suggestions (note)`
4. `chore(security): widen codeql paths-ignore for source-generator output`

## Risk

Minimal. Log-forging fix touches one hot path (every unhandled exception); preserves the existing message template, only sanitises the two parameter values. Test-code edits are local. LINQ refactors are pure. Config change is additive.
