### PR TITLE
fix(helm)!: default image.tag to chart appversion and surface probe paths as values

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,23 @@ See [CLAUDE.md](CLAUDE.md) for full build commands, curl examples, and developme
 
 A Helm chart is included at `helm/expertise-api/` for deploying to Kubernetes (k3s or any k8s cluster). The chart includes PostgreSQL and PgBouncer. Backup is handled out-of-chart by a sidecar deployed from the infrastructure repo.
 
+`image.tag` defaults to empty string and the deployment template falls back to `.Chart.AppVersion`, so a vanilla `helm install` always pulls the chart's appVersion-aligned tag. Override `image.tag` only when pinning to a maintenance/preview tag distinct from the chart's appVersion — the chart emits a `WARNING` in `NOTES.txt` when `image.tag` is set explicitly (image+chart-skew advisory per issue #216 / #153) and a second `WARNING` when it is set to the mutable `latest` tag.
+
+Probe paths are surfaced as values for forks that expose health on non-default routes:
+
+```yaml
+api:
+  probes:
+    liveness:
+      path: /healthz        # default: /health/live
+    readiness:
+      path: /readyz         # default: /health/ready
+    startup:
+      path: /readyz         # default: /health/ready
+```
+
+The `values.schema.json` validates probe paths start with `/` and rejects unknown probe keys at `helm install --dry-run` time.
+
 ```bash
 # Example deploy
 helm upgrade --install expertise-api ./helm/expertise-api \

--- a/README.md
+++ b/README.md
@@ -254,7 +254,24 @@ See [CLAUDE.md](CLAUDE.md) for full build commands, curl examples, and developme
 
 A Helm chart is included at `helm/expertise-api/` for deploying to Kubernetes (k3s or any k8s cluster). The chart includes PostgreSQL and PgBouncer. Backup is handled out-of-chart by a sidecar deployed from the infrastructure repo.
 
-`image.tag` defaults to empty string and the deployment template falls back to `.Chart.AppVersion`, so a vanilla `helm install` always pulls the chart's appVersion-aligned tag. Override `image.tag` only when pinning to a maintenance/preview tag distinct from the chart's appVersion — the chart emits a `WARNING` in `NOTES.txt` when `image.tag` is set explicitly (image+chart-skew advisory per issue #216 / #153) and a second `WARNING` when it is set to the mutable `latest` tag.
+`image.tag` defaults to empty string and the deployment template falls back to `.Chart.AppVersion`, so a vanilla `helm install` always pulls the chart's appVersion-aligned tag. Override `image.tag` only when pinning to a maintenance/preview tag distinct from the chart's appVersion — the chart emits a `WARNING` in `NOTES.txt` when `image.tag` is set explicitly to a value other than the chart's appVersion (image+chart-skew advisory per issue #216 / #153) and a second `WARNING` when it is set to the mutable `latest` tag.
+
+#### Chart 0.3.0 breaking changes (PR #232)
+
+Chart `0.3.0` introduces three values-defaults changes that may affect operators upgrading from `0.2.0` or earlier:
+
+1. **`image.tag` default flipped from `"latest"` to `""`** (which then falls back to `.Chart.AppVersion`, currently `0.1.3`). Operators who relied on the implicit `:latest` rolling-pickup behaviour will see a pinned semver tag after `helm upgrade`. To restore the prior rolling behaviour: `--set image.tag=latest` (or pin to a desired version: `--set image.tag=v0.1.3`).
+2. **`image.pullPolicy` default flipped from `Always` to `IfNotPresent`.** With a pinned tag this saves registry round-trips per pod restart. If you want force-pull on every restart (only meaningful with a mutable tag): `--set image.pullPolicy=Always`.
+3. **`values.schema.json` now sets `additionalProperties: false` on the `api.probes` block.** Unknown probe-kind keys (anything beyond `liveness`, `readiness`, `startup`) are rejected at `helm install --dry-run` time. The `api` parent block remains permissive — sibling keys such as `api.resources` (already schema-defined) and any operator-side overlay keys not in the schema continue to render.
+
+Pinning a tag at install time:
+
+```bash
+helm upgrade --install expertise-api ./helm/expertise-api \
+  --set image.tag=v0.1.3 \
+  --namespace expertise-api \
+  --create-namespace
+```
 
 Probe paths are surfaced as values for forks that expose health on non-default routes:
 

--- a/helm/expertise-api/Chart.yaml
+++ b/helm/expertise-api/Chart.yaml
@@ -4,7 +4,11 @@ description: Self-hosted REST API for storing and serving expertise entries cons
 type: application
 # Chart version — bumped manually when chart structure changes (templates,
 # values shape, hooks). Independent of appVersion / released image tag.
-version: 0.2.0
+# 0.3.0 carries the PR-232 breaking changes: image.tag default falls through
+# to .Chart.AppVersion when unset; image.pullPolicy default flipped from
+# Always to IfNotPresent; api.probes.{liveness,readiness,startup}.path
+# surfaced as values with `additionalProperties: false` on the probe block.
+version: 0.3.0
 # Application version — kept in sync with the released container image tag by
 # `.github/workflows/release.yml` after each successful semantic-release run.
 # Manual baseline: v0.1.3 (the latest tag on `main` at chart-floor introduction).

--- a/helm/expertise-api/templates/NOTES.txt
+++ b/helm/expertise-api/templates/NOTES.txt
@@ -1,5 +1,26 @@
 expertise-api {{ .Chart.AppVersion }} installed in namespace {{ .Release.Namespace | quote }}.
 
+  Image:      {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+  Chart ver:  {{ .Chart.Version }}
+  Probes:     liveness  {{ .Values.api.probes.liveness.path }}
+              readiness {{ .Values.api.probes.readiness.path }}
+              startup   {{ .Values.api.probes.startup.path }}
+{{- if and .Values.image.tag (ne .Values.image.tag .Chart.AppVersion) }}
+
+  WARNING: image.tag ({{ .Values.image.tag | quote }}) is set explicitly and does
+           NOT match the chart's appVersion ({{ .Chart.AppVersion | quote }}). The
+           image may expose health on routes that differ from the chart's defaults.
+           If probes report Unready after rollout, override `api.probes.*.path`
+           to match the image's actual health routes. See issue #216 / #153.
+{{- end }}
+{{- if eq .Values.image.tag "latest" }}
+
+  WARNING: image.tag is set to the mutable tag "latest". This defeats
+           reproducibility and the chart's signed-digest verification
+           contract (Part D C8). Pin to an immutable tag (e.g. the chart's
+           appVersion {{ .Chart.AppVersion | quote }}) before promoting beyond dev.
+{{- end }}
+
 ────────────────────────────────────────────────────────────────────────────────
 1. URL
 ────────────────────────────────────────────────────────────────────────────────

--- a/helm/expertise-api/templates/NOTES.txt
+++ b/helm/expertise-api/templates/NOTES.txt
@@ -1,4 +1,13 @@
 expertise-api {{ .Chart.AppVersion }} installed in namespace {{ .Release.Namespace | quote }}.
+{{- if not .Chart.AppVersion }}
+
+  ERROR: Chart.yaml is missing appVersion. The chart cannot fall back to a
+         default image tag without one. Either set image.tag explicitly in
+         values.yaml, or repair Chart.yaml's appVersion field. (Render aborted
+         downstream by Kubernetes — the Deployment will produce an invalid
+         image reference like "<repo>:" and the Pod will fail to schedule
+         with ErrImagePull / InvalidImageName.)
+{{- end }}
 
   Image:      {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
   Chart ver:  {{ .Chart.Version }}

--- a/helm/expertise-api/templates/deployment.yaml
+++ b/helm/expertise-api/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       {{- end }}
       containers:
         - name: api
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -102,22 +102,22 @@ spec:
               mountPath: /tmp
           startupProbe:
             httpGet:
-              path: /health/ready
+              path: {{ .Values.api.probes.startup.path | quote }}
               port: {{ .Values.service.targetPort }}
-            failureThreshold: 30
-            periodSeconds: 5
+            failureThreshold: {{ .Values.api.probes.startup.failureThreshold }}
+            periodSeconds: {{ .Values.api.probes.startup.periodSeconds }}
           livenessProbe:
             httpGet:
-              path: /health/live
+              path: {{ .Values.api.probes.liveness.path | quote }}
               port: {{ .Values.service.targetPort }}
-            periodSeconds: 30
-            failureThreshold: 3
+            periodSeconds: {{ .Values.api.probes.liveness.periodSeconds }}
+            failureThreshold: {{ .Values.api.probes.liveness.failureThreshold }}
           readinessProbe:
             httpGet:
-              path: /health/ready
+              path: {{ .Values.api.probes.readiness.path | quote }}
               port: {{ .Values.service.targetPort }}
-            periodSeconds: 10
-            failureThreshold: 3
+            periodSeconds: {{ .Values.api.probes.readiness.periodSeconds }}
+            failureThreshold: {{ .Values.api.probes.readiness.failureThreshold }}
       volumes:
         - name: tmp
           emptyDir: {}

--- a/helm/expertise-api/templates/job-migrations.yaml
+++ b/helm/expertise-api/templates/job-migrations.yaml
@@ -43,7 +43,7 @@ spec:
       {{- end }}
       containers:
         - name: efbundle
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false

--- a/helm/expertise-api/tests/test-render.sh
+++ b/helm/expertise-api/tests/test-render.sh
@@ -440,6 +440,38 @@ else
     err "schema-probe-path-leading-slash" "schema accepted invalid probe path: $(echo "$out_bad_path" | tail -2 | tr '\n' ' ')"
 fi
 
+# 44. Migrations Job inherits the same image-tag default-to-appVersion fallback
+#     as the API Deployment (issue #214 — prevents migration/runtime image skew).
+appver=$(awk '/^appVersion:/ {gsub(/"/, "", $2); print $2}' "$CHART/Chart.yaml")
+out_jobimg=$(helm template test-release "$CHART" 2>&1)
+if echo "$out_jobimg" | awk '/kind: Job/,/^---/' | grep -qF "image: \"ghcr.io/thesemicolon/agent-expertise-api:${appver}\""; then
+    ok "migrations-image-tag-default-fallback" "migrations Job image falls back to chart appVersion ${appver}"
+else
+    err "migrations-image-tag-default-fallback" "migrations Job image did not fall back to chart appVersion ${appver}"
+fi
+
+# 45. The `api` parent block in values.schema.json must remain permissive — the
+#     PR-232 review surfaced that an over-broad `additionalProperties: false`
+#     at this level would silently reject operator-side overlay keys. Guard
+#     against accidental re-tightening by asserting an unknown sibling key
+#     under `api` is accepted at install-time (specifically: an unknown key
+#     that is NOT under `api.probes`, which is intentionally closed).
+out_apiextra=$(helm template test-release "$CHART" --set api.unknownOverlayKey=somevalue 2>&1 || true)
+if echo "$out_apiextra" | grep -qiE "additional properties.*not allowed|does not match"; then
+    err "schema-api-block-permissive" "schema unexpectedly rejected an unknown sibling key under api (api block has been over-tightened)"
+else
+    ok "schema-api-block-permissive" "api block remains permissive for operator overlay keys (api.probes still closed)"
+fi
+
+# 46. Schema accepts SemVer prerelease tags on image.tag (issue #214 — release
+#     workflow may pin rc/beta tags during release-candidate cycles).
+out_pretag=$(helm template test-release "$CHART" --set image.tag=0.1.4-rc.1 2>&1 || true)
+if echo "$out_pretag" | grep -qF "image: \"ghcr.io/thesemicolon/agent-expertise-api:0.1.4-rc.1\""; then
+    ok "schema-image-tag-prerelease" "schema accepts SemVer prerelease tag (0.1.4-rc.1)"
+else
+    err "schema-image-tag-prerelease" "prerelease tag rejected or rendered wrong: $(echo "$out_pretag" | tail -2 | tr '\n' ' ')"
+fi
+
 echo "=================================="
 if [ "$ERRORS" -eq 0 ]; then
     echo "PASS — 0 errors, $WARNINGS warning(s)"

--- a/helm/expertise-api/tests/test-render.sh
+++ b/helm/expertise-api/tests/test-render.sh
@@ -431,7 +431,10 @@ fi
 
 # 43. Schema rejects probe paths without a leading / (issue #216).
 out_bad_path=$(helm template test-release "$CHART" --set api.probes.liveness.path=health/live 2>&1 || true)
-if echo "$out_bad_path" | grep -qE "'health/live' does not match pattern"; then
+# Match both helm 3.13+ ("'health/live' does not match pattern '^/.*'") and
+# older helm renderings ("api.probes.liveness.path: Does not match pattern '^/.*'")
+# which differ only in casing of "does" and the value-quoting prefix.
+if echo "$out_bad_path" | grep -qiE "does not match pattern '\^/"; then
     ok "schema-probe-path-leading-slash" "schema rejects probe path without leading /"
 else
     err "schema-probe-path-leading-slash" "schema accepted invalid probe path: $(echo "$out_bad_path" | tail -2 | tr '\n' ' ')"

--- a/helm/expertise-api/tests/test-render.sh
+++ b/helm/expertise-api/tests/test-render.sh
@@ -387,14 +387,14 @@ fi
 
 # 38. Deployment probes: liveness uses /health/live (issue #143, T4).
 output=$(helm template test-release "$CHART" 2>&1)
-if echo "$output" | awk '/livenessProbe:/,/readinessProbe:/' | grep -qE 'path:[[:space:]]*/health/live'; then
+if echo "$output" | awk '/livenessProbe:/,/readinessProbe:/' | grep -qE 'path:[[:space:]]*"?/health/live"?'; then
     ok "probe-liveness-path" "livenessProbe.httpGet.path = /health/live"
 else
     err "probe-liveness-path" "livenessProbe.httpGet.path did not render as /health/live"
 fi
 
 # 39. Deployment probes: readiness uses /health/ready (issue #143, T4).
-if echo "$output" | awk '/readinessProbe:/,/^      volumes:/' | grep -qE 'path:[[:space:]]*/health/ready'; then
+if echo "$output" | awk '/readinessProbe:/,/^      volumes:/' | grep -qE 'path:[[:space:]]*"?/health/ready"?'; then
     ok "probe-readiness-path" "readinessProbe.httpGet.path = /health/ready"
 else
     err "probe-readiness-path" "readinessProbe.httpGet.path did not render as /health/ready"
@@ -402,10 +402,39 @@ fi
 
 # 40. Deployment probes: startup uses /health/ready so the pod isn't declared
 # started until DB, ONNX, and migration checks all pass (issue #143, T4).
-if echo "$output" | awk '/startupProbe:/,/livenessProbe:/' | grep -qE 'path:[[:space:]]*/health/ready'; then
+if echo "$output" | awk '/startupProbe:/,/livenessProbe:/' | grep -qE 'path:[[:space:]]*"?/health/ready"?'; then
     ok "probe-startup-path" "startupProbe.httpGet.path = /health/ready"
 else
     err "probe-startup-path" "startupProbe.httpGet.path did not render as /health/ready"
+fi
+
+# 41. Image tag falls back to .Chart.AppVersion when image.tag is empty/unset (issue #214).
+appver=$(awk '/^appVersion:/ {gsub(/"/,"",$2); print $2}' "$CHART/Chart.yaml")
+if echo "$output" | grep -qE "image: \"ghcr.io/thesemicolon/agent-expertise-api:${appver}\""; then
+    ok "image-tag-default-fallback" "image.tag empty falls back to chart appVersion ${appver}"
+else
+    err "image-tag-default-fallback" "default render did not produce :${appver} image tag"
+fi
+
+# 42. api.probes.*.path overrides flow through to the deployment (issue #216).
+out_override=$(helm template test-release "$CHART" \
+    --set api.probes.liveness.path=/healthz \
+    --set api.probes.readiness.path=/readyz \
+    --set api.probes.startup.path=/readyz 2>&1)
+if echo "$out_override" | awk '/livenessProbe:/,/readinessProbe:/' | grep -qE 'path:[[:space:]]*"?/healthz"?' \
+    && echo "$out_override" | awk '/readinessProbe:/,/^      volumes:/' | grep -qE 'path:[[:space:]]*"?/readyz"?' \
+    && echo "$out_override" | awk '/startupProbe:/,/livenessProbe:/' | grep -qE 'path:[[:space:]]*"?/readyz"?'; then
+    ok "probe-path-override" "api.probes.*.path values flow through to deployment"
+else
+    err "probe-path-override" "probe path overrides not honoured by deployment template"
+fi
+
+# 43. Schema rejects probe paths without a leading / (issue #216).
+out_bad_path=$(helm template test-release "$CHART" --set api.probes.liveness.path=health/live 2>&1 || true)
+if echo "$out_bad_path" | grep -qE "'health/live' does not match pattern"; then
+    ok "schema-probe-path-leading-slash" "schema rejects probe path without leading /"
+else
+    err "schema-probe-path-leading-slash" "schema accepted invalid probe path: $(echo "$out_bad_path" | tail -2 | tr '\n' ' ')"
 fi
 
 echo "=================================="

--- a/helm/expertise-api/values.schema.json
+++ b/helm/expertise-api/values.schema.json
@@ -11,6 +11,21 @@
       "pattern": "^[+-]?([0-9]+(\\.[0-9]+)?|\\.[0-9]+)([eE][+-]?[0-9]+|[numkMGTPE]|[KMGTPE]i)?$",
       "description": "Kubernetes resource quantity matching the apimachinery resource.Quantity grammar: decimal-SI suffixes (n, u, m, k, M, G, T, P, E) or binary-SI suffixes (Ki, Mi, Gi, Ti, Pi, Ei) or scientific notation. Examples: 100m, 256Mi, 1.5, 1Ki, 1e3."
     },
+    "probeSpec": {
+      "type": "object",
+      "description": "Subset of corev1.Probe fields exposed via values; expand here as more knobs are needed.",
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^/.*",
+          "description": "HTTP path used by httpGet. Must start with /."
+        },
+        "periodSeconds":    { "type": "integer", "minimum": 1 },
+        "failureThreshold": { "type": "integer", "minimum": 1 }
+      },
+      "additionalProperties": false
+    },
     "k8sResources": {
       "type": "object",
       "properties": {
@@ -45,7 +60,10 @@
       "required": ["repository"],
       "properties": {
         "repository": { "type": "string", "minLength": 1 },
-        "tag": { "type": "string", "minLength": 1 },
+        "tag": {
+          "type": "string",
+          "description": "Image tag. Empty string (default) falls back to .Chart.AppVersion in deployment.yaml. Override only when pinning to a tag distinct from the chart's appVersion."
+        },
         "pullPolicy": {
           "type": "string",
           "enum": ["Always", "IfNotPresent", "Never"]
@@ -148,8 +166,19 @@
       "properties": {
         "resources": {
           "$ref": "#/$defs/k8sResources"
+        },
+        "probes": {
+          "type": "object",
+          "description": "Liveness, readiness, and startup probe overrides. Defaults match the routes wired in Program.cs (/health/live for liveness; /health/ready for readiness and startup). Override when running a forked image that exposes health on different routes. See issue #216.",
+          "properties": {
+            "startup":   { "$ref": "#/$defs/probeSpec" },
+            "liveness":  { "$ref": "#/$defs/probeSpec" },
+            "readiness": { "$ref": "#/$defs/probeSpec" }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "postgres": {
       "type": "object",

--- a/helm/expertise-api/values.schema.json
+++ b/helm/expertise-api/values.schema.json
@@ -177,8 +177,7 @@
           },
           "additionalProperties": false
         }
-      },
-      "additionalProperties": false
+      }
     },
     "postgres": {
       "type": "object",

--- a/helm/expertise-api/values.yaml
+++ b/helm/expertise-api/values.yaml
@@ -1,7 +1,15 @@
 image:
   repository: ghcr.io/thesemicolon/agent-expertise-api
-  tag: latest
-  pullPolicy: Always
+  # Empty default falls back to .Chart.AppVersion in deployment.yaml. Override
+  # only when pinning to a maintenance/preview tag distinct from the chart's
+  # appVersion (image+chart skew is then surfaced in NOTES.txt as a warning).
+  # Setting tag: "latest" is permitted by the schema but discouraged — it
+  # defeats reproducibility and the C8 signed-digest verification story.
+  tag: ""
+  # IfNotPresent is the default. Pair pullPolicy: Always only with a
+  # mutable tag ("latest", "main"); for any pinned tag IfNotPresent saves
+  # registry round-trips on pod restart.
+  pullPolicy: IfNotPresent
 
 imagePullSecrets:
   - name: ghcr-pull-secret
@@ -109,6 +117,24 @@ api:
     limits:
       cpu: 500m
       memory: 512Mi
+  # Probe paths and tunables. Defaults match the routes wired in Program.cs;
+  # override only when running a forked image that exposes health on
+  # different routes (e.g. behind a reverse-proxy prefix). NOTES.txt prints
+  # the resolved paths and warns when image.tag drifts from .Chart.AppVersion.
+  # See #216 / #153.
+  probes:
+    startup:
+      path: /health/ready
+      failureThreshold: 30
+      periodSeconds: 5
+    liveness:
+      path: /health/live
+      periodSeconds: 30
+      failureThreshold: 3
+    readiness:
+      path: /health/ready
+      periodSeconds: 10
+      failureThreshold: 3
 
 # In-cluster Postgres + PgBouncer (sidecar in the postgres pod).
 #


### PR DESCRIPTION
## Summary

Two convergent Wave 1 helm-chart defects from the readiness sweep (#230), bundled because they both touch the same templates and want the same `helm template` regression run. **Updated post-review** to bump chart version, add `--set` example, document the `pullPolicy` flip explicitly, revert unintended schema scope creep, and add regression tests.

**`image.tag: latest` default flip (#214).** The published chart shipped with `image.tag: latest` and `pullPolicy: Always`, which defeats reproducibility and the Part D C8 signed-digest-verify story for any consumer doing a vanilla `helm install`. Flipped:

- `image.tag` default → empty string. `deployment.yaml` and `job-migrations.yaml` render `{{ .Values.image.tag | default .Chart.AppVersion }}` (verified by `migrations-image-tag-default-fallback` test).
- `image.pullPolicy` default → `IfNotPresent`. Operators wanting `Always` must pair it with a mutable tag deliberately.
- `NOTES.txt` emits two `WARNING`s: one when `image.tag` is set explicitly to a value different from `.Chart.AppVersion`, one when it is set to the literal `latest`. A third `ERROR` block fires if `.Chart.AppVersion` itself is empty (guards against the malformed-Chart.yaml render-as-`:` failure mode).
- README gains explicit `--set image.tag=v0.1.3` pin example per #214 AC.

**Probe-path values surface (#216).** Probe paths were hard-coded in `deployment.yaml`. Surfaced as `api.probes.{startup,liveness,readiness}.{path,periodSeconds,failureThreshold}` with schema enforcement: paths must be non-empty strings starting with `/`, and `additionalProperties: false` on the `probes` block catches typo'd probe keys at `helm install --dry-run` time. The `api` parent block remains permissive (operator-side overlay keys continue to render).

**Chart version bump 0.2.0 → 0.3.0.** The `!` marker requires a chart-version bump per SemVer for the values-defaults changes. Chart.yaml comment enumerates the three breaking items.

## Test Plan

- `helm lint helm/expertise-api` — clean
- `bash helm/expertise-api/tests/test-render.sh` — **46 / 46 cases PASS** (40 baseline + 3 from initial PR + 3 added post-review: `migrations-image-tag-default-fallback`, `schema-api-block-permissive`, `schema-image-tag-prerelease`)
- Default-render: `image: "ghcr.io/thesemicolon/agent-expertise-api:0.1.3"` (appVersion fallback ✓) on both API container and `efbundle` migration job
- Probe-override render: `--set api.probes.liveness.path=/healthz` flows through correctly
- Schema rejection: probe path `health/live` (no leading `/`), unknown probe key, bad `pullPolicy` — all fail with clear errors
- Schema acceptance: `image.tag=0.1.4-rc.1` (SemVer prerelease) renders correctly
- Schema permissiveness: `api.unknownOverlayKey=somevalue` accepted (api block remains open for operator overlays)
- `NOTES.txt` rendered with `--set image.tag=latest` — both warnings fire
- `markdownlint-cli2 README.md` — clean

## Risk

**Three breaking values-defaults changes for consumers upgrading from chart 0.2.0 or earlier.** All three documented in the README "Chart 0.3.0 breaking changes" subsection with `--set` migration recipes. Conventional-commit `!` marker plus chart version bump 0.2.0 → 0.3.0 signal the break through SemVer + commit-history channels.

| Default | Before | After (0.3.0) | Restore-prior |
|---|---|---|---|
| `image.tag` | `latest` | `""` → `.Chart.AppVersion` (`0.1.3`) | `--set image.tag=latest` |
| `image.pullPolicy` | `Always` | `IfNotPresent` | `--set image.pullPolicy=Always` |
| `api.probes` schema | permissive | `additionalProperties: false` | (no restore — typo guard) |

No production .NET code paths touched. No new dependencies.

## Follow-ups

Filed (or to-be-filed) as Wave 2 issues:

- **#153 chart-level deliverables remain open** — distinct from this PR's appVersion alignment. Issue #153's full AC needs a `helm/expertise-api/README.md` with stable `#upgrade-notes-probe-paths` anchor for Artifact Hub deep-linking, plus `Chart.yaml annotations.artifacthub.io/changes`. Downgraded `Closes #153` → `Refs #153` so the chart-README work lands as its own focused PR.
- OCI tag format hardening on `image.tag` schema (currently `type: string` only).
- Probe path schema rejecting `?query`/`#fragment` substrings.
- `:latest` warning case-insensitivity (currently literal-match only).
- NOTES.txt rendered-warning render-test coverage (latest, drift, empty appVersion).

Closes #214
Closes #216
Refs #153
