### PR TITLE
perf(api): cache migration state + 2s OutputCache on /health/ready (closes #158)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ flowchart LR
 | GET | `/audit` | Cross-tenant audit log (cursor-paginated, requires `expertise.admin`). Supports actor-class filter: `?actorClass=human\|agent\|service` (Part D C6) |
 | GET | `/audit/{id}/raw` | Fetch a single audit row by id without response-hygiene transform (admin-only forensic escape hatch). |
 | GET | `/health/live` | Liveness — 200 while the process responds; no dependency checks. Map this to k8s `livenessProbe` and `systemd WatchdogSec=`. No auth. |
-| GET | `/health/ready` | Readiness — 200 only when DB, ONNX model, and pending-migration checks are all healthy; 503 otherwise. Map this to k8s `readinessProbe` and load-balancer health checks. No auth. |
+| GET | `/health/ready` | Readiness — 200 only when DB, ONNX model, and pending-migration checks are all healthy; 503 otherwise. Map this to k8s `readinessProbe` and load-balancer health checks. No auth. Response is cached for 2s (OutputCache policy `health-ready`) and the pending-migration signal is read from a singleton snapshot refreshed every 5 min by `MigrationStateRefresher` — per-probe DB cost is `AddDbContextCheck`'s `CanConnectAsync`, asymptotically bounded at 1 per pod per 2s regardless of incoming RPS (issue #158). |
 | GET | `/health` | Back-compat alias for `/health/ready`. No auth. |
 | GET | `/metrics` | Prometheus scrape endpoint (no auth required) |
 | GET | `/openapi/v1.json` | OpenAPI 3.x document for this deployment (anonymous, all environments). Also attached as a release asset — see ["OpenAPI discovery"](#openapi-discovery) below |

--- a/src/ExpertiseApi/Endpoints/HealthEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/HealthEndpoints.cs
@@ -81,14 +81,23 @@ internal static class HealthEndpoints
             .AllowAnonymous()
             .DisableRateLimiting();
 
+        // OutputCache (policy "health-ready", 2s) caps the underlying
+        // health-check execution rate to one per 2-second window. Issue #158:
+        // /health/ready is AllowAnonymous and runs AddDbContextCheck's
+        // CanConnectAsync per probe — an unauthenticated DoS amplifier without
+        // the cache. /health/live is intentionally NOT cached: its Predicate
+        // matches no checks (response is a const string), so caching adds
+        // overhead with no benefit.
         app.MapHealthChecks("/health/ready", readyOptions)
             .WithTags("Health")
             .AllowAnonymous()
-            .DisableRateLimiting();
+            .DisableRateLimiting()
+            .CacheOutput("health-ready");
 
         app.MapHealthChecks("/health", readyOptions)
             .WithTags("Health")
             .AllowAnonymous()
-            .DisableRateLimiting();
+            .DisableRateLimiting()
+            .CacheOutput("health-ready");
     }
 }

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -72,6 +72,51 @@ builder.Services.AddOutputCache(options =>
         .Cache()
         .Expire(TimeSpan.FromMinutes(5))
         .SetVaryByHost(true));
+
+    // Issue #158 mitigation (2/2): bound the DoS amplification of
+    // /health/ready by capping concurrent probes to one underlying check
+    // execution per 2-second window. The endpoint is AllowAnonymous (k8s
+    // readinessProbe contract); without this cache an attacker can fan-in
+    // thousands of probes and multiply each by AddDbContextCheck's
+    // CanConnectAsync round-trip plus any other tagged check.
+    //
+    // Tenant-agnostic + request-header-agnostic cache key so a per-client
+    // header (User-Agent, X-Forwarded-For) cannot explode the cache into
+    // per-client entries. SetVaryByHost(false) is the explicit default;
+    // pinned here for documentation. SetVaryByQuery([]) drops the
+    // (defensive) default of varying by query so /health/ready?cb=<rand>
+    // cannot defeat the cache.
+    //
+    // CACHING SEMANTICS NOTE: OutputCachePolicyBuilder.Cache() stores only
+    // SUCCESSFUL (200) responses by default. 503 responses (DB outage,
+    // pending migrations) are NOT cached. Outage-path amplification is
+    // therefore bounded by OutputCache's per-key single-flight (default
+    // LockingPolicy.Enabled) — one in-flight check pipeline at a time per
+    // cache key, with subsequent requests sharing the result — NOT by the
+    // 2s window. Recovery is immediate (no cached 503 to expire).
+    //
+    // FUTURE-MAINTAINER GUARD: if /health/ready ever gains
+    // .RequireAuthorization() (replacing .AllowAnonymous() in
+    // HealthEndpoints.cs), the cache policy below MUST either be removed
+    // or extended with SetVaryByValue keyed on the principal. The current
+    // ASP.NET Core pipeline (UseAuthorization -> ... -> UseOutputCache)
+    // protects against unauthenticated cache serving today, but
+    // cross-principal sharing of the cached body would still be incorrect.
+    // See https://learn.microsoft.com/en-us/aspnet/core/performance/caching/output#authorization
+    //
+    // 2s window:
+    //   * shorter than the Helm readinessProbe period (10s default), so a
+    //     steady-state prober never sees a stale response in flight.
+    //   * longer than typical inter-probe arrival within a DoS burst (sub-ms),
+    //     reducing steady-state amplification to 1 DB round-trip per pod per 2s
+    //     regardless of incoming RPS — satisfies the issue's "≤ 10× baseline".
+    //   * tolerable recovery latency on a real outage: 200-cache window
+    //     applies pre-outage; the outage itself is not cached.
+    options.AddPolicy("health-ready", policy => policy
+        .Cache()
+        .Expire(TimeSpan.FromSeconds(2))
+        .SetVaryByHost(false)
+        .SetVaryByQuery(Array.Empty<string>()));
 });
 
 // AddOpenApi registers the document(s) consumed by both runtime MapOpenApi() and the

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -261,7 +261,17 @@ builder.Services.AddDbContext<ExpertiseDbContext>(options =>
 //     unapplied migrations. The framework default maps Degraded → 200 OK; the
 //     readyOptions registration in HealthEndpoints.cs explicitly overrides
 //     ResultStatusCodes so Degraded surfaces as 503.
+//
+//     Per-probe cost is O(1): the actual EF query runs in
+//     MigrationStateRefresher (IHostedService, 5-minute cadence + one-shot
+//     at startup), and the health check is a thin volatile read of the
+//     singleton MigrationState snapshot. Issue #158 (decouples /health/ready
+//     from per-probe DB round-trips).
 string[] readyTag = ["ready"];
+builder.Services.AddSingleton<ExpertiseApi.Services.Health.MigrationState>();
+builder.Services.AddSingleton<ExpertiseApi.Services.Health.IMigrationState>(sp =>
+    sp.GetRequiredService<ExpertiseApi.Services.Health.MigrationState>());
+builder.Services.AddHostedService<ExpertiseApi.Services.Health.MigrationStateRefresher>();
 builder.Services.AddHealthChecks()
     .AddDbContextCheck<ExpertiseDbContext>(
         name: "db",

--- a/src/ExpertiseApi/Services/Health/MigrationState.cs
+++ b/src/ExpertiseApi/Services/Health/MigrationState.cs
@@ -1,0 +1,223 @@
+using System.Collections.Immutable;
+using ExpertiseApi.Data;
+using Microsoft.EntityFrameworkCore;
+using System.Data.Common;
+
+namespace ExpertiseApi.Services.Health;
+
+/// <summary>
+/// Singleton snapshot of the pending-migration state, written by
+/// <see cref="MigrationStateRefresher"/> and read by
+/// <see cref="PendingMigrationHealthCheck"/>.
+///
+/// Decouples the per-probe readiness signal from a per-probe DB round-trip.
+/// Issue #158: <c>/health/ready</c> is <c>AllowAnonymous</c> and was previously
+/// running <c>db.Database.GetPendingMigrationsAsync()</c> on every probe — a
+/// trivial DoS amplifier. The state is now polled on a fixed cadence by the
+/// refresher and read O(1) here.
+/// </summary>
+internal interface IMigrationState
+{
+    /// <summary>
+    /// <c>true</c> until the refresher has completed at least one successful
+    /// poll, then reflects the most recent observation. Conservative default:
+    /// readiness reports <c>Degraded</c> during the boot window before the
+    /// first poll completes, preventing a race where /health/ready briefly
+    /// reports Healthy on a schema that has not yet been checked.
+    /// </summary>
+    bool HasPendingMigrations { get; }
+
+    /// <summary>
+    /// Operator-facing diagnostic. Used as the <c>HealthCheckResult</c>
+    /// description; never reaches the wire on /health/* because
+    /// <c>HealthEndpoints.WriteStatusOnlyPlainText</c> pins the body to the
+    /// aggregate status.
+    /// </summary>
+    string Diagnostic { get; }
+
+    /// <summary>
+    /// Snapshot of the pending migration IDs the last refresh observed.
+    /// Empty when <see cref="HasPendingMigrations"/> is false.
+    /// </summary>
+    ImmutableArray<string> Pending { get; }
+
+    /// <summary>
+    /// UTC timestamp of the last refresh attempt (success or failure).
+    /// <c>null</c> until the first attempt completes.
+    /// </summary>
+    DateTimeOffset? LastCheckedUtc { get; }
+}
+
+/// <summary>
+/// Mutable singleton backing <see cref="IMigrationState"/>. All fields are
+/// <c>volatile</c> / atomic-reference assignment so health-check reads on the
+/// request-pool threads observe the most recent write from the refresher
+/// without locking. <see cref="Set"/> publishes the three fields with a single
+/// store of an immutable record; subsequent reads see either the old triple or
+/// the new triple, never a torn mix.
+/// </summary>
+internal sealed class MigrationState : IMigrationState
+{
+    // Treat the three observable fields as one immutable triple so updates
+    // are torn-write-free under volatile-reference semantics. Field-level
+    // volatility would allow a reader to observe `HasPendingMigrations=false`
+    // alongside a stale `Diagnostic`; one reference assignment fixes that.
+    private volatile Snapshot _snapshot = new(
+        HasPendingMigrations: true,
+        Diagnostic: "Migration state has not yet been checked (boot window).",
+        Pending: ImmutableArray<string>.Empty,
+        LastCheckedUtc: null);
+
+    public bool HasPendingMigrations => _snapshot.HasPendingMigrations;
+    public string Diagnostic => _snapshot.Diagnostic;
+    public ImmutableArray<string> Pending => _snapshot.Pending;
+    public DateTimeOffset? LastCheckedUtc => _snapshot.LastCheckedUtc;
+
+    public void Set(bool hasPending, string diagnostic, ImmutableArray<string> pending)
+    {
+        _snapshot = new Snapshot(hasPending, diagnostic, pending, DateTimeOffset.UtcNow);
+    }
+
+    private sealed record Snapshot(
+        bool HasPendingMigrations,
+        string Diagnostic,
+        ImmutableArray<string> Pending,
+        DateTimeOffset? LastCheckedUtc);
+}
+
+/// <summary>
+/// Polls EF Core's pending-migration list at startup and on a fixed cadence,
+/// writing each observation into <see cref="MigrationState"/>. Runs as a
+/// <see cref="BackgroundService"/> so unhandled exceptions in the refresh
+/// loop are surfaced through the host's logging pipeline (rather than
+/// disappearing as <c>TaskScheduler.UnobservedTaskException</c>) and the
+/// host can apply its configured <c>BackgroundServiceExceptionBehavior</c>.
+///
+/// Startup behaviour: <see cref="BackgroundService.ExecuteAsync"/> is
+/// dispatched on a thread-pool thread by the host runner; it does not block
+/// the host startup sequence. The boot-window readiness state remains the
+/// conservatively-Degraded default until the first poll lands.
+///
+/// Cadence: 5 minutes. The signal changes only when a deploy applies new
+/// migrations or when an operator runs <c>expertise-api migrate</c> out of
+/// band; sub-minute precision is not useful, and once-per-five-minutes is a
+/// negligible DB load (≈ 12 queries/hour/pod against
+/// <c>__EFMigrationsHistory</c>).
+///
+/// Failure handling: transient DB errors during a refresh (DbException,
+/// InvalidOperationException, TimeoutException) do NOT overwrite the last
+/// good observation. The cached state survives a DB outage, which is the
+/// correct behaviour — schema lag is independent of momentary DB
+/// reachability, and <see cref="AddDbContextCheck"/> already covers the
+/// "DB down" signal. Process-fatal exceptions (OOM, AVE) propagate so the
+/// host crashes deterministically. Any other unexpected exception is caught
+/// at the loop top level, logged at Error, and the snapshot is rewritten
+/// to a "refresher faulted" diagnostic so /ready reports Degraded rather
+/// than serving a stale-but-Healthy signal indefinitely.
+/// </summary>
+internal sealed class MigrationStateRefresher : BackgroundService
+{
+    // Internal so tests can substitute a sub-second cadence without exposing
+    // the knob in production configuration. Default chosen to be cheap enough
+    // that we don't need a configuration surface. Mutable-static caveat: this
+    // is a process-wide knob; tests that mutate it should serialise via xUnit
+    // [Collection] to avoid cross-test races.
+    internal static TimeSpan RefreshInterval { get; set; } = TimeSpan.FromMinutes(5);
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly MigrationState _state;
+    private readonly ILogger<MigrationStateRefresher> _logger;
+
+    public MigrationStateRefresher(
+        IServiceScopeFactory scopeFactory,
+        MigrationState state,
+        ILogger<MigrationStateRefresher> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _state = state;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Initial poll happens immediately so readiness state converges as
+        // fast as the DB allows. The timer then paces subsequent polls.
+        try
+        {
+            await RefreshOnceAsync(stoppingToken).ConfigureAwait(false);
+
+            using var timer = new PeriodicTimer(RefreshInterval);
+            while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false))
+            {
+                await RefreshOnceAsync(stoppingToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected during shutdown.
+        }
+        // Top-level catch so an unexpected exception (e.g., NullReferenceException
+        // from a bad future refactor) does not silently kill the refresher and
+        // leave the snapshot pinned to a stale-but-Healthy value. Log loud, then
+        // rewrite the snapshot so /health/ready reports Degraded with the fault
+        // diagnostic.
+        catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+        {
+            _logger.LogError(
+                ex,
+                "MigrationStateRefresher loop faulted; readiness will report Degraded until process restart");
+            _state.Set(
+                hasPending: true,
+                diagnostic: $"Migration state refresher faulted: {ex.GetType().Name}. Snapshot stale.",
+                pending: ImmutableArray<string>.Empty);
+        }
+    }
+
+    private async Task RefreshOnceAsync(CancellationToken ct)
+    {
+        try
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+
+            var pending = await db.Database.GetPendingMigrationsAsync(ct).ConfigureAwait(false);
+            var pendingList = pending.ToImmutableArray();
+
+            if (pendingList.IsEmpty)
+            {
+                _state.Set(
+                    hasPending: false,
+                    diagnostic: "Schema is up to date.",
+                    pending: ImmutableArray<string>.Empty);
+            }
+            else
+            {
+                _state.Set(
+                    hasPending: true,
+                    diagnostic: $"{pendingList.Length} pending migration(s): {string.Join(", ", pendingList)}",
+                    pending: pendingList);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Shutdown; do not overwrite state.
+            throw;
+        }
+        // Narrowed to the same set as PendingMigrationHealthCheck's original
+        // catch (Npgsql/EF errors + DI misconfiguration), plus TimeoutException
+        // for the Npgsql command-timeout path (which is neither DbException
+        // nor InvalidOperationException). Process-fatal exceptions propagate
+        // through this filter and are caught by ExecuteAsync's top-level
+        // handler so the snapshot is rewritten to a fault state.
+        catch (Exception ex) when (ex is DbException or InvalidOperationException or TimeoutException)
+        {
+            // Preserve the last good observation; only log. If this is the
+            // first attempt, the boot-window default ("not yet checked")
+            // remains, which conservatively reports Degraded on /ready.
+            _logger.LogWarning(
+                ex,
+                "Pending-migration refresh failed; readiness state preserved from last successful poll (LastCheckedUtc={LastCheckedUtc})",
+                _state.LastCheckedUtc);
+        }
+    }
+}

--- a/src/ExpertiseApi/Services/Health/PendingMigrationHealthCheck.cs
+++ b/src/ExpertiseApi/Services/Health/PendingMigrationHealthCheck.cs
@@ -1,7 +1,4 @@
-using ExpertiseApi.Data;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using System.Data.Common;
 
 namespace ExpertiseApi.Services.Health;
 
@@ -23,69 +20,31 @@ namespace ExpertiseApi.Services.Health;
 /// Surfaced separately from <c>AddDbContextCheck</c> (which only proves the
 /// server is reachable) because a reachable-but-out-of-date schema is a
 /// distinct operational state from "DB down".
+///
+/// <para>
+/// Per-probe cost: O(1) read from the singleton <see cref="IMigrationState"/>
+/// snapshot. The actual EF Core query runs in
+/// <see cref="MigrationStateRefresher"/> on a fixed cadence, decoupling the
+/// readiness signal from per-probe DB load. Issue #158.
+/// </para>
 /// </summary>
 internal sealed class PendingMigrationHealthCheck : IHealthCheck
 {
-    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IMigrationState _state;
 
-    public PendingMigrationHealthCheck(IServiceScopeFactory scopeFactory)
+    public PendingMigrationHealthCheck(IMigrationState state)
     {
-        _scopeFactory = scopeFactory;
+        _state = state;
     }
 
-    public async Task<HealthCheckResult> CheckHealthAsync(
+    public Task<HealthCheckResult> CheckHealthAsync(
         HealthCheckContext context,
         CancellationToken cancellationToken = default)
     {
-        // DbContext is scoped; resolving via IServiceScopeFactory creates a
-        // throwaway scope per probe invocation so we don't pin a connection
-        // for the lifetime of the singleton check instance. `await using`
-        // honours IAsyncDisposable on the scope so any async-disposable
-        // scoped services (including DbContext) tear down asynchronously.
-        await using var scope = _scopeFactory.CreateAsyncScope();
-        var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
-
-        IEnumerable<string> pending;
-        try
+        if (_state.HasPendingMigrations)
         {
-            pending = await db.Database.GetPendingMigrationsAsync(cancellationToken)
-                .ConfigureAwait(false);
+            return Task.FromResult(HealthCheckResult.Degraded(_state.Diagnostic));
         }
-        // Narrowed from `catch (Exception)` to satisfy CodeQL cs/catch-of-all-exceptions
-        // and to align with the safer-by-default posture:
-        //
-        //   * OperationCanceledException propagates by exclusion — ASP.NET Core
-        //     health-check framework relies on cancellation propagation to
-        //     respect HealthCheckOptions.Timeout. Swallowing it here would let
-        //     a runaway probe pin a DB connection past the configured budget.
-        //   * Process-fatal exceptions (OOM, AVE, stack overflow) propagate so
-        //     the host can crash deterministically rather than masquerading
-        //     as "DB unreachable."
-        //   * DbException covers Npgsql.PostgresException / NpgsqlException
-        //     (connection refused, auth failed, schema missing __EFMigrationsHistory).
-        //   * InvalidOperationException covers EF/DI misconfiguration
-        //     (e.g., DbContext disposed, no provider configured).
-        catch (Exception ex) when (ex is DbException or InvalidOperationException)
-        {
-            // DB unreachable / __EFMigrationsHistory missing — surface as Unhealthy so
-            // the operator distinguishes "can't tell" from "behind schema". The
-            // DbContext check will likely also be Unhealthy in this case, providing
-            // a corroborating signal. The ex argument is consumed by the framework
-            // for its diagnostics payload; the response writer
-            // (WriteStatusOnlyPlainText in HealthEndpoints.cs) ensures the message
-            // and stack trace never reach the wire.
-            return HealthCheckResult.Unhealthy(
-                "Unable to query pending migrations (DB unreachable or migration history missing).",
-                ex);
-        }
-
-        var pendingList = pending.ToList();
-        if (pendingList.Count == 0)
-        {
-            return HealthCheckResult.Healthy("Schema is up to date.");
-        }
-
-        return HealthCheckResult.Degraded(
-            $"{pendingList.Count} pending migration(s): {string.Join(", ", pendingList)}");
+        return Task.FromResult(HealthCheckResult.Healthy(_state.Diagnostic));
     }
 }

--- a/tests/ExpertiseApi.Tests/Unit/HealthEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/HealthEndpointTests.cs
@@ -116,4 +116,68 @@ public class HealthEndpointTests
             CancellationToken cancellationToken = default)
             => Task.FromResult(HealthCheckResult.Degraded("stub: always degraded for routing assertion"));
     }
+
+    [Fact]
+    public async Task HealthReady_OutputCache_CollapsesConcurrentProbes()
+    {
+        // Issue #158: /health/ready is AllowAnonymous and previously ran the
+        // underlying checks per probe — an unauthenticated DoS amplifier. The
+        // "health-ready" OutputCache policy (Expire 2s) caps execution to one
+        // per 2s window. This test proves the cache is wired in front of the
+        // health-check pipeline by:
+        //   (1) replacing the production registrations with a single counter
+        //       check tagged "ready".
+        //   (2) firing N concurrent /health/ready probes within the 2s cache
+        //       window, then asserting the counter incremented exactly once.
+        // Without CacheOutput on the endpoint this assertion fails with
+        // Count == N — the regression guard.
+        var counter = new CountingHealthCheck();
+        using var outerFactory = new ApiFactory(UnreachableConnectionString);
+        using var factory = outerFactory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.Configure<HealthCheckServiceOptions>(options =>
+                    options.Registrations.Clear());
+                services.AddHealthChecks().AddCheck(
+                    "counter-stub",
+                    counter,
+                    failureStatus: HealthStatus.Unhealthy,
+                    tags: ["ready"]);
+            });
+        });
+
+        using var client = factory.CreateClient();
+
+        const int probeCount = 20;
+        var probes = Enumerable.Range(0, probeCount)
+            .Select(_ => client.GetAsync(new Uri("/health/ready", UriKind.Relative)))
+            .ToArray();
+        var responses = await Task.WhenAll(probes);
+
+        foreach (var response in responses)
+        {
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+        // OutputCache lock semantics collapse concurrent misses to a single
+        // executor invocation; tolerate a small slack ( == 2 ) for the race
+        // where a probe arrives in the narrow window between the producer
+        // returning and the cache entry being published. Anything beyond 2
+        // would indicate the cache is not in front of the pipeline at all,
+        // which is the regression this test guards against.
+        counter.Count.Should().BeInRange(1, 2);
+    }
+
+    private sealed class CountingHealthCheck : IHealthCheck
+    {
+        private int _count;
+        public int Count => Volatile.Read(ref _count);
+        public Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context,
+            CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref _count);
+            return Task.FromResult(HealthCheckResult.Healthy("counted"));
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Closes #158. Two-part mitigation for the `/health/ready` DoS amplifier flagged in PR #157's security review:

1. **Commit 1** — cache the pending-migration signal at startup + refresh on a 5-minute cadence via `BackgroundService`. Per-probe cost drops from `SELECT FROM __EFMigrationsHistory + in-memory snapshot diff` to a volatile read.
2. **Commit 2** — 2 s OutputCache on `/health/ready` (and the `/health` alias). Caps the underlying check-pipeline execution to one per 2-second window for 200-cached responses; outage-path bounding is provided by OutputCache's default `LockingPolicy.Enabled` (per-key single-flight).

After both: the endpoint's amplification factor over the static-literal baseline is asymptotically bounded at **1 DB ping per pod per 2 s in steady state**, and **per-key single-flight during DB outage** (concurrent probes share one in-flight check pipeline). The `~∞×` pre-PR factor is closed.

## Change set

| Commit | Effect |
|---|---|
| `perf(api): cache pending-migration state at startup; readiness check O(1)` | New `IMigrationState` singleton + `MigrationStateRefresher : BackgroundService` (`PeriodicTimer` 5 min, top-level catch that rewrites snapshot to a "refresher faulted" diagnostic on unexpected exception). `PendingMigrationHealthCheck` becomes a thin volatile read. Default state is conservatively Degraded ("not yet checked") so /ready never reports Healthy before the first poll lands. |
| `perf(api): 2s OutputCache on /health/ready to bound DoS amplification` | New OutputCache policy `health-ready` (Expire 2 s, no host/query/header vary). Applied to `/health/ready` and `/health`. **NOT** applied to `/health/live` (already a const-string response — caching adds overhead with no benefit). Inline comment documents the 200-only cache behaviour, the single-flight outage-path bound, and the future-maintainer trap around `RequireAuthorization()`. |
| `docs: note /health/ready cache + refresher in API Surface table` | README cross-ref. |

## Architecture decisions

1. **`BackgroundService`, not raw `IHostedService`+`Task.Run`**: unhandled exceptions in the refresh loop are surfaced through the host's logging pipeline rather than disappearing as `TaskScheduler.UnobservedTaskException`. (Corrected during /review — initial draft used raw `IHostedService` and would have silently killed the refresher on any non-DB exception.)
2. **Conservative-Degraded default during the boot window**: prevents a race where /ready briefly reports Healthy on a schema that has not yet been verified.
3. **Transient DB failure preserves last-good state** in the refresher: schema lag is independent of DB reachability. `AddDbContextCheck` already covers the "DB down" signal; doubling up here would be a noisy correlated alert.
4. **Top-level catch in `ExecuteAsync`** rewrites the snapshot to a "refresher faulted" diagnostic so /ready reports Degraded rather than serving a stale-but-Healthy signal indefinitely.
5. **OutputCache window = 2 s**: shorter than `readinessProbe.periodSeconds: 10`; longer than DoS-burst inter-arrival (collapses thousands of probes to one); 200-only caching means outage recovery is immediate (no cached 503 to expire).
6. **Cache key is tenant-/header-/query-agnostic**: `SetVaryByHost(false) + SetVaryByQuery([])` prevents per-client header or `?cb=<rand>` cache-buster from exploding the cache or defeating it. A code-comment guard warns future maintainers that adding `RequireAuthorization()` requires either removing the cache or adding `SetVaryByValue` keyed on the principal.

## Test Plan

- **Cache-correctness regression** (new): `HealthReady_OutputCache_CollapsesConcurrentProbes` — 20 concurrent probes against a stubbed counter `IHealthCheck` tagged `"ready"`, asserts `BeInRange(1, 2)` underlying invocations. Strict `Be(1)` initially flaked ≈ 1-in-3 under in-class contention; loosened with explicit slack comment per code-review-expert's recommendation. The regression surface (cache missing entirely → count == 20) is still guarded.
- 171/171 unit tests pass locally, 8 consecutive runs of the full HealthEndpointTests class.
- Integration suite requires Testcontainers (Docker, unavailable in this dev env) — deferred to CI. The `HealthReady_Returns200_WithHealthyStack` integration test will validate the full pipeline (real Postgres + new BackgroundService + cache) on the runner.

## /review outcome (3-way, PASS_WITH_WARNINGS → addressed in-band)

| Source | Finding | Disposition |
|---|---|---|
| code-review Warning | 503-cache claim in original PR body / Program.cs comment was wrong — `Cache()` only caches 200s by default | **Fixed in 78feeab fixup**: comment rewritten, PR body retracted, outage-path bound correctly attributed to single-flight |
| security Low | Original `IHostedService` + `Task.Run` shape silently kills refresher on unexpected exception (premise in my brief was inverted) | **Fixed in 722ce7f fixup**: converted to `BackgroundService` + top-level catch + snapshot rewrite |
| security Info | Future-maintainer trap: cache + `RequireAuthorization()` | **Fixed in 78feeab fixup**: explicit guard comment on the cache policy block |
| code-review Info | `TimeoutException` not in catch filter (Npgsql command-timeout escapes) | **Fixed in 722ce7f fixup**: added to filter |
| code-review Info | Mutable static `RefreshInterval` test-only seam | Acknowledged; no current test races. Noted in xmldoc. |
| linter | All clean | — |

## Risk

Low after fixups.

- **Hosted-service ordering**: `MigrationStateRefresher` registers as `AddHostedService` after `AddDbContext`. ASP.NET Core hosted-service `ExecuteAsync` runs after DI is built, so the scope-factory resolution is safe.
- **Cache + 200-only behaviour**: outage recovery is immediate (verified via `Cache()` semantics in Microsoft.AspNetCore.OutputCaching docs); only steady-state Healthy responses are cached for 2 s.
- **Boot-window 503**: between host start and first successful poll (≤ ~50 ms typical, up to Npgsql connect timeout on cold DB) the readiness probe reports 503. K8s `readinessProbe.initialDelaySeconds` covers this; in the worst case the pod takes one extra readiness cycle to converge.

## Doc-sync pairs touched

- README API Surface row ↔ `HealthEndpoints.cs` `/health/ready` registration → both in this PR. ✅
- Inline xmldoc on `MigrationState` / `MigrationStateRefresher` / `PendingMigrationHealthCheck` ↔ Program.cs registration comment ↔ Program.cs cache policy comment → all aligned. ✅

## Out of scope (per the issue)

- Adding auth to `/health/ready` — breaks the k8s readinessProbe contract.
- Rate-limiting via `Microsoft.AspNetCore.RateLimiting` — same contract problem.
- `values.networkPolicy.healthEndpointsAllowedCIDRs[]` Helm option — orthogonal hardening; can land as a separate issue if a deployer wants it.
