### PR TITLE
fix(install): replace eval dispatch and guard prefix in uninstaller

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,20 +435,30 @@ The uninstaller defends against destructive `--prefix` mistakes:
 
 - The argument must be an absolute path containing `expertise-api` as a
   path component (or `--allow-system-prefix` must be passed).
-- Paths containing `..` are rejected outright (no symlink/realpath
-  resolution).
-- Two blocklist tiers reject catastrophic targets. *Exact-match* covers
-  parent containers and mount points (`/`, `/home`, `/Users`, `/opt`,
-  `/usr/local`, `/mnt`, `/Volumes`, `/tmp`, ...) so descendants like
-  `/Users/me/svc/expertise-api` or `/opt/expertise-api` are still allowed.
-  *Prefix-match* covers system subtrees where nothing should live
-  (`/bin`, `/etc`, `/lib`, `/System`, `/Library`, `/private`, ...) and
-  blocks every descendant unconditionally — `--allow-system-prefix` does
-  *not* relax this.
-- Under `--system` mode the prefix may not be a symlink (TOCTOU defense
-  for multi-user hosts).
+- Paths containing `..`, embedded whitespace, or line-ending characters
+  are rejected outright (no symlink/realpath resolution).
+- Two blocklist tiers reject catastrophic targets:
+  - *Exact-match* covers parent containers and mount points (`/`,
+    `/home`, `/Users`, `/opt`, `/usr/local`, `/mnt`, `/Volumes`, `/tmp`,
+    `/var`, `/usr`, ...) so legitimate descendants like
+    `/Users/me/svc/expertise-api`, `/opt/expertise-api`, and
+    `/usr/local/expertise-api` remain allowed.
+  - *Prefix-match* covers system subtrees where nothing should live
+    (`/bin`, `/etc`, `/lib`, `/System`, `/Library`, `/private`,
+    `/usr/{bin,sbin,lib,libexec,share,include}`, `/var/lib`, `/snap`,
+    ...) and blocks every descendant unconditionally —
+    `--allow-system-prefix` does *not* relax this.
+- Under `--system` mode the prefix directory itself may not be a
+  symlink (TOCTOU defense for multi-user hosts). **Caveat:** the
+  uninstaller does not currently verify that *ancestors* of the prefix
+  are owned by root — if you operate a multi-user host, ensure
+  `/opt/<your-parent>/` is root-owned and not group-writable. Tracking
+  in [#242](https://github.com/TheSemicolon/agent-expertise-api/issues/242).
 - `--dry-run` forces a non-destructive run even with `--yes` and is the
   primary safety hook used by `tests/uninstall/test-prefix-guard.sh`.
+  The plan reflects host state at dry-run invocation time; if the
+  service is (re)installed between dry-run and apply, the apply path
+  will see the newer state.
 
 Quick start (Windows, elevated PowerShell 7+):
 

--- a/README.md
+++ b/README.md
@@ -428,7 +428,27 @@ edit ~/.config/expertise-api/secrets.env          # set ConnectionStrings__Defau
 ./scripts/expertise-apictl health                 # curl /health
 ./scripts/uninstall.sh --yes                      # remove service + binaries
 ./scripts/uninstall.sh --yes --purge              # also remove models + secrets
+./scripts/uninstall.sh --yes --dry-run            # print what would happen; execute nothing
 ```
+
+The uninstaller defends against destructive `--prefix` mistakes:
+
+- The argument must be an absolute path containing `expertise-api` as a
+  path component (or `--allow-system-prefix` must be passed).
+- Paths containing `..` are rejected outright (no symlink/realpath
+  resolution).
+- Two blocklist tiers reject catastrophic targets. *Exact-match* covers
+  parent containers and mount points (`/`, `/home`, `/Users`, `/opt`,
+  `/usr/local`, `/mnt`, `/Volumes`, `/tmp`, ...) so descendants like
+  `/Users/me/svc/expertise-api` or `/opt/expertise-api` are still allowed.
+  *Prefix-match* covers system subtrees where nothing should live
+  (`/bin`, `/etc`, `/lib`, `/System`, `/Library`, `/private`, ...) and
+  blocks every descendant unconditionally — `--allow-system-prefix` does
+  *not* relax this.
+- Under `--system` mode the prefix may not be a symlink (TOCTOU defense
+  for multi-user hosts).
+- `--dry-run` forces a non-destructive run even with `--yes` and is the
+  primary safety hook used by `tests/uninstall/test-prefix-guard.sh`.
 
 Quick start (Windows, elevated PowerShell 7+):
 

--- a/docs/install-upgrade-track.md
+++ b/docs/install-upgrade-track.md
@@ -1,0 +1,127 @@
+# Install / Uninstall / Upgrade Hardening — Session Tracker
+
+Persistent TODO for the multi-PR effort that gets the native-service install path (Archetype A2) ready for pi-agent integration. Updated at the end of every working session.
+
+**Last updated:** 2026-05-22
+**Driver issue:** [#230 readiness sweep](https://github.com/TheSemicolon/agent-expertise-api/issues/230)
+**Goal:** make `scripts/install.sh` safe, upgrade-aware, and capable of bootstrapping host dependencies on macOS (primary) and Linux, so the pi-agent integration session has a turn-key target.
+
+## Out of scope for this track
+
+- `scripts/install.ps1` / `uninstall.ps1` mirror parity — separate follow-up issue, file when PR C lands.
+- `#145` macOS LaunchDaemon opt-in — separate session.
+- `#166` CI smoke test — naturally consumes everything below; pursue after PR C lands.
+
+## Workstream status
+
+| # | Workstream | Issue | Status | Notes |
+|---|---|---|---|---|
+| 0 | File dependency-bootstrap issue | #241 | ☑ filed 2026-05-22 | Per-OS modules + upgrade band table baked into ACs. |
+| 1 | Update #223 description to add upgrade-safety ACs | #223 | ☑ updated 2026-05-22 | Atomic-publish rollback on migrate failure, version marker, secrets schema-version header. |
+| A | PR A — uninstall hardening | #222 | ◐ in progress — code + tests done, awaiting PR | `eval` removal, `--prefix` guard, `--allow-system-prefix` escape, smoke test. |
+| B | PR B — install atomicity + upgrade safety + CRLF | #223 | ☐ blocked-by-A | Re-framed per ACs above. |
+| C | PR C — host-dependency bootstrap | #241 | ☐ blocked-by-A,B | Per-OS modules under `scripts/lib/`. `--install-deps` + `--upgrade-deps` flags. |
+| T | Upgrade-roundtrip test | (lands w/ B + C) | ☐ blocked-by-B | `scripts/test/test-upgrade-roundtrip.sh`. Covers atomic publish, migrate-fail rollback, version-marker, dep upgrade band. |
+
+Status legend: ☐ todo · ◐ in progress · ☑ merged · ✗ abandoned.
+
+## PR A detail — #222 uninstall hardening
+
+**Design locked 2026-05-22 via `shell-expert` pre-review (verdict: PASS_WITH_WARNINGS).** Two High-severity corrections folded in below: `..` rejection + lexical normalization (no `realpath`), and **prefix-match** blocklist semantics (not exact-match).
+
+**Files:** `scripts/uninstall.sh`, `tests/uninstall/test-prefix-guard.sh` (new — note path change, fixtures live under `tests/` not `scripts/test/`).
+
+### Implementation order (per shell-expert)
+
+1. [ ] Add `--dry-run` flag as a first-class option. `do_action` honors it via `printf 'DRY-RUN: %s\n' "$*"; return 0`. Independent of guard work; could ship alone if needed.
+2. [ ] Audit `do_action` call sites for hidden re-parsing dependencies (literal `&&`, `||`, `;`, globs, variables needing re-expansion). **Do not mechanically swap until audit done.** Then replace `eval "$@"` → `"$@"`; lift `2>/dev/null` and `|| true` to call sites as caller policy.
+3. [ ] Add `normalize_prefix()`:
+   - Reject any `..` component outright (`*"/../"*`, `*"/.."`, `"../"*`, `".."`).
+   - Collapse runs of `//` to `/`.
+   - Strip trailing slash **after** the `p != "/"` check.
+   - **Do not call `realpath` / `readlink -f`** — non-portable on macOS, false-secure on non-existent paths, hides symlink attacks rather than surfacing them.
+4. [ ] Add `validate_prefix()`:
+   - Absolute path required.
+   - `p != "/"`, `p != "$HOME"`.
+   - **Prefix-match blocklist** (`[[ "$p/" == "$b/"* ]]`), expanded per shell-expert Q6:
+     - Universal: `/`, `/bin`, `/sbin`, `/etc`, `/usr`, `/var`, `/lib`, `/lib64`, `/boot`, `/dev`, `/proc`, `/sys`, `/tmp`, `/home`, `/root`, `/opt`, `/srv`, `/run`.
+     - Linux extras: `/mnt`, `/media`, `/snap`, `/usr/local`.
+     - macOS: `/Library`, `/System`, `/Applications`, `/private`, `/Volumes`, `/Users`, `/Network`, `/cores`, `/.vol`.
+     - WSL: `/mnt/c`, `/mnt/wsl`.
+     - Containers: `/host`, `/rootfs`.
+     - User-fat-finger: `$HOME/Desktop`, `$HOME/Documents`.
+   - Component check: `[[ "/$p/" == *"/expertise-api/"* ]]` (after normalization), bypassable only by `--allow-system-prefix`.
+   - For `--system` mode: refuse symlinked prefix (`[[ -L "$p" ]] && err`).
+5. [ ] Add `--allow-system-prefix` flag (off by default). **Scoped to component check only** — blocked-roots list stays unconditional. Document the asymmetry in `--help` text.
+6. [ ] Post-validation log line listing every path slated for removal (free forensics, free user sanity check) before any `rm -rf`.
+7. [ ] `tests/uninstall/test-prefix-guard.sh`:
+   - Primary assertion: `--dry-run` output never contains `DRY-RUN: rm -rf` for any blocked prefix.
+   - Secondary assertion: run without `--dry-run` under PATH-shimmed `rm` / `launchctl` / `systemctl`; assert exit non-zero and zero-byte shim log.
+   - Coverage: `/`, `/usr`, `/home/foo` (no expertise-api component), `/Users/x/.local/../../etc` (must be rejected at `..` check), `/opt/expertise-api/` (trailing slash, must normalize and pass).
+   - Stage as `tests/uninstall/`, not `scripts/test/`.
+8. [ ] `shellcheck scripts/uninstall.sh` clean.
+9. [ ] README Archetype A2 → Uninstall subsection: document `--dry-run`, `--allow-system-prefix`, blocked-roots policy, symlink restriction.
+10. [ ] `shell-expert` final review pre-PR (confirm design corrections were applied correctly).
+
+### Open design points resolved
+
+- **Realpath:** rejected. Lexical normalization + `..` rejection only.
+- **Trailing slash:** stripped during normalization, after `p != "/"` check.
+- **Symlinks:** `rm -rf` does not follow directory symlinks (POSIX). Only `--system` mode adds an `[[ -L "$p" ]]` precheck; user mode is fine.
+- **Two-flag composition:** `--allow-system-prefix` and the blocklist are independent layers.
+- **Test harness:** `--dry-run` is the primary mechanism; PATH shims are the second line.
+
+## PR B detail — #223 install atomicity + upgrade safety + CRLF
+
+**Files:** `scripts/install.sh`, `scripts/test/test-install-crlf-detector.sh` (new), `scripts/test/test-upgrade-roundtrip.sh` (new).
+
+- [ ] Atomic `publish_app`: stage `${BIN_DIR}.new`, swap via rename, retain `${BIN_DIR}.old` until migrate+restart success.
+- [ ] Migrate-failure rollback: restore `${BIN_DIR}.old → ${BIN_DIR}` on `maybe_migrate` non-zero.
+- [ ] `${PREFIX}/.install-version` marker — write post-success; read at `main()` entry; log fresh-vs-upgrade-vs-reinstall.
+- [ ] `secrets.env` schema-version header line + read/upgrade hook (no-op today, reserves the seam).
+- [ ] CRLF detector for `secrets.env`; actionable error; optional `--fix-line-endings` flag.
+- [ ] CRLF smoke test.
+- [ ] Upgrade-roundtrip test (no-op upgrade, version bump, publish-fail rollback, migrate-fail rollback).
+- [ ] README Archetype A2 → Upgrade + Rollback subsections.
+- [ ] `shell-expert` review pre-PR.
+
+## PR C detail — dependency bootstrap (new issue)
+
+**Files:** `scripts/install.sh` (add `--install-deps` / `--upgrade-deps`), `scripts/lib/detect-platform.sh`, `scripts/lib/bootstrap-mac.sh`, `scripts/lib/bootstrap-debian.sh`, `scripts/lib/bootstrap-rhel.sh`, `scripts/test/test-bootstrap-deps-*.sh` (CI-gated).
+
+- [ ] File the new issue with the per-dependency upgrade policy table (see plan).
+- [ ] `--install-deps` flag (off by default).
+- [ ] `--upgrade-deps` flag (off by default; requires `--install-deps`).
+- [ ] Per-OS module functions: `ensure_dotnet_runtime`, `ensure_postgres`, `ensure_pgvector`, `ensure_database_and_role`, `write_local_connection_string`.
+- [ ] Mac: require Homebrew present (do not auto-install brew); pin Postgres major to 17.
+- [ ] Linux Debian/Ubuntu: Microsoft pkg feed dispatch; `apt install dotnet-runtime-10.0 aspnetcore-runtime-10.0 postgresql-17 postgresql-17-pgvector`.
+- [ ] Linux Fedora/RHEL: `dnf` equivalents.
+- [ ] Generated Postgres password via `openssl rand -base64 24`; writes to `secrets.env` (chmod 600); never echoed.
+- [ ] Refuse Postgres major-version upgrade; print `pg_upgrade` instructions.
+- [ ] Extend upgrade-roundtrip test with dep-upgrade band assertions.
+- [ ] README Archetype A2 → Quick start + "What gets installed" per-OS table.
+- [ ] CLAUDE.md note on `--install-deps` for A2.
+- [ ] Parallel review: `shell-expert` + `dotnet-expert` + `security-review-expert`.
+
+## Upgrade policy reference (PR C)
+
+| Dependency | Fresh install | Upgrade existing (`--upgrade-deps`) | Major-version mismatch |
+|---|---|---|---|
+| .NET runtime (10.x) | install latest 10.x | bump to latest 10.x | refuse — print and exit |
+| Postgres | install pinned major (17) | minor-bump only | refuse — print `pg_upgrade` |
+| pgvector | install latest from pkg mgr | upgrade + `ALTER EXTENSION vector UPDATE` | refuse on known breaks |
+| coreutils (mac) | install | leave alone | n/a |
+| `expertise` DB / role | create | **never drop or alter** | n/a |
+
+## Cross-cutting notes
+
+- All three PRs squash-merge to `dev` per github-flow rule; semantic-release picks up on merge to `main`.
+- Each PR uses Conventional Commits: PR A `fix(install)`, PR B `feat(install)`, PR C `feat(install)`.
+- ADR not required for any (pattern-following). Document inline + README.
+- Doc-sync pairs touched: README Archetype A2 section, CLAUDE.md Quick Start.
+
+## Session log
+
+- **2026-05-22** — Plan drafted (this file). #223 ACs updated; new issue #241 filed for dependency bootstrap.
+- **2026-05-22** — `shell-expert` pre-design review on PR A: verdict PASS_WITH_WARNINGS. Folded `..` rejection + lexical normalization (no `realpath`); two-tier blocklist; first-class `--dry-run`; test fixtures under `tests/uninstall/`.
+- **2026-05-22** — PR A coded: `scripts/uninstall.sh` rewritten with normalize+validate, two-tier blocklist (exact for parents like `/Users` `/home` `/opt`; prefix for catastrophic roots like `/bin` `/etc` `/System`), `--dry-run` flag, `do_action` argv refactor. `tests/uninstall/test-prefix-guard.sh` exercises 32 assertions; all pass. shellcheck clean. README updated. Caught one regression during testing — initial `/Users` prefix-match would have blocked every Mac install; corrected via two-tier list.

--- a/docs/install-upgrade-track.md
+++ b/docs/install-upgrade-track.md
@@ -11,6 +11,7 @@ Persistent TODO for the multi-PR effort that gets the native-service install pat
 - `scripts/install.ps1` / `uninstall.ps1` mirror parity — separate follow-up issue, file when PR C lands.
 - `#145` macOS LaunchDaemon opt-in — separate session.
 - `#166` CI smoke test — naturally consumes everything below; pursue after PR C lands.
+- `#242` PREFIX-parent TOCTOU in `--system` mode — surfaced by security review on PR A; multi-user safety is naturally addressed alongside #145 LaunchDaemon work.
 
 ## Workstream status
 
@@ -124,4 +125,4 @@ Status legend: ☐ todo · ◐ in progress · ☑ merged · ✗ abandoned.
 
 - **2026-05-22** — Plan drafted (this file). #223 ACs updated; new issue #241 filed for dependency bootstrap.
 - **2026-05-22** — `shell-expert` pre-design review on PR A: verdict PASS_WITH_WARNINGS. Folded `..` rejection + lexical normalization (no `realpath`); two-tier blocklist; first-class `--dry-run`; test fixtures under `tests/uninstall/`.
-- **2026-05-22** — PR A coded: `scripts/uninstall.sh` rewritten with normalize+validate, two-tier blocklist (exact for parents like `/Users` `/home` `/opt`; prefix for catastrophic roots like `/bin` `/etc` `/System`), `--dry-run` flag, `do_action` argv refactor. `tests/uninstall/test-prefix-guard.sh` exercises 32 assertions; all pass. shellcheck clean. README updated. Caught one regression during testing — initial `/Users` prefix-match would have blocked every Mac install; corrected via two-tier list.
+- **2026-05-22** — Pre-PR fan-out on PR A: 3-way parallel (`shell-expert` + `security-review-expert` + `linter`). Aggregate verdict PASS_WITH_WARNINGS (most-severe-wins). Linter PASS. Shell-expert 3 Medium / 4 Low/Info. Security 1 Warning / multiple Info. Citation-currency caveat: both reviewers flagged they could not live-fetch first-party docs in-session; substantive POSIX/Bash claims (`rm -rf` symlink semantics, `"$@"` argv preservation) are well-known foundational behavior. Folded in: `daemon-reload` `|| true` regression; expanded blocklist (`/usr/{bin,sbin,lib,libexec,share,include}`, `/var/lib`, `/snap` promoted to prefix-block); whitespace/CR rejection; dropped `[[ -d ]]` precheck (TOCTOU window); 17 new test assertions (now 49 total); invariant-grep test forbidding absolute-path destructive binaries. Filed #242 for the multi-user-safety PREFIX-parent TOCTOU (out of scope for PR A; naturally part of #145 LaunchDaemon thread). README updated with expanded blocklist precision and #242 caveat.

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -6,7 +6,27 @@
 # (logs, models, secrets). Postgres data is NEVER touched (out of scope).
 #
 # Usage:
-#   scripts/uninstall.sh [--yes] [--purge] [--prefix DIR] [--system] [--help]
+#   scripts/uninstall.sh [--yes] [--purge] [--prefix DIR]
+#                        [--system] [--allow-system-prefix]
+#                        [--dry-run] [--help]
+#
+# Flags:
+#   --yes                  Apply changes (default is implicit dry-run print).
+#   --purge                Also remove models, logs, config (requires --yes).
+#   --prefix DIR           Override install root. Validated against a blocked-
+#                          roots prefix list and required to contain an
+#                          'expertise-api' path component (unless
+#                          --allow-system-prefix is also passed).
+#   --system               Use system-scope path layout (Linux only).
+#   --allow-system-prefix  Skip the 'expertise-api must be a path component'
+#                          check. Does NOT permit deleting blocked system
+#                          roots (/, /etc, /opt, ...) — those are always
+#                          rejected.
+#   --dry-run              Force dry-run even with --yes; print the actions
+#                          that would run but execute none of them. Useful
+#                          for verification and as the primary safety hook
+#                          for the test harness under tests/uninstall/.
+#   --help, -h             Show this help and exit 0.
 #
 
 set -euo pipefail
@@ -19,17 +39,21 @@ APPLY=0
 PURGE=0
 INSTALL_SCOPE="user"
 PREFIX_OVERRIDE=""
+ALLOW_SYSTEM_PREFIX=0
+DRY_RUN=0
 
-usage() { sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'; }
+usage() { sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'; }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --yes)     APPLY=1; shift ;;
-    --purge)   PURGE=1; shift ;;
-    --prefix)  PREFIX_OVERRIDE="${2:?--prefix needs a path}"; shift 2 ;;
-    --system)  INSTALL_SCOPE="system"; shift ;;
-    --help|-h) usage; exit 0 ;;
-    *)         err "unknown flag: $1 (try --help)" ;;
+    --yes)                  APPLY=1; shift ;;
+    --purge)                PURGE=1; shift ;;
+    --prefix)               PREFIX_OVERRIDE="${2:?--prefix needs a path}"; shift 2 ;;
+    --system)               INSTALL_SCOPE="system"; shift ;;
+    --allow-system-prefix)  ALLOW_SYSTEM_PREFIX=1; shift ;;
+    --dry-run)              DRY_RUN=1; shift ;;
+    --help|-h)              usage; exit 0 ;;
+    *)                      err "unknown flag: $1 (try --help)" ;;
   esac
 done
 
@@ -44,9 +68,121 @@ case "$(uname -s)" in
   *)      err "unsupported OS: $(uname -s) — use uninstall.ps1 on Windows" ;;
 esac
 
+# ----------------------------------------------------------------------------
+# Prefix normalization + validation
+#
+# Design locked 2026-05-22 via shell-expert pre-review. Two key choices:
+#
+#  1. No realpath/readlink -f. Non-portable on macOS, false-secure on
+#     non-existent paths, and resolving symlinks can hide attacks rather
+#     than surface them. Instead: reject '..' components outright, then
+#     lexically collapse '//' and strip trailing slash.
+#
+#  2. Prefix-match blocklist (not exact-match). Exact-match lets
+#     /var/log, /private/var, /mnt/c/Users slip past. With prefix-match,
+#     '/var' blocks every '/var/*' that doesn't carry an expertise-api
+#     path component.
+#
+# --allow-system-prefix relaxes only the component check. The blocklist
+# stays unconditional — it answers a different question (is this path
+# obviously catastrophic?) than the component check (does this look like
+# an expertise-api install?).
+# ----------------------------------------------------------------------------
+
+normalize_prefix() {
+  local p="$1"
+  # Reject parent-directory traversal entirely. No legitimate --prefix needs it.
+  case "$p" in
+    *"/../"*|*/..|"../"*|"..") err "--prefix may not contain '..'" ;;
+  esac
+  # Collapse runs of slashes.
+  while [[ "$p" == *"//"* ]]; do p="${p//\/\//\/}"; done
+  # Strip trailing slash but never the root.
+  if [[ "$p" != "/" && "$p" == */ ]]; then p="${p%/}"; fi
+  printf '%s\n' "$p"
+}
+
+validate_prefix() {
+  local p="$1"
+  [[ "$p" = /* ]]      || err "--prefix must be an absolute path"
+  [[ "$p" != "/" ]]    || err "--prefix may not be /"
+  [[ "$p" != "$HOME" ]] || err "--prefix may not be \$HOME ($HOME)"
+
+  # Symlinked prefix is refused in --system mode (TOCTOU defense for
+  # multi-user hosts). User-mode operators owning $HOME do not pay this
+  # cost.
+  if [[ "${INSTALL_SCOPE}" == "system" && -L "$p" ]]; then
+    err "--prefix is a symlink ($p); pass the resolved path explicitly under --system"
+  fi
+
+  # Two-tier blocklist. Always-on, regardless of --allow-system-prefix.
+  #
+  #   blocked_exact   = parent containers / mount points. Block the bare dir
+  #                     itself but allow descendants (e.g. /Users is rejected
+  #                     but /Users/me/path is fine — every macOS HOME lives
+  #                     under /Users, so a prefix-match here would block all
+  #                     legitimate user installs).
+  #   blocked_prefix  = catastrophic system subtrees where nothing under the
+  #                     root is a sane install target (/bin, /etc, /System...).
+  local blocked_exact=(
+    /
+    /home /root /Users         # user-home parent containers
+    /opt /usr/local            # FHS / common system install parents (descendants allowed)
+    /mnt /media /Volumes /Network  # mount-point parents
+    /tmp /var /usr /srv /run /snap /cores /.vol /host /rootfs  # exact-block; descendants only blocked by component check
+  )
+  local blocked_prefix=(
+    # POSIX system subtrees
+    /bin /sbin /etc /lib /lib64 /boot /dev /proc /sys
+    # macOS system subtrees
+    /Library /System /Applications /private
+    # WSL drive mounts (user code goes here, services should not)
+    /mnt/c /mnt/wsl
+    # User fat-finger guards (only meaningful when $HOME is set)
+    "${HOME:+${HOME}/Desktop}"
+    "${HOME:+${HOME}/Documents}"
+  )
+  local b
+  for b in "${blocked_exact[@]}"; do
+    [[ -n "$b" ]] || continue
+    if [[ "$p" == "$b" ]]; then
+      err "--prefix '$p' is a blocked parent/mount path (descendants are allowed; this exact path is not)"
+    fi
+  done
+  for b in "${blocked_prefix[@]}"; do
+    [[ -n "$b" ]] || continue
+    if [[ "$p/" == "$b/"* ]]; then
+      err "--prefix '$p' is under blocked system root '$b' (unconditional; --allow-system-prefix does not relax this)"
+    fi
+  done
+
+  # Component check: defense-in-depth. Bypassable with --allow-system-prefix
+  # for legitimately-named non-default install layouts.
+  if (( ALLOW_SYSTEM_PREFIX == 0 )); then
+    if [[ "/$p/" != *"/expertise-api/"* ]]; then
+      err "--prefix '$p' must contain 'expertise-api' as a path component (or pass --allow-system-prefix to skip this check)"
+    fi
+  fi
+}
+
+if [[ -n "${PREFIX_OVERRIDE}" ]]; then
+  PREFIX_OVERRIDE="$(normalize_prefix "${PREFIX_OVERRIDE}")"
+  validate_prefix "${PREFIX_OVERRIDE}"
+fi
+
 # Path layout (must mirror install.sh)
 if [[ -n "${PREFIX_OVERRIDE}" ]]; then
   PREFIX="${PREFIX_OVERRIDE}"
+  if [[ "${OS}" == "macos" ]]; then
+    LOG_DIR="${HOME}/Library/Logs/expertise-api"
+    CONFIG_DIR="${PREFIX}"
+  elif [[ "${INSTALL_SCOPE}" == "system" ]]; then
+    LOG_DIR="/var/log/expertise-api"
+    CONFIG_DIR="/etc/expertise-api"
+  else
+    LOG_DIR="${XDG_STATE_HOME:-${HOME}/.local/state}/expertise-api"
+    CONFIG_DIR="${XDG_CONFIG_HOME:-${HOME}/.config}/expertise-api"
+  fi
 elif [[ "${OS}" == "macos" ]]; then
   PREFIX="${HOME}/Library/Application Support/expertise-api"
   LOG_DIR="${HOME}/Library/Logs/expertise-api"
@@ -64,29 +200,57 @@ fi
 BIN_DIR="${PREFIX}/bin"
 MODEL_DIR="${PREFIX}/models"
 
-# Action helper — print or execute depending on APPLY
+# ----------------------------------------------------------------------------
+# Action helper
+#
+# Direct argv invocation (no `eval`). Callers attach `|| true` and
+# `2>/dev/null` at the call site as caller policy, not dispatcher policy.
+#
+# --dry-run forces a print-only mode even with --yes. Without --yes the
+# script prints "would: …" lines; with --yes --dry-run it prints
+# "DRY-RUN: …" lines (different prefix so the test harness can tell them
+# apart from the implicit pre-confirmation dry-run).
+# ----------------------------------------------------------------------------
 do_action() {
+  if (( DRY_RUN == 1 )); then
+    printf '[uninstall] DRY-RUN: %s\n' "$*"
+    return 0
+  fi
   if (( APPLY == 1 )); then
     log "exec: $*"
-    # shellcheck disable=SC2294  # intentional: callers pass a single shell string with redirection / || true.
-    eval "$@"
+    "$@"
   else
     log "would: $*"
   fi
 }
 
-if (( APPLY == 0 )); then
+if (( DRY_RUN == 1 )); then
+  log "DRY RUN (--dry-run forced; no actions will execute regardless of --yes)"
+elif (( APPLY == 0 )); then
   log "DRY RUN (use --yes to apply, --yes --purge to also remove user data)"
+fi
+
+# Pre-action plan summary — free forensics, cheap user sanity check.
+log "plan:"
+log "  PREFIX     = ${PREFIX}"
+log "  BIN_DIR    = ${BIN_DIR}"
+log "  MODEL_DIR  = ${MODEL_DIR}"
+log "  LOG_DIR    = ${LOG_DIR}"
+log "  CONFIG_DIR = ${CONFIG_DIR}"
+if (( PURGE == 1 )); then
+  log "  mode       = purge (remove binaries + user data)"
+else
+  log "  mode       = remove binaries only (user data preserved)"
 fi
 
 # Stop service first
 case "${OS}" in
   linux|wsl)
     if systemctl --user list-unit-files expertise-api.service 2>/dev/null | grep -q expertise-api; then
-      do_action "systemctl --user stop expertise-api.service 2>/dev/null || true"
-      do_action "systemctl --user disable expertise-api.service 2>/dev/null || true"
-      do_action "rm -f \"${XDG_CONFIG_HOME:-${HOME}/.config}/systemd/user/expertise-api.service\""
-      do_action "systemctl --user daemon-reload"
+      do_action systemctl --user stop expertise-api.service 2>/dev/null || true
+      do_action systemctl --user disable expertise-api.service 2>/dev/null || true
+      do_action rm -f "${XDG_CONFIG_HOME:-${HOME}/.config}/systemd/user/expertise-api.service"
+      do_action systemctl --user daemon-reload
     else
       log "systemd unit not present — skipping service teardown"
     fi ;;
@@ -94,8 +258,8 @@ case "${OS}" in
     LABEL="com.thesemicolon.expertise-api"
     PLIST="${HOME}/Library/LaunchAgents/${LABEL}.plist"
     if [[ -f "${PLIST}" ]]; then
-      do_action "launchctl bootout gui/$(id -u)/${LABEL} 2>/dev/null || true"
-      do_action "rm -f \"${PLIST}\""
+      do_action launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true
+      do_action rm -f "${PLIST}"
     else
       log "launchd plist not present — skipping service teardown"
     fi ;;
@@ -103,20 +267,20 @@ esac
 
 # Remove binary tree
 if [[ -d "${BIN_DIR}" ]]; then
-  do_action "rm -rf \"${BIN_DIR}\""
+  do_action rm -rf "${BIN_DIR}"
 else
   log "binary dir not present — skipping"
 fi
 
 # Wrapper script
 if [[ -f "${PREFIX}/bin/launch-expertise-api.sh" ]]; then
-  do_action "rm -f \"${PREFIX}/bin/launch-expertise-api.sh\""
+  do_action rm -f "${PREFIX}/bin/launch-expertise-api.sh"
 fi
 
 if (( PURGE == 1 )); then
   log "purge: removing user data"
   for d in "${MODEL_DIR}" "${LOG_DIR}" "${CONFIG_DIR}" "${PREFIX}"; do
-    [[ -d "${d}" ]] && do_action "rm -rf \"${d}\""
+    [[ -d "${d}" ]] && do_action rm -rf "${d}"
   done
 else
   log "preserved: ${MODEL_DIR}        (use --purge to remove)"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -91,7 +91,16 @@ esac
 
 normalize_prefix() {
   local p="$1"
-  # Reject parent-directory traversal entirely. No legitimate --prefix needs it.
+  # Reject embedded whitespace / line-ending characters. Most often a CR
+  # smuggled in via a Windows clipboard paste; also catches accidental
+  # tabs and newlines. Bash treats NUL as a string terminator so we do
+  # not need to handle it explicitly.
+  case "$p" in
+    *$'\t'*|*$'\r'*|*$'\n'*) err "--prefix may not contain whitespace or line-ending characters" ;;
+  esac
+  # Reject parent-directory traversal entirely. The four patterns are
+  # exhaustive only because absolute paths are '/'-anchored — if this
+  # helper is ever reused for relative paths, extend accordingly.
   case "$p" in
     *"/../"*|*/..|"../"*|"..") err "--prefix may not contain '..'" ;;
   esac
@@ -127,13 +136,19 @@ validate_prefix() {
   local blocked_exact=(
     /
     /home /root /Users         # user-home parent containers
-    /opt /usr/local            # FHS / common system install parents (descendants allowed)
+    /opt /usr/local            # common system install parents (descendants allowed)
     /mnt /media /Volumes /Network  # mount-point parents
-    /tmp /var /usr /srv /run /snap /cores /.vol /host /rootfs  # exact-block; descendants only blocked by component check
+    /tmp /var /usr /srv /run /cores /.vol /host /rootfs  # exact-block; descendants gated by prefix/component checks below
   )
   local blocked_prefix=(
     # POSIX system subtrees
     /bin /sbin /etc /lib /lib64 /boot /dev /proc /sys
+    # FHS /usr subtrees — /usr/local is the exact-only carve-out above.
+    /usr/bin /usr/sbin /usr/lib /usr/libexec /usr/share /usr/include
+    # FHS /var/lib (canonical writable system-state location; off-limits to us).
+    /var/lib
+    # Immutable squashfs mounts (snap packages).
+    /snap
     # macOS system subtrees
     /Library /System /Applications /private
     # WSL drive mounts (user code goes here, services should not)
@@ -243,14 +258,25 @@ else
   log "  mode       = remove binaries only (user data preserved)"
 fi
 
-# Stop service first
+# Stop service first.
+#
+# Note: the `systemctl --user list-unit-files` / `[[ -f PLIST ]]` probes
+# below execute even under --dry-run because they are pure read-only
+# queries. This means the --dry-run plan reflects host state at
+# dry-run time, not at apply time — intentional and documented in
+# README. Do not wrap these probes in do_action.
 case "${OS}" in
   linux|wsl)
     if systemctl --user list-unit-files expertise-api.service 2>/dev/null | grep -q expertise-api; then
       do_action systemctl --user stop expertise-api.service 2>/dev/null || true
       do_action systemctl --user disable expertise-api.service 2>/dev/null || true
       do_action rm -f "${XDG_CONFIG_HOME:-${HOME}/.config}/systemd/user/expertise-api.service"
-      do_action systemctl --user daemon-reload
+      # `daemon-reload` can fail when no user-DBUS session exists (e.g.
+      # uninstall over SSH without `loginctl enable-linger`). That's a
+      # degraded-cleanup case, not a destructive one — the unit file is
+      # already removed by the preceding `rm -f`. Tolerate the failure
+      # so the script proceeds to delete the binary tree below.
+      do_action systemctl --user daemon-reload 2>/dev/null || true
     else
       log "systemd unit not present — skipping service teardown"
     fi ;;
@@ -265,22 +291,18 @@ case "${OS}" in
     fi ;;
 esac
 
-# Remove binary tree
-if [[ -d "${BIN_DIR}" ]]; then
-  do_action rm -rf "${BIN_DIR}"
-else
-  log "binary dir not present — skipping"
-fi
+# Remove binary tree. `rm -rf` swallows ENOENT under `-f`, so we do not
+# precheck `[[ -d ... ]]` — that would only widen the TOCTOU window
+# between the existence test and the deletion.
+do_action rm -rf "${BIN_DIR}"
 
-# Wrapper script
-if [[ -f "${PREFIX}/bin/launch-expertise-api.sh" ]]; then
-  do_action rm -f "${PREFIX}/bin/launch-expertise-api.sh"
-fi
+# Wrapper script (idempotent under `-f`).
+do_action rm -f "${PREFIX}/bin/launch-expertise-api.sh"
 
 if (( PURGE == 1 )); then
   log "purge: removing user data"
   for d in "${MODEL_DIR}" "${LOG_DIR}" "${CONFIG_DIR}" "${PREFIX}"; do
-    [[ -d "${d}" ]] && do_action rm -rf "${d}"
+    do_action rm -rf "${d}"
   done
 else
   log "preserved: ${MODEL_DIR}        (use --purge to remove)"

--- a/tests/uninstall/test-prefix-guard.sh
+++ b/tests/uninstall/test-prefix-guard.sh
@@ -162,9 +162,35 @@ assert_dry_blocked /bin/expertise-api
 assert_dry_blocked /etc/expertise-api
 assert_dry_blocked /sbin/expertise-api
 assert_dry_blocked /lib/expertise-api
+assert_dry_blocked /dev/expertise-api
+assert_dry_blocked /proc/expertise-api
+assert_dry_blocked /sys/expertise-api
 assert_dry_blocked /System/foo --allow-system-prefix
 assert_dry_blocked /Library/foo --allow-system-prefix
 assert_dry_blocked /private/var/expertise-api
+assert_dry_blocked /private/tmp/expertise-api
+# FHS /usr subtrees — promoted to prefix-block after the pre-PR review
+assert_dry_blocked /usr/share/expertise-api --allow-system-prefix
+assert_dry_blocked /usr/lib/expertise-api --allow-system-prefix
+assert_dry_blocked /usr/sbin/expertise-api --allow-system-prefix
+assert_dry_blocked /usr/libexec/expertise-api --allow-system-prefix
+assert_dry_blocked /usr/include/expertise-api --allow-system-prefix
+assert_dry_blocked /var/lib/expertise-api --allow-system-prefix
+# Snap (immutable squashfs) — promoted to prefix-block
+assert_dry_blocked /snap/expertise-api/current --allow-system-prefix
+
+# Whitespace / line-ending smuggling
+assert_dry_blocked $'/home/me/expertise-api/svc\r'
+assert_dry_blocked $'/home/me/\texpertise-api/svc'
+
+# Empty / whitespace-only prefix (the ${2:?} guard catches empty; the
+# space-only case should fail the absolute-path check).
+out=$("${SCRIPT}" --prefix " " --yes --purge --dry-run 2>&1) && {
+  printf 'FAIL: prefix=" " — expected non-zero exit\n' >&2; FAIL=$((FAIL+1))
+} || PASS=$((PASS+1))
+
+# $HOME exact reject (parametric on the running user)
+assert_dry_blocked "$HOME"
 
 # Traversal attack
 assert_dry_blocked /Users/x/.local/../../etc
@@ -193,6 +219,24 @@ assert_dry_allowed /usr/local/expertise-api
 
 # --allow-system-prefix unlocks the component check
 assert_dry_allowed /custom/svc-data --allow-system-prefix
+
+# Descendants of the /usr/local carve-out (exact-only block on /usr/local)
+assert_dry_allowed /usr/local/expertise-api
+
+# ---------------------------------------------------------------------------
+# Invariant: uninstall.sh must not embed absolute paths to destructive
+# binaries. The shim layer below relies on PATH lookups; an absolute
+# `/bin/rm` or `/usr/bin/launchctl` would silently bypass the shim.
+# Catching this here keeps the secondary defense honest.
+# ---------------------------------------------------------------------------
+UNINSTALL="$(cd "$(dirname "$0")/../.." && pwd)/scripts/uninstall.sh"
+if grep -nE '(^|[[:space:]])(/usr)?/(s?bin|libexec)/(rm|launchctl|systemctl)\b' "${UNINSTALL}" >/dev/null; then
+  echo 'FAIL: uninstall.sh contains absolute-path destructive binary (breaks shim defense):' >&2
+  grep -nE '(^|[[:space:]])(/usr)?/(s?bin|libexec)/(rm|launchctl|systemctl)\b' "${UNINSTALL}" | sed 's/^/  | /' >&2
+  FAIL=$((FAIL+1))
+else
+  PASS=$((PASS+1))
+fi
 
 # ---------------------------------------------------------------------------
 # Normalization

--- a/tests/uninstall/test-prefix-guard.sh
+++ b/tests/uninstall/test-prefix-guard.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+#
+# tests/uninstall/test-prefix-guard.sh
+#
+# Black-box guard test for scripts/uninstall.sh. Two layers:
+#
+#   1. Primary: --dry-run output never contains "DRY-RUN: rm" for any
+#      prefix that should be rejected. Asserts the validation gate fires
+#      before the action dispatcher.
+#
+#   2. Secondary: PATH-shimmed `rm`, `launchctl`, `systemctl` capture any
+#      command the script tried to run against a blocked prefix when
+#      --dry-run is not in play. Second line of defense in case a future
+#      refactor moves validation after the action loop.
+#
+# Run from repo root:
+#   bash tests/uninstall/test-prefix-guard.sh
+#
+# Exit 0 = PASS, 1 = at least one assertion failed.
+#
+
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/../.." && pwd)/scripts/uninstall.sh"
+[[ -x "$SCRIPT" ]] || { echo "FAIL: $SCRIPT not executable" >&2; exit 1; }
+
+PASS=0
+FAIL=0
+
+# Use a HOME-local scratch dir; /var/folders (macOS mktemp default) is
+# blocked by the prefix-match guard which would invalidate the layout step.
+SCRATCH="${TMPDIR:-/tmp}/expertise-api-test-prefix-guard.$$"
+case "${SCRATCH}" in
+  /var/*|/private/*)
+    SCRATCH="/tmp/expertise-api-test-prefix-guard.$$" ;;
+esac
+mkdir -p "${SCRATCH}/expertise-api/bin"
+touch "${SCRATCH}/expertise-api/bin/dummy"
+trap 'rm -rf "${SCRATCH}"' EXIT
+
+SHIM_DIR="${SCRATCH}/shims"
+SHIM_LOG="${SCRATCH}/shim.log"
+mkdir -p "${SHIM_DIR}"
+for cmd in rm launchctl systemctl; do
+  cat > "${SHIM_DIR}/${cmd}" <<EOF
+#!/usr/bin/env bash
+printf '%s %s\n' "${cmd}" "\$*" >> "${SHIM_LOG}"
+exit 0
+EOF
+  chmod +x "${SHIM_DIR}/${cmd}"
+done
+
+# ---------------------------------------------------------------------------
+# Assertion helpers
+# ---------------------------------------------------------------------------
+
+# assert_dry_blocked PREFIX [EXTRA_ARGS...]
+#
+# Runs the script with --dry-run and asserts:
+#   (a) exit code is non-zero, AND
+#   (b) stdout/stderr contains no "DRY-RUN: rm" line (validation rejected
+#       before the action loop emitted any planned rm).
+assert_dry_blocked() {
+  local prefix="$1"; shift
+  local label="prefix='${prefix}'"
+  local out
+  if out=$("${SCRIPT}" --prefix "${prefix}" --yes --purge --dry-run "$@" 2>&1); then
+    printf 'FAIL: %s — expected non-zero exit but got 0\n' "${label}" >&2
+    printf '%s\n' "${out}" | sed 's/^/  | /'
+    FAIL=$((FAIL+1)); return
+  fi
+  if printf '%s\n' "${out}" | grep -q 'DRY-RUN: rm'; then
+    printf 'FAIL: %s — guard fired but DRY-RUN: rm appeared in output\n' "${label}" >&2
+    printf '%s\n' "${out}" | sed 's/^/  | /'
+    FAIL=$((FAIL+1)); return
+  fi
+  PASS=$((PASS+1))
+}
+
+# assert_dry_allowed PREFIX [EXTRA_ARGS...]
+#
+# Runs the script with --dry-run on a path the guard should accept and
+# asserts (a) exit 0 and (b) at least one DRY-RUN: line was emitted
+# (proves the validation gate passed and the planner ran).
+assert_dry_allowed() {
+  local prefix="$1"; shift
+  local label="prefix='${prefix}'"
+  local out
+  if ! out=$("${SCRIPT}" --prefix "${prefix}" --yes --purge --dry-run "$@" 2>&1); then
+    printf 'FAIL: %s — expected exit 0 but guard rejected\n' "${label}" >&2
+    printf '%s\n' "${out}" | sed 's/^/  | /'
+    FAIL=$((FAIL+1)); return
+  fi
+  # Validation passed iff the planner reached the "plan:" line. We do NOT
+  # require DRY-RUN: rm because the planner correctly emits "not present —
+  # skipping" for non-existent dirs (these prefixes are not real installs).
+  if ! printf '%s\n' "${out}" | grep -q '^\[uninstall\] plan:$'; then
+    printf 'FAIL: %s — accepted but planner never ran\n' "${label}" >&2
+    printf '%s\n' "${out}" | sed 's/^/  | /'
+    FAIL=$((FAIL+1)); return
+  fi
+  PASS=$((PASS+1))
+}
+
+# assert_shim_silent PREFIX [EXTRA_ARGS...]
+#
+# Secondary defense layer: runs with --yes (no --dry-run) under
+# PATH-shimmed rm/launchctl/systemctl. Asserts (a) script exited
+# non-zero and (b) shim log is empty (no action was attempted before
+# validation refused).
+assert_shim_silent() {
+  local prefix="$1"; shift
+  local label="prefix='${prefix}' (shim layer)"
+  : > "${SHIM_LOG}"
+  local out
+  if out=$(PATH="${SHIM_DIR}:${PATH}" "${SCRIPT}" --prefix "${prefix}" --yes --purge "$@" 2>&1); then
+    printf 'FAIL: %s — expected non-zero exit but got 0\n' "${label}" >&2
+    printf '%s\n' "${out}" | sed 's/^/  | /'
+    FAIL=$((FAIL+1)); return
+  fi
+  if [[ -s "${SHIM_LOG}" ]]; then
+    printf 'FAIL: %s — shim log non-empty (guard let actions through)\n' "${label}" >&2
+    sed 's/^/  | /' < "${SHIM_LOG}" >&2
+    FAIL=$((FAIL+1)); return
+  fi
+  PASS=$((PASS+1))
+}
+
+# assert_normalizes_to PREFIX EXPECTED
+#
+# Runs --dry-run and asserts the planner echoed "PREFIX     = EXPECTED",
+# proving normalization stripped trailing slashes / collapsed //.
+assert_normalizes_to() {
+  local prefix="$1" expected="$2"
+  local out
+  out=$("${SCRIPT}" --prefix "${prefix}" --dry-run 2>&1) || true
+  if printf '%s\n' "${out}" | grep -qE "^\[uninstall\][[:space:]]+PREFIX[[:space:]]+= ${expected}$"; then
+    PASS=$((PASS+1))
+  else
+    printf 'FAIL: normalization — input %q expected PREFIX=%q\n' "${prefix}" "${expected}" >&2
+    printf '%s\n' "${out}" | grep PREFIX | sed 's/^/  | /' >&2
+    FAIL=$((FAIL+1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Test cases — blocked
+# ---------------------------------------------------------------------------
+
+# Exact roots
+assert_dry_blocked /
+assert_dry_blocked /home
+assert_dry_blocked /Users
+assert_dry_blocked /opt
+assert_dry_blocked /usr/local
+assert_dry_blocked /mnt
+assert_dry_blocked /tmp
+
+# Prefix-match catastrophic roots (any descendant blocked even with
+# --allow-system-prefix)
+assert_dry_blocked /bin/expertise-api
+assert_dry_blocked /etc/expertise-api
+assert_dry_blocked /sbin/expertise-api
+assert_dry_blocked /lib/expertise-api
+assert_dry_blocked /System/foo --allow-system-prefix
+assert_dry_blocked /Library/foo --allow-system-prefix
+assert_dry_blocked /private/var/expertise-api
+
+# Traversal attack
+assert_dry_blocked /Users/x/.local/../../etc
+
+# Component check
+assert_dry_blocked /custom/svc-data
+
+# --allow-system-prefix relaxes only the component check, not the blocklist
+assert_dry_blocked /etc/something --allow-system-prefix
+assert_dry_blocked / --allow-system-prefix
+assert_dry_blocked /home --allow-system-prefix
+
+# ---------------------------------------------------------------------------
+# Test cases — allowed
+# ---------------------------------------------------------------------------
+
+# Default-style HOME-adjacent install
+assert_dry_allowed "${SCRATCH}/expertise-api"
+
+# Descendants of exact-only parents (these were the regression that nearly
+# shipped: /Users prefix-match would block every real macOS install)
+assert_dry_allowed /home/foo/expertise-api
+assert_dry_allowed /Users/me/svc/expertise-api
+assert_dry_allowed /opt/expertise-api
+assert_dry_allowed /usr/local/expertise-api
+
+# --allow-system-prefix unlocks the component check
+assert_dry_allowed /custom/svc-data --allow-system-prefix
+
+# ---------------------------------------------------------------------------
+# Normalization
+# ---------------------------------------------------------------------------
+
+assert_normalizes_to "${SCRATCH}/expertise-api/"     "${SCRATCH}/expertise-api"
+assert_normalizes_to "${SCRATCH}//expertise-api///"  "${SCRATCH}/expertise-api"
+assert_normalizes_to "${SCRATCH}/expertise-api///"   "${SCRATCH}/expertise-api"
+
+# ---------------------------------------------------------------------------
+# Secondary defense — PATH shims should never log a command for blocked
+# prefixes, even if --dry-run is omitted.
+# ---------------------------------------------------------------------------
+
+assert_shim_silent /
+assert_shim_silent /etc/expertise-api
+assert_shim_silent /Users/x/.local/../../etc
+assert_shim_silent /custom/svc-data
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+printf '\n[test-prefix-guard] %d passed, %d failed\n' "${PASS}" "${FAIL}"
+if (( FAIL == 0 )); then
+  echo 'PASS — 0 errors, 0 warnings'
+  exit 0
+else
+  echo "FAIL — ${FAIL} errors, 0 warnings"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Hardens `scripts/uninstall.sh` against destructive `--prefix` mistakes. The pre-rewrite script trusted `--prefix` and used `eval` to dispatch `rm -rf "${PREFIX}"`, which would happily delete `/`, `$HOME`, `/etc`, or whatever the operator (or upstream automation) handed it. This PR replaces that with:

- **Argv dispatch** (`do_action "$@"`) — eliminates `eval`, so a hostile filename inside `${BIN_DIR}` cannot break out via shell re-parsing.
- **Two-tier blocklist** for `--prefix`:
  - *Exact-match* parents (`/`, `/home`, `/Users`, `/opt`, `/usr/local`, `/mnt`, `/Volumes`, `/tmp`, `/var`, `/usr`, ...) so legitimate descendants like `/Users/me/svc/expertise-api`, `/opt/expertise-api`, `/usr/local/expertise-api` stay allowed.
  - *Prefix-match* catastrophic subtrees (`/bin`, `/etc`, `/lib`, `/System`, `/Library`, `/private`, `/usr/{bin,sbin,lib,libexec,share,include}`, `/var/lib`, `/snap`, `/mnt/{c,wsl}`, `$HOME/{Desktop,Documents}`) where every descendant is blocked unconditionally — `--allow-system-prefix` does **not** relax this.
- **`..` and whitespace/CR rejection** in `normalize_prefix` (no `realpath`/`readlink -f` — non-portable on macOS, false-secure on non-existent paths). Defends against Windows clipboard-paste smuggling.
- **`expertise-api` path-component requirement** — bypassable via the explicit `--allow-system-prefix` flag for legitimate custom layouts.
- **`--system` mode refuses symlink prefix** (TOCTOU defense, scoped to the leaf — ancestor coverage tracked separately in #242).
- **First-class `--dry-run`** that forces non-destructive execution even with `--yes`. Drives the test harness.
- **Pre-action plan summary** so operators see exactly what will be removed before confirming.
- **Drop `[[ -d ]]` prechecks** before destructive operations — tightens the validate→execute TOCTOU window; `-f` already swallows ENOENT.
- **Tolerate `daemon-reload` failure** under set -e (missing user-DBUS session over SSH is a degraded-cleanup case, not destructive — must not abort before binary teardown).

Closes #222. Follow-up #242 tracks the PREFIX-parent TOCTOU in `--system` mode (multi-user-safety hardening that belongs alongside the #145 LaunchDaemon thread).

## Test Plan

New `tests/uninstall/test-prefix-guard.sh` — **49 assertions, all pass**:

- 18 catastrophic-target rejections (`/`, `/etc`, `/Users`, `/Volumes/Data`, `/snap/expertise-api/current`, `/usr/share/expertise-api`, `/var/lib/expertise-api`, ...).
- 11 legitimate-target acceptances (`/opt/expertise-api`, `/Users/me/svc/expertise-api`, `/usr/local/expertise-api`, ...).
- 6 traversal / smuggling rejections (`..`, tab/CR/LF in prefix, empty/whitespace-only, `$HOME` exact).
- Normalization coverage (`//` collapse, trailing slash).
- `--allow-system-prefix` scoping (lifts component check, does not lift blocklist).
- Shim layer (PATH-prepended `rm`/`launchctl`/`systemctl` no-ops) as secondary defense to dry-run.
- Invariant grep test forbidding absolute-path destructive binaries in `uninstall.sh` (would silently bypass the shim defense).

Pre-PR review fan-out (`shell-expert` + `security-review-expert` + `linter`) returned aggregate **PASS_WITH_WARNINGS**. Folded in:

- **shell-expert M1** — restored `|| true` on `systemctl --user daemon-reload`.
- **shell-expert M2** — expanded blocklist with `/usr/{bin,sbin,lib,libexec,share,include}` and `/var/lib`.
- **shell-expert M3** — promoted `/snap` to prefix-block (immutable squashfs mount).
- **shell-expert L1** — whitespace/CR rejection in `normalize_prefix`.
- **security Info** — dropped `[[ -d ]]` prechecks before `rm -rf`.
- **Coverage** — 17 new test assertions across the expanded blocklist and smuggling cases.

The **security Warning** (PREFIX-parent TOCTOU in `--system` mode) is deferred to #242 — multi-user-safety hardening naturally belongs alongside the #145 LaunchDaemon work. Documented in README with the explicit caveat and link.

Citation-currency caveat: both reviewers flagged they could not live-fetch first-party docs in-session. Substantive POSIX/Bash claims (`rm -rf` symlink semantics, `"$@"` argv preservation, FHS `/usr` semantics) are foundational well-known behavior; agents marked anything beyond that as "not corroborated." Follow-up infrastructure to fix this generally tracked in [pi_config#151](https://github.com/TheSemicolon/pi_config/issues/151) (register a `web_fetch` tool so research subagents can cite first-party docs).

Gates:

- `shellcheck`: clean (2 files)
- `bash tests/uninstall/test-prefix-guard.sh`: 49/49 pass
- `markdownlint-cli2`: 0 errors
- `scripts/validate-pr.sh`: PASS

## Risk

- **Low** for user-mode uninstalls — the design preserves every legitimate descendant of `/Users`, `/home`, `/opt`, `/usr/local`. The initial coding pass had a `/Users` prefix-match bug that would have blocked every Mac install; caught in testing and corrected via the two-tier split.
- **Medium** for `--system` mode on multi-user hosts — the symlink check covers PREFIX itself but not its ancestors. Operators must ensure `/opt/<parent>/` is root-owned and non-group-writable. Tracked in #242.
- **Backward compatibility** — operators who relied on the prior trust-me behavior to remove unrelated trees will see the script error out and need `--allow-system-prefix`. This is the intended behavior change.

## Follow-ups

- #242 — close PREFIX-parent TOCTOU in `--system` mode (multi-user-safety; depends on #145 LaunchDaemon thread for shared design).
- #223 — install atomicity + upgrade safety (PR B in this track; independent of PR A).
- #241 — host-dependency bootstrap (PR C in this track; depends on A + B).
- pi_config#151 — register `web_fetch` tool so research subagents can cite first-party docs (closes the citation-currency gap surfaced during this review).
- See `docs/install-upgrade-track.md` for the consolidated multi-PR plan.
