### PR TITLE
feat(ci): oasdiff breaking-change gate for /openapi/v1.json (closes #174)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,3 +197,137 @@ jobs:
       - name: Tear down container
         if: always()
         run: docker rm -f apictl-test || true
+
+  openapi-diff:
+    name: OpenAPI breaking-change check
+    # PR-only: a push to dev has no base to diff against (semantically the spec
+    # IS dev at that point). Required-check status, if/when promoted in branch
+    # protection, applies only to PRs into main/dev.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      # Label gate is read via the github.event.pull_request.labels payload
+      # (no API call needed), but pull-requests: read keeps the principle of
+      # least-surprise if a future refactor moves to gh CLI for label query.
+      pull-requests: read
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: head
+
+      - name: Checkout base ref (${{ github.event.pull_request.base.ref }})
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Pin to the actual base SHA at PR creation time, not the moving
+          # branch tip. Diff semantics match what the merge-base would resolve
+          # to had we used `actions/checkout@... { ref: refs/heads/${base} }`.
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          global-json-file: head/global.json
+
+      - name: Cache NuGet packages
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.nuget/packages
+          # Distinct from build-and-test cache (different working trees, both
+          # csproj hashes contribute). restore-keys fall back to build-and-test
+          # cache to avoid cold restore on first run.
+          key: nuget-${{ runner.os }}-oasdiff-${{ hashFiles('head/**/*.csproj', 'base/**/*.csproj') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-oasdiff-
+            nuget-${{ runner.os }}-
+
+      - name: Build PR head spec
+        working-directory: head
+        run: dotnet build ExpertiseApi.slnx --configuration Release --disable-build-servers
+
+      - name: Build base ref spec (tolerate missing / failure)
+        id: base-build
+        working-directory: base
+        # Tolerate two edge cases without failing the gate:
+        #   1. base ref pre-dates the API project (introductory PR after
+        #      reorg) — no diff possible, treat as non-breaking.
+        #   2. base build fails (SDK drift, transient infra) — we cannot
+        #      diff, but failing the gate would block unrelated PRs on
+        #      base-branch breakage. Surface as a Warning instead.
+        # set -uo pipefail (no -e) so we can capture rc explicitly.
+        run: |
+          set -uo pipefail
+          if [ ! -f src/ExpertiseApi/ExpertiseApi.csproj ]; then
+            echo "::notice::base ref has no API project; skipping diff"
+            echo "buildable=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          dotnet build ExpertiseApi.slnx --configuration Release --disable-build-servers
+          rc=$?
+          if [ $rc -ne 0 ]; then
+            echo "::warning::base ref build failed (rc=$rc); cannot diff openapi spec — treating as non-breaking"
+            echo "buildable=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "buildable=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install oasdiff (SHA-pinned binary release)
+        run: |
+          set -euo pipefail
+          ver=v1.15.3
+          # SHA-256 from upstream release page checksums.txt
+          # https://github.com/oasdiff/oasdiff/releases/tag/v1.15.3
+          expected_sha=a8b2f765dd976792f6fb14a5b9854fe94d73aa3b777161d45535f9002b7a4575
+          url="https://github.com/oasdiff/oasdiff/releases/download/${ver}/oasdiff_${ver#v}_linux_amd64.tar.gz"
+          curl -fsSL -o oasdiff.tgz "$url"
+          echo "${expected_sha}  oasdiff.tgz" | sha256sum -c -
+          tar -xzf oasdiff.tgz oasdiff
+          sudo mv oasdiff /usr/local/bin/oasdiff
+          oasdiff --version
+
+      - name: oasdiff breaking-change scan
+        id: diff
+        if: steps.base-build.outputs.buildable == 'true'
+        # Capture exit code without aborting the step; the next step is the
+        # policy gate (label override vs hard fail).
+        run: |
+          set -uo pipefail
+          base=base/src/ExpertiseApi/artifacts/openapi/ExpertiseApi.json
+          head=head/src/ExpertiseApi/artifacts/openapi/ExpertiseApi.json
+          if [ ! -f "$base" ]; then
+            echo "::notice::base spec absent (feature-introducing PR); treating as non-breaking"
+            echo "breaking=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # --format githubactions annotates the PR diff with breaking findings.
+          # oasdiff exits non-zero iff breaking changes are present.
+          oasdiff breaking "$base" "$head" --format githubactions
+          rc=$?
+          if [ $rc -eq 0 ]; then
+            echo "breaking=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "breaking=true" >> "$GITHUB_OUTPUT"
+          fi
+          exit 0
+
+      - name: Enforce gate or honor breaking-change-approved label
+        if: steps.base-build.outputs.buildable == 'true'
+        env:
+          BREAKING: ${{ steps.diff.outputs.breaking }}
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -euo pipefail
+          if [ "${BREAKING:-false}" != "true" ]; then
+            echo "no breaking OpenAPI changes"
+            exit 0
+          fi
+          if printf '%s' "$LABELS" | jq -e 'any(. == "breaking-change-approved")' >/dev/null; then
+            echo "::warning::Breaking OpenAPI changes detected; bypassing gate via 'breaking-change-approved' label (auto-removed on merge)"
+            exit 0
+          fi
+          echo "::error::Breaking OpenAPI changes detected. To merge anyway, apply the 'breaking-change-approved' label to this PR."
+          exit 1

--- a/.github/workflows/openapi-label-cleanup.yml
+++ b/.github/workflows/openapi-label-cleanup.yml
@@ -1,0 +1,43 @@
+name: OpenAPI breaking-change label cleanup
+
+# Auto-remove the `breaking-change-approved` override label on PR merge so it
+# cannot carry over into subsequent feature branches cut from the merge commit.
+# Companion to the openapi-diff job in ci.yml (#174).
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  # Workflow-level baseline is read-only; the cleanup job below scopes
+  # `pull-requests: write` to itself. Matches release.yml's per-job
+  # permissions convention so a future job added to this file does not
+  # silently inherit label-write.
+  contents: read
+
+jobs:
+  cleanup:
+    name: Remove breaking-change-approved label
+    runs-on: ubuntu-latest
+    permissions:
+      # gh pr edit --remove-label requires write on pull-requests.
+      pull-requests: write
+      contents: read
+    # Only on actual merge — closed-without-merge keeps the label as a record
+    # of the decision that led to the close. Filter on the label too so we
+    # do not spawn jobs for PRs that never had the label.
+    if: |
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'breaking-change-approved')
+    timeout-minutes: 2
+    steps:
+      - name: Remove label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh pr edit "$PR_NUMBER" \
+            --repo "$REPO" \
+            --remove-label breaking-change-approved

--- a/README.md
+++ b/README.md
@@ -457,6 +457,26 @@ bash helm/expertise-api/tests/test-render.sh
 
 New features and bug fixes should include tests. See [CLAUDE.md](CLAUDE.md) for test project structure and filtering commands.
 
+## Contributing
+
+### OpenAPI breaking-change gate
+
+The `OpenAPI breaking-change check` CI job (defined in `.github/workflows/ci.yml`) runs on every PR. It builds the OpenAPI spec on both the PR head and the base ref, then runs [oasdiff](https://github.com/oasdiff/oasdiff) `breaking` between them. If breaking changes are detected, the check fails and blocks merge.
+
+A breaking change is, for example: removing a path, removing a response code, renaming a property, narrowing a type, or tightening a required-field set. oasdiff's exact rule set is documented at <https://github.com/oasdiff/oasdiff/blob/main/BREAKING-CHANGES.md>.
+
+#### Bypassing the gate
+
+If the breaking change is intentional and accepted (e.g. removing a deprecated endpoint after the announced sunset window), apply the `breaking-change-approved` label to the PR. The check then passes with a warning annotation. The label is **auto-removed on merge** (by `openapi-label-cleanup.yml`) so it cannot silently carry over to subsequent PRs cut from the merge commit.
+
+Adding the label is an explicit human decision recorded on the PR. Anyone with `pull-requests: write` can apply it; reviewers should treat its presence the same way they would treat a `!` in a Conventional Commit subject.
+
+#### Tolerated edge cases (surface as warnings, not failures)
+
+- PR base ref pre-dates the API project (introductory PRs after a reorg).
+- Base build fails (SDK drift, transient infrastructure). Failing the gate on base-branch breakage would block unrelated PRs.
+- Base spec file is absent (feature-introducing PR that adds the spec for the first time).
+
 ## Documentation
 
 | File | Purpose |


### PR DESCRIPTION
## Summary

Closes #174. Adds an `oasdiff` breaking-change gate to CI for the build-time OpenAPI spec (`src/ExpertiseApi/artifacts/openapi/ExpertiseApi.json`, served at `/openapi/v1.json` at runtime, and attached to GitHub Releases by `release.yml` as `openapi.json`).

The integration backlog (`#147` skill, `#148` pi extension, `#149` docs prompts) treats this spec as a stability contract. Breaking changes should fail CI before they merge, not after a downstream consumer breaks.

## Change set

| Commit | Effect |
|---|---|
| `ci(openapi): oasdiff breaking-change gate for /openapi/v1.json` | New `openapi-diff` job in `ci.yml`. PR-only. Builds spec on PR head + base ref, runs `oasdiff breaking`, fails on breaking change unless `breaking-change-approved` label is present. oasdiff installed as a SHA-pinned binary from the upstream v1.15.3 release (`a8b2f765...4575`). |
| `ci(openapi): auto-remove breaking-change-approved label on merge` | New `openapi-label-cleanup.yml` workflow. Triggered on `pull_request: closed`, filtered to `merged == true` + label present. Removes the label via `gh pr edit --remove-label`. Closed-without-merge keeps the label as audit. |
| `docs: document OpenAPI breaking-change gate + override workflow` | New `## Contributing` section in README documenting the gate, the override label, the auto-removal, and the tolerated edge cases. |

## Architecture decisions (per pre-PR plan)

1. **New job in `ci.yml`, not a separate workflow file.** Cohesive CI surface, single cancellation group, single PR-checks view.
2. **Binary install with SHA-256 verification**, not a third-party action or docker image. Matches release.yml's SHA-pinning convention; avoids transitive action supply chain.
3. **Override via label** (`breaking-change-approved`), auto-removed on merge only (not on close-without-merge — that's a useful audit trail).
4. **Base build failure tolerated as non-breaking with a warning** rather than fail-closed. Failing the gate on base-branch breakage (SDK drift, transient infra) would block unrelated PRs.

## Tolerated edge cases (warnings, not failures)

- Base ref pre-dates the API project (introductory PR after a reorg).
- Base build fails for unrelated reasons.
- Base spec file is absent (feature-introducing PR — the situation this PR itself is in for any future feature that hits the gate).

## Test Plan

- `actionlint` on both modified/new workflow files → clean.
- `markdownlint-cli2` on README → 0 errors.
- **End-to-end smoke**: this PR triggers the new `openapi-diff` job itself. Since this PR doesn't touch the spec, it should report `no breaking OpenAPI changes` and pass. Will verify before promoting from draft.
- Pre-PR `/review` 3-way fan-out (code-review-expert + security-review-expert + linter).

The failure path (breaking change detected → gate fails → label override → gate passes) cannot be exercised within this PR without an artificial spec mutation. If you want a demonstrator PR cut afterwards proving the full state machine, I can file one as a tiny follow-up; otherwise the logic is straightforward enough to trust on code review.

## Risk

Low.

- New job is additive; existing `build-and-test` is untouched.
- New cleanup workflow runs only on merged PRs that carry the override label — strictly opt-in surface.
- Label was created out-of-band (`gh label create breaking-change-approved`) before this PR opened, so it's already available for any future invoker.
- The override surface is `pull-requests: write` — that's the existing review-merge trust boundary, no escalation.

## Doc-sync pairs touched

- README `## Contributing` ↔ `ci.yml` `openapi-diff` job → both in this PR. ✅
- README override note ↔ `openapi-label-cleanup.yml` → both in this PR. ✅

## Out of scope (filed separately if needed)

- **Promoting `OpenAPI breaking-change check` to a required check in branch protection** — repo-admin action, can land post-merge once we observe a few PRs through the gate. Not codified in this PR.
- **Demonstrator PR exercising the failure path** — optional; ask if you want it.
