### PR TITLE
fix(install): disable systemd watchdog timer and lint hygiene cleanup

### DIFF
--- a/.claude/agents/expertise-api-owner.md
+++ b/.claude/agents/expertise-api-owner.md
@@ -35,7 +35,7 @@ Your output is structured guidance that the calling agent or user implements.
 
 ## Output format
 
-```
+```text
 ## Answer
 [Direct answer to the question, grounded in design document and/or source code]
 

--- a/.github/agents/expertise-api-owner.agent.md
+++ b/.github/agents/expertise-api-owner.agent.md
@@ -37,7 +37,7 @@ The authoritative design decisions, data model, API surface, authentication arch
 
 ## Output format
 
-```
+```text
 ## Answer
 [Direct answer to the question, grounded in design document and/or source code]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,8 +329,10 @@ jobs:
             exit 0
           fi
           if printf '%s' "$LABELS" | jq -e 'any(. == "breaking-change-approved")' >/dev/null; then
-            echo "::warning::Breaking OpenAPI changes detected; bypassing gate via 'breaking-change-approved' label (auto-removed on merge)"
+            echo "::warning::Breaking OpenAPI changes detected; bypassing gate via" \
+                 "'breaking-change-approved' label (auto-removed on merge)"
             exit 0
           fi
-          echo "::error::Breaking OpenAPI changes detected. To merge anyway, apply the 'breaking-change-approved' label to this PR."
+          echo "::error::Breaking OpenAPI changes detected. To merge anyway," \
+               "apply the 'breaking-change-approved' label to this PR."
           exit 1

--- a/README.md
+++ b/README.md
@@ -368,6 +368,16 @@ plist (`ExitTimeOut=45`) add a 15s OS-level margin on top — stop the service
 and the .NET host has 30s to drain, after which systemd/launchd will fire
 SIGKILL at the 45s mark.
 
+**Systemd watchdog timer** (#217): `WatchdogSec=` is intentionally
+*disabled* in the shipped unit template. `Microsoft.Extensions.Hosting.Systemd`
+emits `READY=1`/`STOPPING=1` only — it does not periodically ping
+`WATCHDOG=1`. Enabling `WatchdogSec=` without a hosted service that pings
+the watchdog on a `WatchdogSec/2` cadence produces a silent SIGABRT loop
+under any load that delays the runtime by ~half the interval. To re-enable,
+implement a `WATCHDOG=1` notifier hosted service (via Tmds.Systemd or
+libsystemd P/Invoke) and uncomment `WatchdogSec=30` in
+`scripts/service-templates/expertise-api.service.tmpl`.
+
 **Schema migrations on install/upgrade** (#144): both install scripts run
 `scripts/migrate.{sh,ps1}` between publish and service start. The migrate
 step invokes the bundled `ExpertiseApi migrate` verb, which applies any

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ flowchart LR
 | GET | `/expertise/search/semantic?q=` | Semantic vector search (pgvector, Approved only) |
 | GET | `/audit` | Cross-tenant audit log (cursor-paginated, requires `expertise.admin`). Supports actor-class filter: `?actorClass=human\|agent\|service` (Part D C6) |
 | GET | `/audit/{id}/raw` | Fetch a single audit row by id without response-hygiene transform (admin-only forensic escape hatch). |
-| GET | `/health/live` | Liveness — 200 while the process responds; no dependency checks. Map this to k8s `livenessProbe` and `systemd WatchdogSec=`. No auth. |
+| GET | `/health/live` | Liveness — 200 while the process responds; no dependency checks. Map this to k8s `livenessProbe`. (Not used by systemd `WatchdogSec=`, which consumes `sd_notify(WATCHDOG=1)` datagrams rather than HTTP probes — the directive is intentionally disabled in the shipped unit template; see the watchdog note in the Native OS service section per #217.) No auth. |
 | GET | `/health/ready` | Readiness — 200 only when DB, ONNX model, and pending-migration checks are all healthy; 503 otherwise. Map this to k8s `readinessProbe` and load-balancer health checks. No auth. Response is cached for 2s (OutputCache policy `health-ready`) and the pending-migration signal is read from a singleton snapshot refreshed every 5 min by `MigrationStateRefresher` — per-probe DB cost is `AddDbContextCheck`'s `CanConnectAsync`, asymptotically bounded at 1 per pod per 2s regardless of incoming RPS (issue #158). |
 | GET | `/health` | Back-compat alias for `/health/ready`. No auth. |
 | GET | `/metrics` | Prometheus scrape endpoint (no auth required) |
@@ -377,6 +377,19 @@ under any load that delays the runtime by ~half the interval. To re-enable,
 implement a `WATCHDOG=1` notifier hosted service (via Tmds.Systemd or
 libsystemd P/Invoke) and uncomment `WatchdogSec=30` in
 `scripts/service-templates/expertise-api.service.tmpl`.
+
+*Verifying the directive is safely disabled* (smoke recipe for operators
+who re-enable it): induce ≥30 s of GC pressure with
+`stress-ng --vm 2 --vm-bytes 1G --timeout 60s` against the host running
+the unit, then check `journalctl -u expertise-api --since '2 minutes ago'`
+for `Watchdog timeout` or `WATCHDOG=trigger` lines. With the shipped
+(disabled) configuration none should appear; with `WatchdogSec=30`
+uncommented and no notifier service, expect a SIGABRT/restart entry
+within ~30 s of the stress run. The structural side of this regression
+— that `expertise-apictl restart` does not race the watchdog while the
+service is transitioning — is covered by the `apictl restart race
+regression` CI jobs in `.github/workflows/ci.yml` (Debian 13 + macOS
+matrix), which remain in place and are unaffected by this change.
 
 **Schema migrations on install/upgrade** (#144): both install scripts run
 `scripts/migrate.{sh,ps1}` between publish and service start. The migrate

--- a/scripts/service-templates/expertise-api.service.tmpl
+++ b/scripts/service-templates/expertise-api.service.tmpl
@@ -7,7 +7,20 @@ After=network-online.target
 [Service]
 Type=notify
 NotifyAccess=main
-WatchdogSec=30
+# Watchdog intentionally disabled — see issue #217.
+#
+# Microsoft.Extensions.Hosting.Systemd registers SystemdNotifier for
+# READY=1 and STOPPING=1 only; it does NOT periodically ping
+# WATCHDOG=1. Enabling 'WatchdogSec=' without a hosted-service that
+# pings WATCHDOG=1 every WatchdogSec/2 causes systemd to SIGABRT the
+# unit after the first interval expires, producing a silent restart
+# loop under any GC/load condition that delays the runtime by ~half
+# the configured interval.
+#
+# To re-enable: add a hosted service that calls sd_notify("WATCHDOG=1")
+# on a timer (e.g. via the Tmds.Systemd or libsystemd P/Invoke route),
+# then reinstate 'WatchdogSec=30' here.
+#WatchdogSec=30
 WorkingDirectory=@@WORKDIR@@
 ExecStart=@@WRAPPER@@
 


### PR DESCRIPTION
## Summary

Two Wave 1 readiness items bundled because both are scoped to non-code-path files and review-light. Part of #230.

### Watchdog timer (#217)

`scripts/service-templates/expertise-api.service.tmpl` carried `WatchdogSec=30` with no `sd_notify(WATCHDOG=1)` ping anywhere in the process. `Microsoft.Extensions.Hosting.Systemd` registers a `SystemdNotifier` that emits `READY=1` and `STOPPING=1` only — it does **not** periodically ping the watchdog. With `WatchdogSec=30` active, systemd `SIGABRT`s the unit after the first 30 s window with no ping, producing a silent restart loop under any load that delays the runtime by ~half the interval.

Opted for **Option A** (per the issue): comment out the directive and document the re-enable path. The directive is preserved as a commented line with a multi-line explanatory block above it so future operators can:

1. Implement a hosted service pinging `WATCHDOG=1` on `WatchdogSec/2` (via `Tmds.Systemd` or libsystemd P/Invoke).
2. Uncomment `WatchdogSec=30`.

Option B (implement the notifier) is the right long-term shape but is not release-blocking; if anyone re-prioritises it, a fresh enhancement issue can be filed citing this PR.

### Lint hygiene (#219)

- README "Native OS service install" section gains a `Systemd watchdog timer` paragraph documenting the disabled-by-default state and the re-enable path.
- **MD040** on two agent-card files (`.claude/agents/expertise-api-owner.md` line 38 and `.github/agents/expertise-api-owner.agent.md` line 40) — fenced "output format" example blocks now carry the `text` language tag.
- **yamllint line-length** on `.github/workflows/ci.yml` lines 332 and 335 — the two `::warning::` / `::error::` `echo` invocations broken across two lines each using a trailing backslash. `echo`'s space-joining behaviour produces the identical output string at runtime.

## Test Plan

- `shellcheck scripts/install.sh scripts/uninstall.sh scripts/expertise-apictl` — clean
- `yamllint .github/workflows/ci.yml` — clean (was: 2 line-length warnings)
- `markdownlint-cli2` on the two touched .md files — clean (was: 1 MD040 each)
- `actionlint .github/workflows/ci.yml` — clean (unchanged behaviour by inspection: `echo` join semantics)
- `systemd-analyze verify` not exercised locally (macOS dev session); the change is a single commented-out line in an otherwise unchanged template

## Risk

**Low.**

- The watchdog change removes a latent silent-SIGABRT loop. The unit was almost certainly self-restarting silently for any operator already running it; commenting the directive simply stops the loop. No new behaviour, only the removal of buggy behaviour.
- The lint changes are mechanical and content-preserving by construction.
- Both changes are confined to scripts/templates/CI-config — no production .NET code touched.

## Follow-ups

- Option B (a `sd_notify(WATCHDOG=1)` hosted service) remains on the table as a future enhancement — not release-blocking; file a fresh issue if and when that work is prioritised.

Closes #217
Closes #219
