### PR TITLE
feat(pi-prompts): slash-command templates for expertise search/create/approve (closes #149)

### DIFF
--- a/.pi/prompts/expertise-approve.md
+++ b/.pi/prompts/expertise-approve.md
@@ -1,0 +1,18 @@
+---
+description: Approve a Draft expertise entry (requires expertise.write.approve)
+argument-hint: "<id> [visibility]"
+---
+Approve the draft expertise entry with id **$1**. Visibility argument (optional): **$2**
+
+Steps:
+
+1. First call `expertise_get` with `id: "$1"` and show me the entry's title, domain, entryType, severity, body summary, and current `reviewState`.
+2. If `reviewState` is not `Draft`, stop and report the actual state — `expertise_approve` will return 409 on non-Draft entries.
+3. If the second argument above is `Private` or `Shared`, pass `visibility: "$2"` to `expertise_approve`. If empty or any other value, omit `visibility` so the server applies its default (`Private`).
+   - Only set `Shared` if the entry is genuinely useful across tenants. Shared entries are visible to every caller; private entries are visible only within the owning tenant.
+4. Call `expertise_approve` with `id: "$1"` (and `visibility` if applicable per step 3).
+5. Report the response: `id`, new `reviewState`, `visibility`, and `reviewedAt` timestamp.
+
+If you do not hold the `expertise.write.approve` scope the API will return 403; surface that and stop.
+
+To reject instead of approve, ask the invoker for a rejection reason and call `expertise_reject` directly (no slash-command template; the reason must be 1-2000 chars).

--- a/.pi/prompts/expertise-create.md
+++ b/.pi/prompts/expertise-create.md
@@ -1,0 +1,25 @@
+---
+description: Draft a new expertise entry capturing what was just learned
+argument-hint: "<title> [summary]"
+---
+Draft a new expertise entry titled **$1**.
+
+Additional context from the invoker (if any): ${@:2}
+
+Before drafting, briefly answer these questions to yourself so the entry is useful to the next agent:
+
+- **Domain** — which logical grouping does this belong to? (e.g. `shared`, `azure-devops`, `iac`, or a more specific one observed in recent search results)
+- **Entry type** — `IssueFix` (root-cause + fix for a real bug), `Caveat` (warning about a footgun), `Requirement` (rule that must be followed), or `Pattern` (recommended approach)
+- **Severity** — `Info`, `Warning`, or `Critical` based on the blast radius of getting it wrong
+- **Source version** — if this is tied to a specific tool/library version (e.g. `PgBouncer 1.21.0`, `EF Core 10.0.1`), include it as `sourceVersion` so the entry can be flagged stale later
+
+Then call `expertise_create` with:
+
+- `title: "$1"` (short imperative — e.g. "PgBouncer transaction mode breaks advisory locks")
+- `body`: a markdown body covering **Problem**, **Root cause**, **Fix**, and (if relevant) **Verification**. Keep it tight; cite commits/issues by id where possible.
+- `domain`, `entryType`, `severity`, `source`, optional `sourceVersion`, optional `tags[]` as decided above.
+- `source`: a self-reported origin string identifying this session (e.g. `agent-session-YYYY-MM`).
+
+If the server returns 409 (duplicate), surface the existing entry id and ask the invoker whether to update it via `expertise_update` instead.
+
+The entry is created in **Draft** state by default and requires `/expertise-approve` (with the `expertise.write.approve` scope) to become visible to other agents.

--- a/.pi/prompts/expertise-search.md
+++ b/.pi/prompts/expertise-search.md
@@ -1,0 +1,12 @@
+---
+description: Search the expertise corpus for prior knowledge on a topic
+argument-hint: "<query>"
+---
+Search the agent-expertise-api for prior knowledge relevant to: **$@**
+
+1. Call the `expertise_search_semantic` tool first with `q: "$@"` — it handles paraphrases and conceptual queries well.
+2. If the semantic results look weak (fewer than two hits, or none above a clearly-relevant threshold), fall back to `expertise_search` with `q: "$@"` for keyword-exact matching.
+3. Summarise the top 3 hits with: id, title, severity, entryType, and a one-line takeaway. If any hit looks directly applicable to the current task, quote the salient sentence verbatim and cite the id.
+4. If nothing relevant is found, say so explicitly — do not invent precedent.
+
+Do not call `expertise_create` from this template; that is `/expertise-create`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,8 @@ An action-oriented skill ships in-tree at [`.agents/skills/expertise-api/`](.age
 
 pi users additionally get the in-tree extension at [`.pi/extensions/expertise-api/`](.pi/extensions/expertise-api/README.md) which registers eight typed tools (`expertise_search`, `expertise_search_semantic`, `expertise_get`, `expertise_create`, `expertise_update`, `expertise_approve`, `expertise_reject`, `expertise_delete`). The LLM calls them via `fetch()` so the bearer token does not appear in `ps`/`/proc`. Symlink `.pi/extensions/expertise-api/` into `~/.pi/agent/extensions/` to enable globally.
 
+Three slash-command prompt templates at [`.pi/prompts/`](.pi/prompts/) layer on top: `/expertise-search <query>` (semantic-first), `/expertise-create <title> [summary]`, `/expertise-approve <id> [visibility]`. They appear in `/` autocomplete with `argument-hint` annotations.
+
 Codex CLI: add the path to `skills = [...]` in `~/.codex/config.toml`.
 
 The legacy skill at `.claude/skills/expertise-api-design/SKILL.md` is now a shim that redirects to the new path. The design reference (data model, scopes, approval state machine, audit-log shape, authentication modes) moved to [`.agents/skills/expertise-api/references/DESIGN.md`](.agents/skills/expertise-api/references/DESIGN.md) and is loaded on demand only.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,14 @@ A backwards-compat shim is retained at `.claude/skills/expertise-api-design/` (t
 
 pi users get a richer integration: the in-tree extension at [`.pi/extensions/expertise-api/`](.pi/extensions/expertise-api/README.md) registers eight typed tools (`expertise_search`, `expertise_search_semantic`, `expertise_get`, `expertise_create`, `expertise_update`, `expertise_approve`, `expertise_reject`, `expertise_delete`) that the LLM can call directly via `fetch()` — no shelling to `curl`, and the bearer token stays out of `/proc/<pid>/cmdline`. The skill remains useful for ad-hoc terminal use and for harnesses without pi.
 
+For user-initiated workflows, three slash-command templates live at [`.pi/prompts/`](.pi/prompts/) and appear in `/` autocomplete:
+
+| Command | Purpose |
+| --- | --- |
+| `/expertise-search <query>` | Semantic-first search with keyword fallback; summarises top 3 hits |
+| `/expertise-create <title> [summary]` | Drafts a new entry with the recommended Problem / Root cause / Fix structure |
+| `/expertise-approve <id> [visibility]` | Inspects the draft, then approves with optional `Private`/`Shared` visibility |
+
 Env contract for all three harnesses:
 
 ```sh


### PR DESCRIPTION
## Summary

Adds three user-initiated slash-command prompt templates at `.pi/prompts/*.md`, layered on top of the pi extension from PR #179/#180. Closes #149.

| Command | argument-hint | Behavior |
|---|---|---|
| `/expertise-search` | `<query>` | Semantic-first via `expertise_search_semantic`; keyword fallback via `expertise_search`; summarises top 3 with id/title/severity/entryType and quotes salient sentences |
| `/expertise-create` | `<title> [summary]` | Guides domain/entryType/severity/sourceVersion selection, then calls `expertise_create` with Problem / Root cause / Fix / Verification structure; offers `expertise_update` on 409 duplicate |
| `/expertise-approve` | `<id> [visibility]` | `expertise_get` first to confirm Draft state and show reviewer what they're approving; forwards optional Private/Shared `visibility`; surfaces 403 scope failure path |

## Why prompt templates vs more extension tools

Templates encode **opinionated workflow** rather than just expanding to a single tool call. `/expertise-search` is not "call expertise_search" — it's "try semantic first, fall back, summarise the top 3, don't invent precedent". `/expertise-approve` is not "call expertise_approve" — it's "GET first so the human can see what they're rubber-stamping, then approve with explicit visibility intent". The extension (#148) provides the primitives; these templates encode the **recommended way to use them**.

## Acceptance criteria

| Criterion | Status |
|---|---|
| Templates appear in `/` autocomplete with descriptions and arg hints | \u2705 frontmatter has `description` + `argument-hint` per pi `prompt-templates.md` spec |
| README "pi users" subsection lists them | \u2705 table added to both `README.md` and `CLAUDE.md` |

## Out of scope

- Claude Code custom-command equivalents \u2014 different mechanism; revisit if user demand surfaces (already called out in issue #149).
- `/expertise-reject` template \u2014 the reject path requires a 1-2000 char reason that's better written by the human directly; covered in the `/expertise-approve` template's tail note.

## Risk

Documentation-only. Three new markdown files + two README edits. No code paths touched, no schemas changed, no CI impact.

## Commit

`feat(pi-prompts): slash-command templates for expertise search/create/approve`
