### PR TITLE
chore(pi-ext): address PR #179 review warnings (tenant/visibility/scheme/dep)

### DIFF
--- a/.pi/extensions/expertise-api/index.ts
+++ b/.pi/extensions/expertise-api/index.ts
@@ -82,7 +82,27 @@ function getBaseUrl(): string {
 			"EXPERTISE_API_BASE_URL is not set. Export it or write it to ~/.config/expertise-api/secrets.env.",
 		);
 	}
-	return raw.replace(/\/+$/, "");
+	const normalised = raw.replace(/\/+$/, "");
+	// Refuse to send the bearer over cleartext unless explicitly pointed at a
+	// loopback host (developer mode). Closes the misconfiguration footgun
+	// flagged by security-review on PR #179: a base URL of 'http://...' would
+	// otherwise leak the token in cleartext on the wire.
+	let parsed: URL;
+	try {
+		parsed = new URL(normalised);
+	} catch {
+		throw new Error(`EXPERTISE_API_BASE_URL is not a valid URL: ${raw}`);
+	}
+	const isLoopback =
+		parsed.hostname === "localhost" ||
+		parsed.hostname === "127.0.0.1" ||
+		parsed.hostname === "[::1]";
+	if (parsed.protocol !== "https:" && !isLoopback) {
+		throw new Error(
+			`EXPERTISE_API_BASE_URL must use https:// (or a loopback host for dev). Got: ${raw}`,
+		);
+	}
+	return normalised;
 }
 
 function getToken(): string {
@@ -203,6 +223,8 @@ const EntryTypeEnum = StringEnum([
 
 const SeverityEnum = StringEnum(["Info", "Warning", "Critical"] as const);
 
+const VisibilityEnum = StringEnum(["Private", "Shared"] as const);
+
 const CreateEntryParams = Type.Object({
 	domain: Type.String({
 		description: "Logical grouping (e.g. 'shared', 'azure-devops', 'iac').",
@@ -227,6 +249,12 @@ const CreateEntryParams = Type.Object({
 	tags: Type.Optional(
 		Type.Array(Type.String(), {
 			description: "Free-form tags (text[] with GIN index).",
+		}),
+	),
+	tenant: Type.Optional(
+		Type.String({
+			description:
+				"Optional tenant override. Only 'shared' is accepted; all other tenants are server-assigned from the caller's token. Requires expertise.write.approve and bypasses the draft queue (created Approved, not Draft).",
 		}),
 	),
 });
@@ -419,18 +447,23 @@ export default function (pi: ExtensionAPI): void {
 		name: "expertise_approve",
 		label: "Expertise Approve",
 		description:
-			"Transition a Draft entry to Approved via POST /expertise/{id}/approve. Requires expertise.write.approve. Returns 409 if the entry is not in Draft state (state machine).",
+			"Transition a Draft entry to Approved via POST /expertise/{id}/approve. Requires expertise.write.approve. Optional `visibility` ('Private' default | 'Shared') is forwarded in the request body to choose post-approval visibility. Returns 409 if the entry is not in Draft state (state machine).",
 		promptSnippet:
 			"Approve a draft expertise entry. Requires expertise.write.approve.",
 		parameters: Type.Object({
 			id: Type.String({ description: "Entry id (GUID)." }),
+			visibility: Type.Optional(VisibilityEnum),
 		}),
 		async execute(_id, params, signal) {
 			try {
 				const enc = encodeURIComponent(params.id);
+				const init: RequestInit = { method: "POST" };
+				if (params.visibility !== undefined) {
+					init.body = JSON.stringify({ visibility: params.visibility });
+				}
 				const result = await apiCall(
 					`/expertise/${enc}/approve`,
-					{ method: "POST" },
+					init,
 					signal,
 				);
 				return toolResult(result, "expertise_approve");

--- a/.pi/extensions/expertise-api/package-lock.json
+++ b/.pi/extensions/expertise-api/package-lock.json
@@ -1,13 +1,14 @@
 {
-  "name": "@theseimcolon/pi-extension-expertise-api",
+  "name": "@thesemicolon/pi-extension-expertise-api",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@theseimcolon/pi-extension-expertise-api",
+      "name": "@thesemicolon/pi-extension-expertise-api",
       "version": "0.1.0",
       "devDependencies": {
+        "@earendil-works/pi-ai": "0.75.3",
         "@earendil-works/pi-coding-agent": "0.75.3",
         "typebox": "^1.1.38",
         "typescript": "^5.7.0"

--- a/.pi/extensions/expertise-api/package.json
+++ b/.pi/extensions/expertise-api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@theseimcolon/pi-extension-expertise-api",
+  "name": "@thesemicolon/pi-extension-expertise-api",
   "version": "0.1.0",
   "private": true,
   "description": "pi extension exposing the agent-expertise-api as typed tools (search, create, approve, reject, etc.) for use inside the pi coding agent.",
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
+    "@earendil-works/pi-ai": "0.75.3",
     "@earendil-works/pi-coding-agent": "0.75.3",
     "typebox": "^1.1.38",
     "typescript": "^5.7.0"


### PR DESCRIPTION
## Summary

Addresses the four `Warning`/`Low` findings from the `/review` on PR #179. That PR auto-merged before the fixup could be applied, so we land the fixes as a small follow-up.

| # | Source | Severity | Fix |
|---|---|---|---|
| 1 | code-review | Warning | `CreateEntryParams.tenant` added — server accepts `Tenant = "shared"` for `expertise.write.approve` callers (created Approved, bypassing draft queue) |
| 2 | code-review | Warning | `expertise_approve.visibility` added — server's `ApproveExpertiseRequest` takes optional `Visibility?` (Private \| Shared); forwarded only when supplied so server default still applies |
| 3 | code-review | Warning | `@earendil-works/pi-ai` promoted from transitive-only to direct devDependency (pinned at 0.75.3) — `StringEnum` import was resolving through pi-coding-agent's nested install |
| 4 | security-review | Low | `getBaseUrl()` now rejects non-`https://` URLs unless the host is `localhost`/`127.0.0.1`/`::1`. Closes the bearer-in-cleartext misconfiguration footgun. |

Cosmetic: corrects the package `name` typo (`@theseimcolon` → `@thesemicolon`). `private: true`, never published.

## Verification

- `tsc --noEmit` clean (`npm run typecheck`).
- `package-lock.json` regenerated by `npm install`; 5 lines net change; integrity hashes preserved.
- Behavioural verification deferred to live API (CI has none).

## Risk

Minimal. Three of four changes are additive (new optional fields + new dep). The scheme allow-list is a hard fail for `http://` non-loopback URLs — intentional. Any existing dev setup using `http://localhost:...` continues to work.

## Commit

`chore(pi-ext): address PR #179 review warnings`
