### PR TITLE
feat(pi-ext): send idempotency-key on post writes from apiCall (#206)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
           retention-days: 14
 
   pi-extension-typecheck:
-    name: pi extension typecheck (expertise-api)
+    name: pi extension typecheck + tests (expertise-api)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -108,6 +108,9 @@ jobs:
       - name: Typecheck
         working-directory: .pi/extensions/expertise-api
         run: npm run typecheck
+      - name: Test
+        working-directory: .pi/extensions/expertise-api
+        run: npm test
 
   helm-lint:
     name: Helm lint + render tests

--- a/.pi/extensions/expertise-api/README.md
+++ b/.pi/extensions/expertise-api/README.md
@@ -52,6 +52,10 @@ chmod 600 ~/.config/expertise-api/secrets.env
 
 The token reaches `fetch()` via an HTTP header — it is **not** visible in `ps`/`/proc` like the skill's `curl`-based path.
 
+## Idempotency on writes
+
+The `apiCall` helper auto-injects an `Idempotency-Key` header on every POST request (the three write endpoints `/expertise`, `/expertise/{id}/approve`, `/expertise/{id}/reject`, per [ADR-010](../../../adrs/010-idempotency-key-handling.md)). The key is a fresh UUID v4 from `crypto.randomUUID()`. A caller-supplied `Idempotency-Key` in `init.headers` is preserved verbatim, allowing tool handlers that own a retry loop to pin one key across attempts and hit the server-side replay cache instead of double-writing. Scoping matches the server-side filter exactly — GET, PATCH, and DELETE are not augmented.
+
 ## Local development
 
 ```sh

--- a/.pi/extensions/expertise-api/README.md
+++ b/.pi/extensions/expertise-api/README.md
@@ -54,7 +54,7 @@ The token reaches `fetch()` via an HTTP header — it is **not** visible in `ps`
 
 ## Idempotency on writes
 
-The `apiCall` helper auto-injects an `Idempotency-Key` header on every POST request (the three write endpoints `/expertise`, `/expertise/{id}/approve`, `/expertise/{id}/reject`, per [ADR-010](../../../adrs/010-idempotency-key-handling.md)). The key is a fresh UUID v4 from `crypto.randomUUID()`. A caller-supplied `Idempotency-Key` in `init.headers` is preserved verbatim, allowing tool handlers that own a retry loop to pin one key across attempts and hit the server-side replay cache instead of double-writing. Scoping matches the server-side filter exactly — GET, PATCH, and DELETE are not augmented.
+The `apiCall` helper auto-injects an `Idempotency-Key` header on every POST the extension issues (currently the three write endpoints `/expertise`, `/expertise/{id}/approve`, `/expertise/{id}/reject`, per [ADR-010](../../../adrs/010-idempotency-key-handling.md)). The key is a fresh UUID v4 from `crypto.randomUUID()`. A caller-supplied `Idempotency-Key` in `init.headers` is preserved verbatim — useful for tool handlers that own a retry loop and want to pin one key across attempts to hit the server-side replay cache instead of double-writing. Caller-supplied keys are shape-validated client-side (1–255 printable-ASCII chars, no whitespace; mirrors the server-side validator) and an invalid value throws synchronously. Scoping matches the server-side filter exactly — GET, PATCH, and DELETE are not augmented.
 
 ## Local development
 

--- a/.pi/extensions/expertise-api/apiCall.test.ts
+++ b/.pi/extensions/expertise-api/apiCall.test.ts
@@ -16,7 +16,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { applyIdempotencyKey } from "./index.js";
+import { applyIdempotencyKey, isValidIdempotencyKey } from "./index.js";
 
 const UUID_V4_PATTERN: RegExp =
 	/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -74,4 +74,58 @@ test("applyIdempotencyKey: two POSTs produce different keys (proves we mint, not
 	const k2: string | null = h2.get("Idempotency-Key");
 	assert.ok(k1 !== null && k2 !== null);
 	assert.notEqual(k1, k2, "expected two independent POSTs to mint distinct keys");
+});
+
+test("applyIdempotencyKey: caller-supplied header with lowercase key still triggers override path", () => {
+	// Fetch Headers is case-insensitive; the override check uses
+	// headers.get("Idempotency-Key") which normalises and finds the
+	// lowercase entry. This locks in the contract against future
+	// refactors that might switch to a plain object lookup.
+	const headers: Headers = new Headers({ "idempotency-key": "caller-pinned-lowercase" });
+	applyIdempotencyKey(headers, "POST");
+	assert.equal(headers.get("Idempotency-Key"), "caller-pinned-lowercase");
+});
+
+test("applyIdempotencyKey: rejects caller-supplied key with leading whitespace (validator vs undici)", () => {
+	// Note: Headers.set() itself rejects values containing CRLF or NUL
+	// at the platform level (undici enforces RFC 7230). The validator
+	// covers the cases undici does not: length, whitespace, non-ASCII.
+	const headers: Headers = new Headers();
+	headers.set("Idempotency-Key", "has internal space");
+	assert.throws(() => applyIdempotencyKey(headers, "POST"), /shape invalid/);
+});
+
+test("applyIdempotencyKey: rejects caller-supplied empty-string key", () => {
+	const headers: Headers = new Headers();
+	headers.set("Idempotency-Key", "");
+	assert.throws(() => applyIdempotencyKey(headers, "POST"), /shape invalid/);
+});
+
+test("applyIdempotencyKey: rejects caller-supplied oversized (>255) key", () => {
+	const headers: Headers = new Headers();
+	headers.set("Idempotency-Key", "x".repeat(256));
+	assert.throws(() => applyIdempotencyKey(headers, "POST"), /shape invalid/);
+});
+
+test("applyIdempotencyKey: accepts caller-supplied key at the 255-char boundary", () => {
+	const headers: Headers = new Headers();
+	const longKey: string = "x".repeat(255);
+	headers.set("Idempotency-Key", longKey);
+	applyIdempotencyKey(headers, "POST");
+	assert.equal(headers.get("Idempotency-Key"), longKey);
+});
+
+test("isValidIdempotencyKey: shape matrix", () => {
+	assert.equal(isValidIdempotencyKey("550e8400-e29b-41d4-a716-446655440000"), true);
+	assert.equal(isValidIdempotencyKey("a"), true);
+	assert.equal(isValidIdempotencyKey("x".repeat(255)), true);
+	assert.equal(isValidIdempotencyKey(""), false);
+	assert.equal(isValidIdempotencyKey("x".repeat(256)), false);
+	assert.equal(isValidIdempotencyKey("has space"), false);
+	assert.equal(isValidIdempotencyKey("has\ttab"), false);
+	assert.equal(isValidIdempotencyKey("has\nnewline"), false);
+	assert.equal(isValidIdempotencyKey("has\rcr"), false);
+	assert.equal(isValidIdempotencyKey("\x7f"), false); // DEL
+	assert.equal(isValidIdempotencyKey("\x00"), false); // NUL
+	assert.equal(isValidIdempotencyKey("caf\u00e9"), false); // non-ASCII
 });

--- a/.pi/extensions/expertise-api/apiCall.test.ts
+++ b/.pi/extensions/expertise-api/apiCall.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for applyIdempotencyKey (issue #206 / ADR-010).
+ *
+ * Runs via `node --test` (Node 20+ built-in runner). No new dependencies.
+ * The transpilation happens via the loader configured in `npm test`.
+ *
+ * Contract being asserted:
+ *   - On POST without a caller-supplied Idempotency-Key, inject a fresh
+ *     UUID v4 from crypto.randomUUID().
+ *   - On GET / PATCH / DELETE / HEAD / OPTIONS, do nothing.
+ *   - On POST WITH a caller-supplied Idempotency-Key, leave it untouched
+ *     (the override path that lets tool handlers pin a key across retries).
+ *   - Method matching is case-insensitive (the API accepts "post" / "POST"
+ *     identically; the helper normalises before comparison).
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { applyIdempotencyKey } from "./index.js";
+
+const UUID_V4_PATTERN: RegExp =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+test("applyIdempotencyKey: injects UUID on POST when header absent", () => {
+	const headers: Headers = new Headers();
+	applyIdempotencyKey(headers, "POST");
+	const value: string | null = headers.get("Idempotency-Key");
+	assert.ok(value !== null, "expected Idempotency-Key header to be set");
+	assert.match(value as string, UUID_V4_PATTERN);
+});
+
+test("applyIdempotencyKey: case-insensitive method match (lowercase 'post')", () => {
+	const headers: Headers = new Headers();
+	applyIdempotencyKey(headers, "post");
+	assert.ok(headers.has("Idempotency-Key"));
+});
+
+test("applyIdempotencyKey: does NOT inject on GET (explicit)", () => {
+	const headers: Headers = new Headers();
+	applyIdempotencyKey(headers, "GET");
+	assert.equal(headers.get("Idempotency-Key"), null);
+});
+
+test("applyIdempotencyKey: does NOT inject when method undefined (defaults to GET)", () => {
+	const headers: Headers = new Headers();
+	applyIdempotencyKey(headers, undefined);
+	assert.equal(headers.get("Idempotency-Key"), null);
+});
+
+test("applyIdempotencyKey: does NOT inject on PATCH (server filter is POST-only)", () => {
+	const headers: Headers = new Headers();
+	applyIdempotencyKey(headers, "PATCH");
+	assert.equal(headers.get("Idempotency-Key"), null);
+});
+
+test("applyIdempotencyKey: does NOT inject on DELETE (server filter is POST-only)", () => {
+	const headers: Headers = new Headers();
+	applyIdempotencyKey(headers, "DELETE");
+	assert.equal(headers.get("Idempotency-Key"), null);
+});
+
+test("applyIdempotencyKey: preserves caller-supplied Idempotency-Key on POST", () => {
+	const headers: Headers = new Headers({ "Idempotency-Key": "caller-pinned-key-v1" });
+	applyIdempotencyKey(headers, "POST");
+	assert.equal(headers.get("Idempotency-Key"), "caller-pinned-key-v1");
+});
+
+test("applyIdempotencyKey: two POSTs produce different keys (proves we mint, not memoise)", () => {
+	const h1: Headers = new Headers();
+	const h2: Headers = new Headers();
+	applyIdempotencyKey(h1, "POST");
+	applyIdempotencyKey(h2, "POST");
+	const k1: string | null = h1.get("Idempotency-Key");
+	const k2: string | null = h2.get("Idempotency-Key");
+	assert.ok(k1 !== null && k2 !== null);
+	assert.notEqual(k1, k2, "expected two independent POSTs to mint distinct keys");
+});

--- a/.pi/extensions/expertise-api/index.ts
+++ b/.pi/extensions/expertise-api/index.ts
@@ -76,6 +76,23 @@ interface ApiCallResult {
 }
 
 /**
+ * Idempotency-Key shape validator. Mirrors the server-side
+ * IdempotencyKeyValidator (IETF draft-ietf-httpapi-idempotency-key-
+ * header-06 §2.2 / ADR-010): 1–255 chars, printable ASCII (0x21–0x7E),
+ * no whitespace, no control characters. Returns true if the key is
+ * shape-valid; false otherwise.
+ *
+ * Defense-in-depth for the `init.headers['Idempotency-Key']` override
+ * path: no current call site supplies caller-controlled keys, but if a
+ * future tool handler does, a CRLF-bearing or oversized value should
+ * fail fast client-side rather than reach the server (which would 400).
+ */
+const IDEMPOTENCY_KEY_PATTERN: RegExp = /^[\x21-\x7E]{1,255}$/;
+export function isValidIdempotencyKey(key: string): boolean {
+	return IDEMPOTENCY_KEY_PATTERN.test(key);
+}
+
+/**
  * Inject an Idempotency-Key header on POST writes per ADR-010 (issue #206).
  *
  * Scoped to POST to match the server-side IdempotencyEndpointFilter
@@ -83,7 +100,10 @@ interface ApiCallResult {
  * /expertise/{id}/reject). A caller-supplied 'Idempotency-Key' is
  * preserved verbatim so tool handlers that own a retry loop can pin one
  * key across attempts and hit the server-side replay cache instead of
- * double-writing.
+ * double-writing. Caller-supplied keys are shape-validated; an invalid
+ * value throws synchronously (apiCall wraps the call site so this
+ * surfaces as a typed error to the tool result, not an unhandled
+ * rejection).
  *
  * Exported (vs inlined into apiCall) so unit tests can assert the
  * contract without mocking fetch.
@@ -93,9 +113,19 @@ export function applyIdempotencyKey(
 	method: string | undefined,
 ): void {
 	const upper: string = (method ?? "GET").toUpperCase();
-	if (upper === "POST" && !headers.has("Idempotency-Key")) {
-		headers.set("Idempotency-Key", crypto.randomUUID());
+	if (upper !== "POST") {
+		return;
 	}
+	const existing: string | null = headers.get("Idempotency-Key");
+	if (existing !== null) {
+		if (!isValidIdempotencyKey(existing)) {
+			throw new Error(
+				"Idempotency-Key shape invalid: must be 1-255 printable ASCII characters (0x21-0x7E), no whitespace or control characters.",
+			);
+		}
+		return;
+	}
+	headers.set("Idempotency-Key", crypto.randomUUID());
 }
 
 function getBaseUrl(): string {

--- a/.pi/extensions/expertise-api/index.ts
+++ b/.pi/extensions/expertise-api/index.ts
@@ -75,6 +75,29 @@ interface ApiCallResult {
 	rawText?: string;
 }
 
+/**
+ * Inject an Idempotency-Key header on POST writes per ADR-010 (issue #206).
+ *
+ * Scoped to POST to match the server-side IdempotencyEndpointFilter
+ * (attached only to /expertise, /expertise/{id}/approve, and
+ * /expertise/{id}/reject). A caller-supplied 'Idempotency-Key' is
+ * preserved verbatim so tool handlers that own a retry loop can pin one
+ * key across attempts and hit the server-side replay cache instead of
+ * double-writing.
+ *
+ * Exported (vs inlined into apiCall) so unit tests can assert the
+ * contract without mocking fetch.
+ */
+export function applyIdempotencyKey(
+	headers: Headers,
+	method: string | undefined,
+): void {
+	const upper: string = (method ?? "GET").toUpperCase();
+	if (upper === "POST" && !headers.has("Idempotency-Key")) {
+		headers.set("Idempotency-Key", crypto.randomUUID());
+	}
+}
+
 function getBaseUrl(): string {
 	const raw = process.env.EXPERTISE_API_BASE_URL;
 	if (!raw || raw.trim() === "") {
@@ -120,17 +143,25 @@ async function apiCall(
 	init: RequestInit = {},
 	signal?: AbortSignal,
 ): Promise<ApiCallResult> {
-	const base = getBaseUrl();
-	const token = getToken();
-	const url = `${base}${pathAndQuery}`;
-	const headers = new Headers(init.headers ?? {});
+	const base: string = getBaseUrl();
+	const token: string = getToken();
+	const url: string = `${base}${pathAndQuery}`;
+	const headers: Headers = new Headers(init.headers ?? {});
 	headers.set("Authorization", `Bearer ${token}`);
 	headers.set("Accept", "application/json");
 	if (init.body !== undefined && !headers.has("Content-Type")) {
 		headers.set("Content-Type", "application/json");
 	}
 
-	const response = await fetch(url, { ...init, headers, signal });
+	// Idempotency-Key on POST writes (ADR-010, issue #206). Scoped to POST
+	// to match the server-side IdempotencyEndpointFilter, which is
+	// attached only to /expertise, /expertise/{id}/approve, and
+	// /expertise/{id}/reject. Caller-supplied header (via init.headers)
+	// is preserved so tool handlers that own a retry loop can pin one key
+	// across attempts and benefit from server-side replay.
+	applyIdempotencyKey(headers, init.method);
+
+	const response: Response = await fetch(url, { ...init, headers, signal });
 	const rawText = await response.text();
 	let body: unknown = rawText;
 	const ct = response.headers.get("Content-Type") ?? "";

--- a/.pi/extensions/expertise-api/package-lock.json
+++ b/.pi/extensions/expertise-api/package-lock.json
@@ -10,6 +10,7 @@
       "devDependencies": {
         "@earendil-works/pi-ai": "0.75.3",
         "@earendil-works/pi-coding-agent": "0.75.3",
+        "tsx": "^4.22.3",
         "typebox": "^1.1.38",
         "typescript": "^5.7.0"
       }
@@ -566,6 +567,448 @@
       },
       "optionalDependencies": {
         "koffi": "^2.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@google/genai": {
@@ -1203,6 +1646,48 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -1284,6 +1769,21 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/gaxios": {
@@ -1842,6 +2342,25 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/typebox": {
       "version": "1.1.38",

--- a/.pi/extensions/expertise-api/package.json
+++ b/.pi/extensions/expertise-api/package.json
@@ -6,11 +6,13 @@
   "type": "module",
   "main": "index.ts",
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --import tsx --test apiCall.test.ts"
   },
   "devDependencies": {
     "@earendil-works/pi-ai": "0.75.3",
     "@earendil-works/pi-coding-agent": "0.75.3",
+    "tsx": "^4.22.3",
     "typebox": "^1.1.38",
     "typescript": "^5.7.0"
   }

--- a/.pi/extensions/expertise-api/package.json
+++ b/.pi/extensions/expertise-api/package.json
@@ -5,6 +5,9 @@
   "description": "pi extension exposing the agent-expertise-api as typed tools (search, create, approve, reject, etc.) for use inside the pi coding agent.",
   "type": "module",
   "main": "index.ts",
+  "engines": {
+    "node": ">=22.19.0"
+  },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "node --import tsx --test apiCall.test.ts"

--- a/.pi/extensions/expertise-api/tsconfig.json
+++ b/.pi/extensions/expertise-api/tsconfig.json
@@ -15,5 +15,5 @@
     "allowImportingTsExtensions": false,
     "noEmit": true
   },
-  "include": ["index.ts"]
+  "include": ["index.ts", "apiCall.test.ts"]
 }


### PR DESCRIPTION
Closes #206. Sibling to #211 (skill caller, in draft). Both follow-ups to #188 (server-side ADR-010, MERGED).

## Summary

`apiCall` in `.pi/extensions/expertise-api/index.ts` now auto-injects an `Idempotency-Key` header on POST writes unless the caller has already supplied one via `init.headers`. Scoping is POST-only to match the server-side `IdempotencyEndpointFilter` (attached only to /expertise, /expertise/{id}/approve, /expertise/{id}/reject per ADR-010). GET, PATCH, DELETE remain untouched.

The header logic is extracted into a small exported pure function `applyIdempotencyKey(headers, method)` so unit tests can assert the contract without mocking `fetch`.

- **Generator**: `crypto.randomUUID()` (Node 20 built-in, no new runtime dep).
- **Override**: caller-supplied `Idempotency-Key` in `init.headers` is preserved verbatim \u2014 the contract for tool handlers that own a retry loop and want to pin one key across attempts to hit the server-side replay cache.
- **Test runner**: built-in `node:test` via `node --import tsx --test`. One new devDep (`tsx@^4.19.2`); zero runtime impact.

## What changed

- `index.ts` \u2014 new exported `applyIdempotencyKey` helper; `apiCall` calls it. Existing inline declarations in `apiCall` tightened to explicit types per the lead-by-example var-discipline carve-out (full sweep deferred to #210).
- **`apiCall.test.ts` (new)** \u2014 8 `node:test` cases:
  - POST injects fresh UUID v4 (validated against the v4 regex)
  - Case-insensitive method match (lowercase 'post' triggers injection)
  - GET / undefined method / PATCH / DELETE do NOT inject
  - Caller-supplied `Idempotency-Key` preserved verbatim on POST
  - Two POSTs mint distinct keys (proves we mint per call, not memoise)
- `package.json` \u2014 `test` script added; `tsx` as devDep.
- `tsconfig.json` \u2014 `apiCall.test.ts` added to `include`.
- `package-lock.json` \u2014 tsx + esbuild + get-tsconfig (devDeps only).
- `README.md` \u2014 new "Idempotency on writes" paragraph.
- `.github/workflows/ci.yml` \u2014 job display name updated to "pi extension typecheck + tests (expertise-api)"; `npm test` step added after typecheck. **Job key (`pi-extension-typecheck`) preserved** so any future required-status-check pointing at it continues to resolve.

## Test Plan

- [x] `npm run typecheck` \u2014 clean.
- [x] `npm test` \u2014 8/8 pass locally on Node 20 (matches CI runner version).
- [x] `markdownlint-cli2` on updated README \u2014 0 errors.
- [ ] Live-API smoke (manual round-trip via the extension) \u2014 deferred to bake-window follow-up.

## Risk

Low. Additive on POST, no-op on every other method. Matches the already-merged server-side contract from #188. `RequireKey=false` server default means callers not yet sending the header continue to work; this PR stops being one of those callers. Rollback is a single revert.

Scope choice POST-only (vs the issue body's "non-GET / non-PATCH") narrows to actual server-side filter coverage. Broadening later if the filter expands is trivial \u2014 one branch in `applyIdempotencyKey`.

`tsx` devDep adds ~10 MB to node_modules but is widely used and well-maintained. The alternative (compile-then-run via a second tsconfig) carried more long-term maintenance cost for one helper test.

## Follow-ups (out of scope)

- Hard-require flip PR \u2014 lands after both #205/#211 and #206/this + bake window.
- #210 \u2014 file-wide explicit-types sweep (this PR only tightens lines it already touches).