### PR TITLE
feat(install): atomic publish, migrate-against-staged, version marker, crlf detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,11 +402,94 @@ pending EF Core migrations and is idempotent (no-op when up to date).
   (or `%ProgramData%\ExpertiseApi\config\secrets.env` on Windows), run
   `scripts/migrate.sh` (or `.\scripts\migrate.ps1`) manually, then start
   the service.
-- On an **upgrade** the secrets file is preserved and migrate runs to
-  completion. Migrate failure is fatal: the install script exits non-zero,
-  the service is **not** restarted, and the prior binary keeps serving.
+- On an **upgrade** the secrets file is preserved and migrate runs
+  against the **staged** binaries (`${BIN_DIR}.new`) before the atomic
+  swap. If migrate fails, the staged tree is removed, the live `bin/`
+  directory is untouched, the service keeps running on the prior
+  binaries, and the install script exits non-zero with a remediation
+  message.
 - The migrate scripts are safe to run standalone any time; they exit 0 on
   no-op so they're cheap to wire into other automation.
+
+#### Upgrade safety
+
+`scripts/install.sh` is safe to re-run for upgrades. Each invocation:
+
+1. Acquires a `mkdir`-based lock at `${PREFIX}/.install.lock` (portable;
+   no `flock`). A second concurrent invocation fails fast.
+2. Validates `secrets.env` line endings in pre-flight — fails on CRLF
+   (Windows clipboard paste smuggling) with a line-number-only message
+   (the offending value is never echoed). Pass `--fix-line-endings` to
+   convert in place; mode 600 and original owner are preserved (the
+   latter matters under `sudo`).
+3. Stages the new publish output to `${BIN_DIR}.new` and refuses to
+   proceed if `${BIN_DIR}.new` or `${BIN_DIR}.old` exist as symlinks
+   (TOCTOU defense).
+4. Writes the launch wrapper to `${PREFIX}/launch-expertise-api.sh`
+   (NOT inside `${BIN_DIR}`) so it survives binary swaps.
+5. Runs migrate against the staged binaries via
+   `scripts/migrate.sh --bin-dir ${BIN_DIR}.new`. On failure the staged
+   tree is removed and the live tree is untouched. EF Core migrations
+   are transactional per migration, so a retry on the next install run
+   resumes at the failed migration.
+6. Performs the atomic swap (`mv ${BIN_DIR} → .old; mv .new → ${BIN_DIR}`).
+   The brief window where `${BIN_DIR}` does not exist does not affect
+   the running service (POSIX inode-by-handle). `${BIN_DIR}.old` is
+   preserved as a rollback runway through the remaining steps; it is
+   cleaned only after step 8 succeeds.
+7. Re-installs the service unit (systemd `daemon-reload` + restart, or
+   `launchctl bootstrap + kickstart`).
+8. Writes the new version to `${PREFIX}/.install-version`. On the next
+   run, the marker is read to log one of `fresh install` /
+   `reinstall (X)` / `upgrade X -> Y`. Steady-state cleanup of
+   `${BIN_DIR}.old` then runs in the success branch of the trap.
+
+`scripts/install.sh` shares the same `--prefix` validation as
+`scripts/uninstall.sh` (catastrophic-target blocklist, `..` rejection,
+`expertise-api` path-component requirement — see the Uninstall section
+below). When `--prefix DIR` is passed, `secrets.env`, models/, and
+logs/ all co-locate under `DIR/` rather than the per-OS XDG/macOS
+defaults; set the XDG paths explicitly via env vars if you want them
+split.
+
+##### Rollback
+
+Automatic on failure. Trap-based cleanup branches on a `STAGE` variable:
+
+| Failure stage | Action |
+|---|---|
+| `init`, `preflight`, `version`, `models`, `config` | Release lock. Live tree untouched. |
+| `staged`, `migrated` | Remove `${BIN_DIR}.new`. Live tree untouched. |
+| `swapped` (post-swap step failed) | Best-effort restore `${BIN_DIR}.old → ${BIN_DIR}`. If restoration itself fails, prints manual recovery steps. |
+
+The `secrets.env`, `models/`, `logs/`, and `.install-version` paths all
+live outside `${BIN_DIR}` and are unaffected by binary swaps.
+
+##### Troubleshooting
+
+- **`CRLF line endings detected`** — your `secrets.env` was edited on a
+  Windows host or pasted from a clipboard that injected `\r`. Either
+  re-run with `--fix-line-endings`, or manually:
+  `tr -d '\r' < secrets.env > secrets.env.tmp && mv secrets.env.tmp
+  secrets.env && chmod 600 secrets.env`.
+- **`another install in progress`** — a prior `install.sh` invocation
+  crashed before releasing its lock. If no install is actually running,
+  `rmdir ${PREFIX}/.install.lock` and retry.
+- **`refusing to swap: symlink at ${BIN_DIR}.new`** — stale or hostile
+  symlink in `${PREFIX}`. Inspect with `ls -la ${PREFIX}/`, remove the
+  symlink, retry.
+- **`migrate failed`** — the staged tree was removed, the live tree is
+  intact, and the prior binaries are still serving. Inspect the migrate
+  output (typically Npgsql or EF schema-conflict messages), fix the DB
+  or migration, then re-run `scripts/install.sh`.
+
+##### Schema version
+
+`secrets.env` carries a `# expertise-api-secrets-version=N` header (`N=1`
+today). Files predating the header are treated as v0; the installer
+warns but does not auto-mutate operator-owned credential files.
+Forward migrations will land behind an explicit
+`--upgrade-secrets` flag when needed.
 
 > **Upgrade note** for installs that predate #144: pre-existing `secrets.env`
 > files generated by earlier installs may have the connection string

--- a/docs/install-upgrade-track.md
+++ b/docs/install-upgrade-track.md
@@ -125,4 +125,40 @@ Status legend: ☐ todo · ◐ in progress · ☑ merged · ✗ abandoned.
 
 - **2026-05-22** — Plan drafted (this file). #223 ACs updated; new issue #241 filed for dependency bootstrap.
 - **2026-05-22** — `shell-expert` pre-design review on PR A: verdict PASS_WITH_WARNINGS. Folded `..` rejection + lexical normalization (no `realpath`); two-tier blocklist; first-class `--dry-run`; test fixtures under `tests/uninstall/`.
-- **2026-05-22** — Pre-PR fan-out on PR A: 3-way parallel (`shell-expert` + `security-review-expert` + `linter`). Aggregate verdict PASS_WITH_WARNINGS (most-severe-wins). Linter PASS. Shell-expert 3 Medium / 4 Low/Info. Security 1 Warning / multiple Info. Citation-currency caveat: both reviewers flagged they could not live-fetch first-party docs in-session; substantive POSIX/Bash claims (`rm -rf` symlink semantics, `"$@"` argv preservation) are well-known foundational behavior. Folded in: `daemon-reload` `|| true` regression; expanded blocklist (`/usr/{bin,sbin,lib,libexec,share,include}`, `/var/lib`, `/snap` promoted to prefix-block); whitespace/CR rejection; dropped `[[ -d ]]` precheck (TOCTOU window); 17 new test assertions (now 49 total); invariant-grep test forbidding absolute-path destructive binaries. Filed #242 for the multi-user-safety PREFIX-parent TOCTOU (out of scope for PR A; naturally part of #145 LaunchDaemon thread). README updated with expanded blocklist precision and #242 caveat.
+- **2026-05-22** — Pre-PR fan-out on PR A: 3-way parallel (`shell-expert` + `security-review-expert` + `linter`). Aggregate verdict PASS_WITH_WARNINGS (most-severe-wins). Linter PASS. Shell-expert 3 Medium / 4 Low/Info. Security 1 Warning / multiple Info. Citation-currency caveat: both reviewers flagged they could not live-fetch first-party docs in-session. Folded in: `daemon-reload` `|| true` regression; expanded blocklist (`/usr/{bin,sbin,lib,libexec,share,include}`, `/var/lib`, `/snap` promoted to prefix-block); whitespace/CR rejection; dropped `[[ -d ]]` precheck (TOCTOU window); 17 new test assertions (now 49 total); invariant-grep test. Filed #242 for the multi-user-safety PREFIX-parent TOCTOU. Filed pi_config#151 for the web_fetch enablement gap.
+- **2026-05-22** — PR A (#243) merged to dev as `411bcad`. #222 closed.
+- **2026-05-22** — Pre-design fan-out on PR B: 3-way parallel (`shell-expert` + `security-review-expert` + `dotnet-expert`). All three NEEDS_CHANGES with a converging redesign. Critical finding: `migrate.sh` execs the published binary's `migrate` verb (not `dotnet ef`), so the original publish→swap→migrate→rollback shape was inverted. Correct shape: publish-staged → migrate-against-staged → swap on success. Additional findings: wrapper-script clobber (relocate outside BIN_DIR), `migrate.sh` hardcodes `${BIN_DIR}` (needs `--bin-dir` flag), trap-with-SUCCESS-flag, CRLF detector moves to preflight, secrets-stub umask window, schema-header opt-in only, portable `mkdir` lock (not flock), `git describe` byte-filter, CRLF output line-number-only.
+
+## PR B redesign (locked 2026-05-22)
+
+Final operation order in `main()`:
+
+```text
+acquire_install_lock                    # mkdir ${PREFIX}/.install.lock
+preflight                               # + secrets CRLF detector (early)
+resolve_install_version                 # git describe → sanitized $NEW_VERSION
+ensure_models                           # idempotent, outside swap surface
+ensure_config_stubs                     # umask 077 wrap; v1 header on fresh
+publish_app_staged                      # → ${BIN_DIR}.new (symlink-trap checked)
+write_wrapper_to_prefix                 # → ${PREFIX}/launch-expertise-api.sh
+run_migrate_against_staged              # migrate.sh --bin-dir ${BIN_DIR}.new
+atomic_swap                             # rename current→old; rename new→current; rm old
+install_service                         # templates updated for new wrapper path
+write_install_version_marker            # ${PREFIX}/.install-version
+SUCCESS=1
+```
+
+Trap cleanup (single function, branches on `STAGE`):
+
+- `STAGE=init`: release lock only.
+- `STAGE=staged` or `STAGE=migrated`: remove `${BIN_DIR}.new`, release lock. Live tree untouched.
+- `STAGE=swapped`: best-effort restore from `${BIN_DIR}.old`; emit operator recovery checklist; release lock.
+- `STAGE=done` (SUCCESS=1): trap is no-op.
+
+Wrapper script lives at `${PREFIX}/launch-expertise-api.sh` (NOT inside `${BIN_DIR}`) so it survives binary swaps. Service templates updated. Uninstall guard already protects PREFIX root.
+
+Not in PR B (deferred):
+
+- Destructive-migration convention guardrail (doc-only follow-up commit).
+- Multi-user ancestor-ownership check on `${PREFIX}` — #242.
+- `--system` permissions hardening on `.install-version` — #145 LaunchDaemon thread.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,9 +9,31 @@
 # Usage:
 #   scripts/install.sh [--prefix DIR] [--bind ADDR:PORT] [--system]
 #                      [--publish-mode fdd|scd] [--skip-preflight]
-#                      [--rid RID] [--help]
+#                      [--rid RID] [--fix-line-endings] [--help]
 #
 # Defaults: per-user install, fdd publish, bind 127.0.0.1:8080.
+#
+# Upgrade safety (issue #223):
+#
+#   * Concurrent installs blocked by a `mkdir`-based lock at
+#     ${PREFIX}/.install.lock — portable across Linux + macOS (no flock).
+#   * Publish output staged to ${BIN_DIR}.new; live ${BIN_DIR} is only
+#     touched once both publish AND migrate succeed.
+#   * Migrate runs against the STAGED binaries (via migrate.sh --bin-dir)
+#     so a migrate failure leaves the live tree, the running service, and
+#     the DB-from-the-operator's perspective unchanged. EF migrations are
+#     transactional per-migration, so partial DB advance from a failed
+#     batch is retry-safe on the next install run.
+#   * Service wrapper lives at ${PREFIX}/launch-expertise-api.sh (NOT
+#     inside ${BIN_DIR}) so it survives binary swaps. Service templates
+#     are updated to reference the new location.
+#   * Version marker written to ${PREFIX}/.install-version after every
+#     successful install; main() reads it at entry to log fresh /
+#     reinstall / upgrade-from-X-to-Y.
+#   * secrets.env carries a schema-version header. Absent header = v0
+#     (legacy) and is not auto-mutated; v1 is the current shape.
+#   * CRLF detector fails fast in preflight before any publish work;
+#     --fix-line-endings converts in place preserving mode + owner.
 #
 
 set -euo pipefail
@@ -26,6 +48,10 @@ err()  { printf '[install] ERROR: %s\n' "$1" >&2; exit 1; }
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
+# Pinned secrets-file schema version. Bump when the format changes; add
+# a per-version fixup in `migrate_secrets_schema` and re-export.
+SECRETS_SCHEMA_VERSION=1
+
 # ---------------------------------------------------------------------------
 # Defaults & arg parsing
 # ---------------------------------------------------------------------------
@@ -35,21 +61,28 @@ BIND_ADDR="127.0.0.1:8080"
 SKIP_PREFLIGHT=0
 EXPLICIT_RID=""
 PREFIX_OVERRIDE=""
+FIX_LINE_ENDINGS=0
+ALLOW_SYSTEM_PREFIX=0
 
 usage() { sed -n '2,15p' "$0" | sed 's/^# \{0,1\}//'; }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --prefix)         PREFIX_OVERRIDE="${2:?--prefix needs a path}"; shift 2 ;;
-    --bind)           BIND_ADDR="${2:?--bind needs ADDR:PORT}"; shift 2 ;;
-    --system)         INSTALL_SCOPE="system"; shift ;;
-    --publish-mode)   PUBLISH_MODE="${2:?--publish-mode needs fdd|scd}"; shift 2 ;;
-    --skip-preflight) SKIP_PREFLIGHT=1; shift ;;
-    --rid)            EXPLICIT_RID="${2:?--rid needs a runtime identifier}"; shift 2 ;;
-    --help|-h)        usage; exit 0 ;;
-    *)                err "unknown flag: $1 (try --help)" ;;
+    --prefix)            PREFIX_OVERRIDE="${2:?--prefix needs a path}"; shift 2 ;;
+    --bind)              BIND_ADDR="${2:?--bind needs ADDR:PORT}"; shift 2 ;;
+    --system)            INSTALL_SCOPE="system"; shift ;;
+    --publish-mode)      PUBLISH_MODE="${2:?--publish-mode needs fdd|scd}"; shift 2 ;;
+    --skip-preflight)    SKIP_PREFLIGHT=1; shift ;;
+    --rid)               EXPLICIT_RID="${2:?--rid needs a runtime identifier}"; shift 2 ;;
+    --fix-line-endings)  FIX_LINE_ENDINGS=1; shift ;;
+    --allow-system-prefix) ALLOW_SYSTEM_PREFIX=1; shift ;;
+    --help|-h)           usage; exit 0 ;;
+    *)                   err "unknown flag: $1 (try --help)" ;;
   esac
 done
+# Touch ALLOW_SYSTEM_PREFIX so shellcheck sees it as referenced; the
+# real consumer is scripts/lib/prefix-validation.sh sourced below.
+: "${ALLOW_SYSTEM_PREFIX}"
 
 [[ "${PUBLISH_MODE}" == "fdd" || "${PUBLISH_MODE}" == "scd" ]] \
   || err "--publish-mode must be 'fdd' or 'scd'"
@@ -94,10 +127,29 @@ OS="$(detect_os)"
 RID="${EXPLICIT_RID:-$(detect_rid)}"
 
 # ---------------------------------------------------------------------------
+# Prefix validation (shared with uninstall.sh)
+#
+# Runs BEFORE path layout so a hostile --prefix can never reach BIN_DIR /
+# STAGE_DIR / OLD_DIR / LOCK_DIR derivation. Closes the install/uninstall
+# asymmetry surfaced by the PR B (#223) pre-PR security review.
+# ---------------------------------------------------------------------------
+# shellcheck source=lib/prefix-validation.sh disable=SC1091
+. "${SCRIPT_DIR}/lib/prefix-validation.sh"
+if [[ -n "${PREFIX_OVERRIDE}" ]]; then
+  PREFIX_OVERRIDE="$(normalize_prefix "${PREFIX_OVERRIDE}")"
+  validate_prefix "${PREFIX_OVERRIDE}"
+fi
+
+# ---------------------------------------------------------------------------
 # Path layout per OS (matches notes/agent-expertise-api-hosting.md §A2)
 # ---------------------------------------------------------------------------
 if [[ -n "${PREFIX_OVERRIDE}" ]]; then
   PREFIX="${PREFIX_OVERRIDE}"
+  # When --prefix overrides the default, co-locate config + logs under it
+  # so the layout stays self-contained. Operators who want split locations
+  # can set XDG_* explicitly before invoking install.sh.
+  LOG_DIR="${PREFIX}/logs"
+  CONFIG_DIR="${PREFIX}"
 elif [[ "${OS}" == "macos" ]]; then
   PREFIX="${HOME}/Library/Application Support/expertise-api"
   LOG_DIR="${HOME}/Library/Logs/expertise-api"
@@ -116,14 +168,94 @@ else
 fi
 
 BIN_DIR="${PREFIX}/bin"
+STAGE_DIR="${BIN_DIR}.new"
+OLD_DIR="${BIN_DIR}.old"
 MODEL_DIR="${PREFIX}/models"
 SECRETS_FILE="${CONFIG_DIR}/secrets.env"
-WRAPPER_SCRIPT="${BIN_DIR}/launch-expertise-api.sh"
+# Wrapper relocated outside BIN_DIR so it survives the atomic swap (#223).
+WRAPPER_SCRIPT="${PREFIX}/launch-expertise-api.sh"
+WRAPPER_LEGACY="${PREFIX}/bin/launch-expertise-api.sh"
+VERSION_MARKER="${PREFIX}/.install-version"
+LOCK_DIR="${PREFIX}/.install.lock"
+
+# ---------------------------------------------------------------------------
+# Cleanup / trap — staged STAGE variable drives rollback granularity
+# ---------------------------------------------------------------------------
+STAGE="init"
+SUCCESS=0
+
+cleanup() {
+  local rc=$?
+  trap - ERR EXIT INT TERM
+  # Cleanup must not itself trip set -e — guard each op with || true.
+  if (( SUCCESS == 1 )); then
+    # Steady-state cleanup of the rollback runway (deferred from
+    # atomic_swap so install_service / write_install_version_marker
+    # failures still have something to restore from).
+    if [[ -d "${OLD_DIR}" && ! -L "${OLD_DIR}" ]]; then
+      rm -rf -- "${OLD_DIR}" 2>/dev/null || true
+    fi
+    release_lock || true
+    exit 0
+  fi
+  warn "install failed at stage=${STAGE} (rc=${rc}) — performing rollback"
+  case "${STAGE}" in
+    init|preflight|version|models|config|staged|migrated)
+      # Live ${BIN_DIR} untouched. Drop the staged tree if it exists.
+      if [[ -d "${STAGE_DIR}" && ! -L "${STAGE_DIR}" ]]; then
+        rm -rf -- "${STAGE_DIR}" 2>/dev/null || true
+        warn "removed staged tree: ${STAGE_DIR}"
+      fi
+      ;;
+    swapped)
+      # Swap completed but a later step failed. Restore old binaries.
+      if [[ -d "${OLD_DIR}" && ! -L "${OLD_DIR}" ]]; then
+        if [[ -e "${BIN_DIR}" ]]; then
+          mv -- "${BIN_DIR}" "${STAGE_DIR}" 2>/dev/null || true
+        fi
+        if mv -- "${OLD_DIR}" "${BIN_DIR}" 2>/dev/null; then
+          warn "restored prior binaries from ${OLD_DIR} -> ${BIN_DIR}"
+          warn "Operator: verify with 'scripts/expertise-apictl status' and 'scripts/expertise-apictl health'"
+          rm -rf -- "${STAGE_DIR}" 2>/dev/null || true
+        else
+          warn "AUTOMATIC ROLLBACK FAILED. Manual recovery required:"
+          warn "  1. mv ${OLD_DIR} ${BIN_DIR}"
+          warn "  2. rm -rf ${STAGE_DIR}"
+          warn "  3. scripts/expertise-apictl restart"
+        fi
+      else
+        warn "no ${OLD_DIR} present — cannot auto-restore; investigate ${BIN_DIR} state"
+      fi
+      ;;
+  esac
+  release_lock || true
+  exit "${rc}"
+}
+trap cleanup ERR EXIT INT TERM
+
+# ---------------------------------------------------------------------------
+# Concurrent-install lock (portable: mkdir is atomic per POSIX.1-2017)
+# ---------------------------------------------------------------------------
+acquire_lock() {
+  mkdir -p "${PREFIX}" 2>/dev/null || err "cannot create ${PREFIX}"
+  if ! mkdir "${LOCK_DIR}" 2>/dev/null; then
+    err "another install in progress (lock dir ${LOCK_DIR} exists). If no install is running, remove it manually and retry."
+  fi
+  printf '%s\n' "$$" > "${LOCK_DIR}/pid" 2>/dev/null || true
+}
+
+release_lock() {
+  if [[ -d "${LOCK_DIR}" ]]; then
+    rm -f -- "${LOCK_DIR}/pid" 2>/dev/null || true
+    rmdir -- "${LOCK_DIR}" 2>/dev/null || true
+  fi
+}
 
 # ---------------------------------------------------------------------------
 # Pre-flight
 # ---------------------------------------------------------------------------
 preflight() {
+  STAGE="preflight"
   log "pre-flight: OS=${OS} RID=${RID} scope=${INSTALL_SCOPE} mode=${PUBLISH_MODE}"
 
   if [[ "${PUBLISH_MODE}" == "fdd" ]]; then
@@ -171,14 +303,128 @@ preflight() {
     err "insufficient disk space at ${PREFIX}: ${avail_mib} MiB free, need ${need_mib}"
   fi
   log "disk space: ${avail_mib} MiB"
+
+  check_secrets_line_endings
 }
 
 # ---------------------------------------------------------------------------
-# Publish
+# CRLF detector — fail fast before any publish work. Only filename and
+# line number are echoed; never the matched content (which may contain
+# secret values).
 # ---------------------------------------------------------------------------
-publish_app() {
-  log "publishing to ${BIN_DIR} (rid=${RID}, mode=${PUBLISH_MODE})"
-  mkdir -p "${BIN_DIR}"
+check_secrets_line_endings() {
+  [[ -f "${SECRETS_FILE}" ]] || return 0
+  # No `grep -U`: not in POSIX; busybox grep (Alpine, minimal containers)
+  # rejects it silently, which would let CRLF slip past on exactly the
+  # platforms this hardening is meant to cover. `-U` is a no-op outside
+  # Windows-host grep anyway.
+  if LC_ALL=C grep -l $'\r' "${SECRETS_FILE}" >/dev/null 2>&1; then
+    local line
+    line=$(LC_ALL=C grep -n -m1 $'\r' "${SECRETS_FILE}" 2>/dev/null | cut -d: -f1 || echo "?")
+    if (( FIX_LINE_ENDINGS == 1 )); then
+      fix_secrets_line_endings
+      log "CRLF detected at ${SECRETS_FILE}:${line} — fixed in place (mode + owner preserved)"
+    else
+      err "CRLF line endings detected at ${SECRETS_FILE}:${line}. Rerun with --fix-line-endings, or remediate manually: tr -d '\\r' < ${SECRETS_FILE} > ${SECRETS_FILE}.tmp && mv ${SECRETS_FILE}.tmp ${SECRETS_FILE} && chmod 600 ${SECRETS_FILE}"
+    fi
+  fi
+}
+
+# In-place CRLF fix preserving mode 600 and original owner (matters under
+# sudo where the effective uid is 0 but the secrets file is operator-owned).
+fix_secrets_line_endings() {
+  local tmp orig_mode orig_uid orig_gid umask_old
+  umask_old=$(umask)
+  umask 077
+  tmp=$(mktemp "${SECRETS_FILE}.XXXXXX") || err "mktemp failed for ${SECRETS_FILE}"
+  # Read existing mode + ownership via stat (BSD-vs-GNU branch).
+  if stat -f '%p' /dev/null >/dev/null 2>&1; then
+    orig_mode=$(stat -f '%Lp' "${SECRETS_FILE}")
+    orig_uid=$(stat -f '%u' "${SECRETS_FILE}")
+    orig_gid=$(stat -f '%g' "${SECRETS_FILE}")
+  else
+    orig_mode=$(stat -c '%a' "${SECRETS_FILE}")
+    orig_uid=$(stat -c '%u' "${SECRETS_FILE}")
+    orig_gid=$(stat -c '%g' "${SECRETS_FILE}")
+  fi
+  tr -d '\r' < "${SECRETS_FILE}" > "${tmp}"
+  chmod "${orig_mode:-600}" "${tmp}"
+  # Restore owner only if we have privilege (root or same uid).
+  if [[ "$(id -u)" == "0" ]] || [[ "$(id -u)" == "${orig_uid}" ]]; then
+    chown "${orig_uid}:${orig_gid}" "${tmp}" 2>/dev/null || true
+  fi
+  mv -f -- "${tmp}" "${SECRETS_FILE}"
+  umask "${umask_old}"
+}
+
+# ---------------------------------------------------------------------------
+# Version resolution + marker
+# ---------------------------------------------------------------------------
+resolve_install_version() {
+  STAGE="version"
+  local v=""
+  if command -v git >/dev/null 2>&1 && git -C "${REPO_ROOT}" rev-parse --git-dir >/dev/null 2>&1; then
+    v=$(git -C "${REPO_ROOT}" describe --tags --always --dirty 2>/dev/null || true)
+  fi
+  # Sanitize: git refnames permit characters wider than [:alnum:]._+-;
+  # clamp to a known-safe alphabet and length to prevent injection into
+  # the marker file (which is later echoed in logs). Allow `_` so tags
+  # like `release_2026_05` are not silently mangled.
+  v=$(printf '%s' "${v:-unknown}" | LC_ALL=C tr -cd '[:alnum:]._+-' | cut -c1-64)
+  [[ -z "${v}" ]] && v="unknown"
+  NEW_VERSION="${v}"
+
+  local prior=""
+  # Refuse to read through a symlink — a hostile pre-existing symlink
+  # at the marker path under --system could leak content fragments via
+  # the log line below.
+  if [[ -L "${VERSION_MARKER}" ]]; then
+    err "${VERSION_MARKER} exists as a symlink — refusing to read (potential information disclosure)"
+  fi
+  if [[ -r "${VERSION_MARKER}" ]]; then
+    prior=$(LC_ALL=C tr -cd '[:alnum:]._+-' < "${VERSION_MARKER}" | cut -c1-64 || true)
+  fi
+  # shellcheck disable=SC2034  # PRIOR_VERSION reserved for future doc/log surfaces
+  PRIOR_VERSION="${prior}"
+
+  if [[ -z "${prior}" ]]; then
+    log "version: fresh install (${NEW_VERSION})"
+  elif [[ "${prior}" == "${NEW_VERSION}" ]]; then
+    log "version: reinstall (${NEW_VERSION})"
+  else
+    log "version: upgrade ${prior} -> ${NEW_VERSION}"
+  fi
+}
+
+write_install_version_marker() {
+  # Refuse to write through a hostile symlink (parity with the read-side
+  # guard in resolve_install_version).
+  if [[ -L "${VERSION_MARKER}" ]]; then
+    err "${VERSION_MARKER} exists as a symlink — refusing to write"
+  fi
+  printf '%s\n' "${NEW_VERSION}" > "${VERSION_MARKER}.tmp"
+  mv -f -- "${VERSION_MARKER}.tmp" "${VERSION_MARKER}"
+  chmod 644 "${VERSION_MARKER}"
+}
+
+# ---------------------------------------------------------------------------
+# Publish (staged)
+# ---------------------------------------------------------------------------
+publish_app_staged() {
+  STAGE="staged"
+  # Defense-in-depth: refuse stage/old paths that exist as symlinks (a
+  # local attacker with write access to ${PREFIX} could pre-create them
+  # to redirect rm -rf or the rename swap).
+  if [[ -L "${STAGE_DIR}" ]]; then err "${STAGE_DIR} exists as a symlink — refusing to overwrite (potential TOCTOU)"; fi
+  if [[ -L "${OLD_DIR}"   ]]; then err "${OLD_DIR} exists as a symlink — refusing to overwrite (potential TOCTOU)"; fi
+  # Clean any leftover staged tree from a prior failed run.
+  if [[ -d "${STAGE_DIR}" ]]; then
+    log "removing leftover staged tree at ${STAGE_DIR}"
+    rm -rf -- "${STAGE_DIR}"
+  fi
+
+  log "publishing to ${STAGE_DIR} (rid=${RID}, mode=${PUBLISH_MODE})"
+  mkdir -p "${STAGE_DIR}"
   local self_contained="false"
   [[ "${PUBLISH_MODE}" == "scd" ]] && self_contained="true"
   ( cd "${REPO_ROOT}" && dotnet publish src/ExpertiseApi/ExpertiseApi.csproj \
@@ -186,14 +432,15 @@ publish_app() {
       --runtime "${RID}" \
       --self-contained "${self_contained}" \
       -p:UseAppHost=true \
-      --output "${BIN_DIR}" )
-  log "publish: complete"
+      --output "${STAGE_DIR}" )
+  log "publish: complete (staged)"
 }
 
 # ---------------------------------------------------------------------------
 # Models
 # ---------------------------------------------------------------------------
 ensure_models() {
+  STAGE="models"
   if [[ -f "${MODEL_DIR}/model.onnx" && -f "${MODEL_DIR}/vocab.txt" ]]; then
     log "ONNX models present at ${MODEL_DIR}"
     return
@@ -205,36 +452,62 @@ ensure_models() {
 
 # ---------------------------------------------------------------------------
 # Config / secrets stub
+#
+# Wrapped in umask 077 to close the ~10ms window where the tmp file
+# inherited the process umask (typically 0022 → mode 644 → world-readable)
+# before the explicit chmod 600. Belt-and-suspenders: the chmod stays.
 # ---------------------------------------------------------------------------
 ensure_config_stubs() {
+  STAGE="config"
   mkdir -p "${CONFIG_DIR}" "${LOG_DIR}"
   if [[ ! -f "${SECRETS_FILE}" ]]; then
     log "creating secrets stub at ${SECRETS_FILE} (chmod 600) — edit before starting service"
-    cat > "${SECRETS_FILE}.tmp" <<'EOF'
+    local umask_old; umask_old=$(umask)
+    umask 077
+    cat > "${SECRETS_FILE}.tmp" <<EOF
+# expertise-api-secrets-version=${SECRETS_SCHEMA_VERSION}
 # secrets.env — sourced by launch-expertise-api.sh / EnvironmentFile= directive.
 # chmod 600. Do NOT commit. Do NOT log.
 #
 # Set the connection string after install. Example for native Postgres:
 #   ConnectionStrings__DefaultConnection="Host=127.0.0.1;Port=5432;Database=expertise;Username=expertise;Password=CHANGE_ME"
 #
-# The double quotes are REQUIRED: bash sources this file via `set -a; . file`
+# The double quotes are REQUIRED: bash sources this file via \`set -a; . file\`
 # from the launch wrapper (and scripts/migrate.sh), and an unquoted value
-# containing `;` would be split as separate commands. systemd's own
+# containing \`;\` would be split as separate commands. systemd's own
 # EnvironmentFile= parser is literal and tolerates the unquoted form, but
 # the launchd-on-macOS path and the migrate scripts both use the bash sourcer.
 #
 # When Auth:Mode=Oidc, populate per-issuer overrides via Auth__Oidc__Issuers__N__*
 # environment variables — see appsettings.json for the shape.
 EOF
-    mv "${SECRETS_FILE}.tmp" "${SECRETS_FILE}"
-    chmod 600 "${SECRETS_FILE}"
+    chmod 600 "${SECRETS_FILE}.tmp"
+    mv -f -- "${SECRETS_FILE}.tmp" "${SECRETS_FILE}"
+    umask "${umask_old}"
   else
     log "secrets file present at ${SECRETS_FILE} (preserved)"
+    detect_secrets_schema_version
+  fi
+}
+
+# Read schema-version header. Absent = v0 (legacy); do NOT auto-rewrite.
+# Future v0→v1 migrations should land behind an explicit --upgrade-secrets
+# flag to avoid mutating operator-owned credential files implicitly.
+detect_secrets_schema_version() {
+  local ver
+  ver=$(LC_ALL=C grep -m1 -E '^# expertise-api-secrets-version=' "${SECRETS_FILE}" 2>/dev/null \
+          | sed 's/^# expertise-api-secrets-version=//; s/[^0-9].*//' || true)
+  if [[ -z "${ver}" ]]; then
+    warn "${SECRETS_FILE} predates schema-version header (treating as v0). No action required today; future schema migrations may require manual upgrade."
+  elif [[ "${ver}" != "${SECRETS_SCHEMA_VERSION}" ]]; then
+    warn "${SECRETS_FILE} declares schema version ${ver}; installer expects ${SECRETS_SCHEMA_VERSION}. Inspect appsettings.json for any format change."
   fi
 }
 
 # ---------------------------------------------------------------------------
 # Wrapper script — sources secrets, then exec's dotnet (or native binary)
+# Wrapper lives at ${PREFIX}/launch-expertise-api.sh (NOT in ${BIN_DIR})
+# so the atomic swap of ${BIN_DIR} does not destroy it.
 # ---------------------------------------------------------------------------
 write_wrapper() {
   cat > "${WRAPPER_SCRIPT}.tmp" <<EOF
@@ -244,6 +517,8 @@ write_wrapper() {
 set -euo pipefail
 
 SECRETS_FILE="${SECRETS_FILE}"
+BIN_DIR="${BIN_DIR}"
+
 if [[ -f "\${SECRETS_FILE}" ]]; then
   set -a
   # shellcheck disable=SC1090
@@ -258,30 +533,27 @@ export DOTNET_PRINT_TELEMETRY_MESSAGE=false
 export Onnx__ModelPath="${MODEL_DIR}/model.onnx"
 export Onnx__VocabPath="${MODEL_DIR}/vocab.txt"
 
-if [[ -x "${BIN_DIR}/ExpertiseApi" ]]; then
-  exec "${BIN_DIR}/ExpertiseApi"
+if [[ -x "\${BIN_DIR}/ExpertiseApi" ]]; then
+  exec "\${BIN_DIR}/ExpertiseApi"
 else
-  exec dotnet "${BIN_DIR}/ExpertiseApi.dll"
+  exec dotnet "\${BIN_DIR}/ExpertiseApi.dll"
 fi
 EOF
-  mv "${WRAPPER_SCRIPT}.tmp" "${WRAPPER_SCRIPT}"
+  mv -f -- "${WRAPPER_SCRIPT}.tmp" "${WRAPPER_SCRIPT}"
   chmod 755 "${WRAPPER_SCRIPT}"
   log "wrapper: ${WRAPPER_SCRIPT}"
+  # Remove the legacy in-BIN_DIR wrapper if present (back-compat sweep).
+  if [[ -f "${WRAPPER_LEGACY}" && "${WRAPPER_LEGACY}" != "${WRAPPER_SCRIPT}" ]]; then
+    rm -f -- "${WRAPPER_LEGACY}" 2>/dev/null || true
+  fi
 }
 
 # ---------------------------------------------------------------------------
-# Migrate — apply pending EF Core migrations BEFORE service start (issue #144)
+# Migrate against the STAGED binaries (#223). Failure leaves the live tree
+# untouched; trap cleans the stage dir.
 # ---------------------------------------------------------------------------
-maybe_migrate() {
-  # Conditional, not unconditional. The fresh-install flow generates a
-  # placeholder secrets.env in ensure_config_stubs above, and the operator
-  # can't have filled in the connection string yet — attempting migrate
-  # would always fail with a misleading Npgsql connect timeout. Detect that
-  # case and tell the operator how to recover; do NOT abort install.
-  #
-  # On the upgrade path the secrets file is preserved by ensure_config_stubs
-  # and contains a real connection string, so migrate runs to completion or
-  # fails fatally (correctly aborting the install before service restart).
+run_migrate_staged() {
+  STAGE="migrated"
   local conn=""
   if [[ -f "${SECRETS_FILE}" ]]; then
     # shellcheck disable=SC1090
@@ -295,24 +567,50 @@ maybe_migrate() {
     return 0
   fi
 
-  # Legacy upgrade footgun (PR #157 review): pre-#144 stub examples showed the
-  # connection string UNQUOTED, which under `set -a; . file` gets split on `;`
-  # — the first segment (`Host=127.0.0.1`) becomes the value and the rest
-  # (`Port=5432`, `Database=...`, ...) are exported as separate vars. The
-  # resulting truncated conn passes the non-empty + non-placeholder checks
-  # above but fails to connect, aborting the upgrade with a generic Npgsql
-  # error. Detect the smoking gun (Host= present, no `;` separator, and a
-  # Port= line elsewhere in the file) and surface a remediation-specific
-  # error instead.
+  # Legacy upgrade footgun: pre-#144 stub examples showed the connection
+  # string UNQUOTED, which under `set -a; . file` gets split on `;`. See
+  # PR #157 review for the smoking-gun heuristic.
   if [[ "${conn}" == *Host=* && "${conn}" != *\;* ]] \
       && grep -qE '^[[:space:]]*Port=' "${SECRETS_FILE}" 2>/dev/null; then
     err "detected legacy unquoted ConnectionStrings__DefaultConnection in ${SECRETS_FILE}: the bash sourcer split on ';' and only kept the Host= segment. Wrap the value in double quotes (e.g., ConnectionStrings__DefaultConnection=\"Host=...;Port=...;Database=...;Username=...;Password=...\") and re-run scripts/install.sh."
   fi
 
-  log "running migrate (scripts/migrate.sh — idempotent; no-op when up to date)"
-  if ! "${SCRIPT_DIR}/migrate.sh" --prefix "${PREFIX}" --secrets-file "${SECRETS_FILE}"; then
-    err "migrate failed — service NOT restarted; prior state intact. Inspect the output above, fix the schema/DB issue, then re-run scripts/install.sh."
+  log "running migrate against staged binaries (${STAGE_DIR})"
+  if ! "${SCRIPT_DIR}/migrate.sh" --bin-dir "${STAGE_DIR}" --secrets-file "${SECRETS_FILE}"; then
+    err "migrate failed — live binaries NOT swapped; service NOT restarted; prior state intact. EF migrations are transactional per-migration; retry by fixing the schema/DB issue and re-running scripts/install.sh."
   fi
+}
+
+# ---------------------------------------------------------------------------
+# Atomic swap — two-mv pattern. POSIX rename(2) cannot replace a non-empty
+# directory, so we use:
+#   1. mv ${BIN_DIR}   -> ${OLD_DIR}   (atomic; only if ${BIN_DIR} exists)
+#   2. mv ${STAGE_DIR} -> ${BIN_DIR}   (atomic)
+# We do NOT remove ${OLD_DIR} here — it is the rollback runway for any
+# failure between this swap and final SUCCESS=1 in main() (e.g., a
+# systemd `daemon-reload` or `launchctl bootstrap` failure during
+# install_service). Cleanup of ${OLD_DIR} is deferred to the SUCCESS
+# branch of cleanup() so the rollback path remains valid.
+#
+# There is a small window between (1) and (2) where ${BIN_DIR} does not
+# exist. The running service holds an open fd to its binary inode and is
+# unaffected by the parent-directory rename (POSIX inode-by-handle).
+# ---------------------------------------------------------------------------
+atomic_swap() {
+  # Re-check symlink trap defense immediately before the destructive step.
+  if [[ -L "${BIN_DIR}" ]]; then err "${BIN_DIR} exists as a symlink — refusing to swap"; fi
+  if [[ -L "${STAGE_DIR}" ]]; then err "${STAGE_DIR} exists as a symlink — refusing to swap"; fi
+  if [[ -L "${OLD_DIR}" ]]; then err "${OLD_DIR} exists as a symlink — refusing to swap"; fi
+  # Clean any leftover .old from a prior failed run (steady-state cleanup
+  # also happens in cleanup()'s success branch and at the next swap).
+  if [[ -d "${OLD_DIR}" ]]; then rm -rf -- "${OLD_DIR}"; fi
+
+  if [[ -d "${BIN_DIR}" ]]; then
+    mv -- "${BIN_DIR}" "${OLD_DIR}"
+  fi
+  mv -- "${STAGE_DIR}" "${BIN_DIR}"
+  STAGE="swapped"
+  log "atomic swap: ${STAGE_DIR} -> ${BIN_DIR} (rollback runway preserved at ${OLD_DIR})"
 }
 
 # ---------------------------------------------------------------------------
@@ -334,7 +632,7 @@ install_systemd_user() {
     -e "s|@@SECRETS_FILE@@|${SECRETS_FILE}|g" \
     -e "s|@@LOG_DIR@@|${LOG_DIR}|g" \
     "${tpl}" > "${unit_path}.tmp"
-  mv "${unit_path}.tmp" "${unit_path}"
+  mv -f -- "${unit_path}.tmp" "${unit_path}"
   log "systemd user unit: ${unit_path}"
 
   systemctl --user daemon-reload
@@ -369,7 +667,7 @@ install_launchd() {
     -e "s|@@WORKDIR@@|${PREFIX}|g" \
     -e "s|@@LOG_DIR@@|${LOG_DIR}|g" \
     "${tpl}" > "${plist_path}.tmp"
-  mv "${plist_path}.tmp" "${plist_path}"
+  mv -f -- "${plist_path}.tmp" "${plist_path}"
   log "launchd plist: ${plist_path}"
 
   local domain
@@ -396,16 +694,23 @@ install_service() {
 # Main
 # ---------------------------------------------------------------------------
 main() {
+  acquire_lock
   if (( SKIP_PREFLIGHT == 0 )); then preflight; fi
-  publish_app
-  ensure_models
+  resolve_install_version
   ensure_config_stubs
+  ensure_models
+  publish_app_staged
   write_wrapper
-  maybe_migrate
+  run_migrate_staged
+  atomic_swap
   install_service
+  write_install_version_marker
+  SUCCESS=1
 
   log "install complete"
+  log "  version:  ${NEW_VERSION}"
   log "  binary:   ${BIN_DIR}"
+  log "  wrapper:  ${WRAPPER_SCRIPT}"
   log "  models:   ${MODEL_DIR}"
   log "  config:   ${CONFIG_DIR}"
   log "  logs:     ${LOG_DIR}"

--- a/scripts/lib/prefix-validation.sh
+++ b/scripts/lib/prefix-validation.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# scripts/lib/prefix-validation.sh — shared --prefix safety guard.
+#
+# Sourced by scripts/install.sh and scripts/uninstall.sh. Exposes two
+# functions:
+#
+#   normalize_prefix PATH        — lexical normalization; rejects '..',
+#                                   embedded whitespace, line-end chars.
+#                                   Prints the normalized path on stdout.
+#   validate_prefix  PATH        — runs two-tier blocklist + component
+#                                   check. Errors out via `err` (which
+#                                   the sourcing script must define).
+#
+# Required caller-defined symbols:
+#
+#   err()                       — must exit non-zero with the message
+#   INSTALL_SCOPE               — "user" | "system" (drives symlink trap)
+#   ALLOW_SYSTEM_PREFIX         — 0 | 1 (component check bypass)
+#
+# Design locked 2026-05-22 via shell-expert + security-review pre-review;
+# extracted from scripts/uninstall.sh (PR #243) into a shared library on
+# 2026-05-22 to close the install/uninstall asymmetry surfaced by the
+# PR B (#223) pre-PR security review.
+#
+
+normalize_prefix() {
+  local p="$1"
+  # Reject embedded whitespace / line-ending characters. Most often a CR
+  # smuggled in via a Windows clipboard paste; also catches accidental
+  # tabs and newlines. Bash treats NUL as a string terminator so we do
+  # not need to handle it explicitly.
+  case "$p" in
+    *$'\t'*|*$'\r'*|*$'\n'*) err "--prefix may not contain whitespace or line-ending characters" ;;
+  esac
+  # Reject parent-directory traversal entirely. The four patterns are
+  # exhaustive only because absolute paths are '/'-anchored — if this
+  # helper is ever reused for relative paths, extend accordingly.
+  case "$p" in
+    *"/../"*|*/..|"../"*|"..") err "--prefix may not contain '..'" ;;
+  esac
+  # Collapse runs of slashes.
+  while [[ "$p" == *"//"* ]]; do p="${p//\/\//\/}"; done
+  # Strip trailing slash but never the root.
+  if [[ "$p" != "/" && "$p" == */ ]]; then p="${p%/}"; fi
+  printf '%s\n' "$p"
+}
+
+validate_prefix() {
+  local p="$1"
+  [[ "$p" = /* ]]        || err "--prefix must be an absolute path"
+  [[ "$p" != "/" ]]      || err "--prefix may not be /"
+  [[ "$p" != "$HOME" ]]  || err "--prefix may not be \$HOME ($HOME)"
+
+  # Symlinked prefix is refused in --system mode (TOCTOU defense for
+  # multi-user hosts). User-mode operators owning $HOME do not pay this
+  # cost.
+  if [[ "${INSTALL_SCOPE}" == "system" && -L "$p" ]]; then
+    err "--prefix is a symlink ($p); pass the resolved path explicitly under --system"
+  fi
+
+  # Two-tier blocklist. Always-on, regardless of --allow-system-prefix.
+  local blocked_exact=(
+    /
+    /home /root /Users         # user-home parent containers
+    /opt /usr/local            # common system install parents (descendants allowed)
+    /mnt /media /Volumes /Network  # mount-point parents
+    /tmp /var /usr /srv /run /cores /.vol /host /rootfs  # exact-block; descendants gated by prefix/component checks below
+  )
+  local blocked_prefix=(
+    # POSIX system subtrees
+    /bin /sbin /etc /lib /lib64 /boot /dev /proc /sys
+    # FHS /usr subtrees — /usr/local is the exact-only carve-out above.
+    /usr/bin /usr/sbin /usr/lib /usr/libexec /usr/share /usr/include
+    # FHS /var/lib (canonical writable system-state location; off-limits to us).
+    /var/lib
+    # Immutable squashfs mounts (snap packages).
+    /snap
+    # macOS system subtrees
+    /Library /System /Applications /private
+    # WSL drive mounts (user code goes here, services should not)
+    /mnt/c /mnt/wsl
+    # User fat-finger guards (only meaningful when $HOME is set)
+    "${HOME:+${HOME}/Desktop}"
+    "${HOME:+${HOME}/Documents}"
+  )
+  local b
+  for b in "${blocked_exact[@]}"; do
+    [[ -n "$b" ]] || continue
+    if [[ "$p" == "$b" ]]; then
+      err "--prefix '$p' is a blocked parent/mount path (descendants are allowed; this exact path is not)"
+    fi
+  done
+  for b in "${blocked_prefix[@]}"; do
+    [[ -n "$b" ]] || continue
+    if [[ "$p/" == "$b/"* ]]; then
+      err "--prefix '$p' is under blocked system root '$b' (unconditional; --allow-system-prefix does not relax this)"
+    fi
+  done
+
+  # Component check: defense-in-depth. Bypassable with --allow-system-prefix
+  # for legitimately-named non-default install layouts.
+  if (( ${ALLOW_SYSTEM_PREFIX:-0} == 0 )); then
+    if [[ "/$p/" != *"/expertise-api/"* ]]; then
+      err "--prefix '$p' must contain 'expertise-api' as a path component (or pass --allow-system-prefix to skip this check)"
+    fi
+  fi
+}

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -21,10 +21,13 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: scripts/migrate.sh [--prefix DIR] [--secrets-file FILE]
+Usage: scripts/migrate.sh [--prefix DIR] [--bin-dir DIR] [--secrets-file FILE]
 
 Options:
   --prefix DIR         Install root (default: $HOME/.local/share/expertise-api)
+  --bin-dir DIR        Target binary directory directly (overrides --prefix-derived
+                       ${PREFIX}/bin). Used by install.sh during stage-then-swap
+                       to migrate against the new binaries before they go live.
   --secrets-file FILE  Override path to secrets.env (default: $XDG_CONFIG_HOME/expertise-api/secrets.env)
   -h, --help           Show this help
 
@@ -37,17 +40,23 @@ EOF
 
 PREFIX="${HOME}/.local/share/expertise-api"
 SECRETS_FILE="${XDG_CONFIG_HOME:-${HOME}/.config}/expertise-api/secrets.env"
+BIN_DIR_OVERRIDE=""
 
 while (($#)); do
   case "$1" in
     --prefix)        PREFIX="${2:?--prefix needs a directory}"; shift 2 ;;
     --secrets-file)  SECRETS_FILE="${2:?--secrets-file needs a path}"; shift 2 ;;
+    --bin-dir)       BIN_DIR_OVERRIDE="${2:?--bin-dir needs a directory}"; shift 2 ;;
     -h|--help)       usage; exit 0 ;;
     *)               printf '[migrate] ERROR: unknown arg: %s\n' "$1" >&2; usage >&2; exit 2 ;;
   esac
 done
 
-BIN_DIR="${PREFIX}/bin"
+# --bin-dir takes precedence over --prefix-derived path. Used by
+# install.sh during the publish-staged → migrate-against-staged → swap
+# flow so migrate runs against the new binaries without disturbing
+# the live tree.
+BIN_DIR="${BIN_DIR_OVERRIDE:-${PREFIX}/bin}"
 
 log()  { printf '[migrate] %s\n' "$1"; }
 warn() { printf '[migrate] WARN: %s\n' "$1" >&2; }

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -56,6 +56,9 @@ while [[ $# -gt 0 ]]; do
     *)                      err "unknown flag: $1 (try --help)" ;;
   esac
 done
+# Touch ALLOW_SYSTEM_PREFIX so shellcheck sees it as referenced; the
+# real consumer is scripts/lib/prefix-validation.sh sourced below.
+: "${ALLOW_SYSTEM_PREFIX}"
 
 if (( PURGE == 1 && APPLY == 0 )); then
   err "--purge requires --yes (refusing destructive op without explicit confirmation)"
@@ -71,114 +74,14 @@ esac
 # ----------------------------------------------------------------------------
 # Prefix normalization + validation
 #
-# Design locked 2026-05-22 via shell-expert pre-review. Two key choices:
-#
-#  1. No realpath/readlink -f. Non-portable on macOS, false-secure on
-#     non-existent paths, and resolving symlinks can hide attacks rather
-#     than surface them. Instead: reject '..' components outright, then
-#     lexically collapse '//' and strip trailing slash.
-#
-#  2. Prefix-match blocklist (not exact-match). Exact-match lets
-#     /var/log, /private/var, /mnt/c/Users slip past. With prefix-match,
-#     '/var' blocks every '/var/*' that doesn't carry an expertise-api
-#     path component.
-#
-# --allow-system-prefix relaxes only the component check. The blocklist
-# stays unconditional — it answers a different question (is this path
-# obviously catastrophic?) than the component check (does this look like
-# an expertise-api install?).
+# Implementation lives in scripts/lib/prefix-validation.sh so install.sh
+# and uninstall.sh share the same guard (extracted from this file during
+# PR B / #223 pre-PR review). Required caller-defined symbols:
+#   err(), INSTALL_SCOPE, ALLOW_SYSTEM_PREFIX.
 # ----------------------------------------------------------------------------
 
-normalize_prefix() {
-  local p="$1"
-  # Reject embedded whitespace / line-ending characters. Most often a CR
-  # smuggled in via a Windows clipboard paste; also catches accidental
-  # tabs and newlines. Bash treats NUL as a string terminator so we do
-  # not need to handle it explicitly.
-  case "$p" in
-    *$'\t'*|*$'\r'*|*$'\n'*) err "--prefix may not contain whitespace or line-ending characters" ;;
-  esac
-  # Reject parent-directory traversal entirely. The four patterns are
-  # exhaustive only because absolute paths are '/'-anchored — if this
-  # helper is ever reused for relative paths, extend accordingly.
-  case "$p" in
-    *"/../"*|*/..|"../"*|"..") err "--prefix may not contain '..'" ;;
-  esac
-  # Collapse runs of slashes.
-  while [[ "$p" == *"//"* ]]; do p="${p//\/\//\/}"; done
-  # Strip trailing slash but never the root.
-  if [[ "$p" != "/" && "$p" == */ ]]; then p="${p%/}"; fi
-  printf '%s\n' "$p"
-}
-
-validate_prefix() {
-  local p="$1"
-  [[ "$p" = /* ]]      || err "--prefix must be an absolute path"
-  [[ "$p" != "/" ]]    || err "--prefix may not be /"
-  [[ "$p" != "$HOME" ]] || err "--prefix may not be \$HOME ($HOME)"
-
-  # Symlinked prefix is refused in --system mode (TOCTOU defense for
-  # multi-user hosts). User-mode operators owning $HOME do not pay this
-  # cost.
-  if [[ "${INSTALL_SCOPE}" == "system" && -L "$p" ]]; then
-    err "--prefix is a symlink ($p); pass the resolved path explicitly under --system"
-  fi
-
-  # Two-tier blocklist. Always-on, regardless of --allow-system-prefix.
-  #
-  #   blocked_exact   = parent containers / mount points. Block the bare dir
-  #                     itself but allow descendants (e.g. /Users is rejected
-  #                     but /Users/me/path is fine — every macOS HOME lives
-  #                     under /Users, so a prefix-match here would block all
-  #                     legitimate user installs).
-  #   blocked_prefix  = catastrophic system subtrees where nothing under the
-  #                     root is a sane install target (/bin, /etc, /System...).
-  local blocked_exact=(
-    /
-    /home /root /Users         # user-home parent containers
-    /opt /usr/local            # common system install parents (descendants allowed)
-    /mnt /media /Volumes /Network  # mount-point parents
-    /tmp /var /usr /srv /run /cores /.vol /host /rootfs  # exact-block; descendants gated by prefix/component checks below
-  )
-  local blocked_prefix=(
-    # POSIX system subtrees
-    /bin /sbin /etc /lib /lib64 /boot /dev /proc /sys
-    # FHS /usr subtrees — /usr/local is the exact-only carve-out above.
-    /usr/bin /usr/sbin /usr/lib /usr/libexec /usr/share /usr/include
-    # FHS /var/lib (canonical writable system-state location; off-limits to us).
-    /var/lib
-    # Immutable squashfs mounts (snap packages).
-    /snap
-    # macOS system subtrees
-    /Library /System /Applications /private
-    # WSL drive mounts (user code goes here, services should not)
-    /mnt/c /mnt/wsl
-    # User fat-finger guards (only meaningful when $HOME is set)
-    "${HOME:+${HOME}/Desktop}"
-    "${HOME:+${HOME}/Documents}"
-  )
-  local b
-  for b in "${blocked_exact[@]}"; do
-    [[ -n "$b" ]] || continue
-    if [[ "$p" == "$b" ]]; then
-      err "--prefix '$p' is a blocked parent/mount path (descendants are allowed; this exact path is not)"
-    fi
-  done
-  for b in "${blocked_prefix[@]}"; do
-    [[ -n "$b" ]] || continue
-    if [[ "$p/" == "$b/"* ]]; then
-      err "--prefix '$p' is under blocked system root '$b' (unconditional; --allow-system-prefix does not relax this)"
-    fi
-  done
-
-  # Component check: defense-in-depth. Bypassable with --allow-system-prefix
-  # for legitimately-named non-default install layouts.
-  if (( ALLOW_SYSTEM_PREFIX == 0 )); then
-    if [[ "/$p/" != *"/expertise-api/"* ]]; then
-      err "--prefix '$p' must contain 'expertise-api' as a path component (or pass --allow-system-prefix to skip this check)"
-    fi
-  fi
-}
+# shellcheck source=lib/prefix-validation.sh disable=SC1091
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/prefix-validation.sh"
 
 if [[ -n "${PREFIX_OVERRIDE}" ]]; then
   PREFIX_OVERRIDE="$(normalize_prefix "${PREFIX_OVERRIDE}")"
@@ -297,6 +200,9 @@ esac
 do_action rm -rf "${BIN_DIR}"
 
 # Wrapper script (idempotent under `-f`).
+# Wrapper script (idempotent under `-f`). Cover both the post-#223 location
+# (${PREFIX}/launch-expertise-api.sh) and the legacy in-BIN_DIR location.
+do_action rm -f "${PREFIX}/launch-expertise-api.sh"
 do_action rm -f "${PREFIX}/bin/launch-expertise-api.sh"
 
 if (( PURGE == 1 )); then

--- a/tests/install/test-crlf-detector.sh
+++ b/tests/install/test-crlf-detector.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# test-crlf-detector.sh — exercise scripts/install.sh's secrets.env CRLF
+# detector (issue #223). The detector lives in preflight() so we drive the
+# script with --skip-preflight off and stub everything that would otherwise
+# require a working environment (dotnet, lsof/nc, mkdir into ${PREFIX}).
+#
+# We do NOT execute install.sh end-to-end here; we extract and exercise the
+# detector function in isolation by sourcing it under controlled conditions.
+# The full install path is covered by test-upgrade-roundtrip.sh.
+#
+
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/../.." && pwd)/scripts/install.sh"
+[[ -x "${SCRIPT}" ]] || { echo "FAIL: install.sh missing"; exit 2; }
+
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/install-crlf.XXXXXX")"
+trap 'rm -rf "${SCRATCH}"' EXIT
+
+PASS=0
+FAIL=0
+
+# ---------------------------------------------------------------------------
+# Helpers — source install.sh's detector under a controlled SECRETS_FILE.
+# install.sh has a `main "$@"` trailer that would fire on sourcing, so we
+# extract only the two functions we need.
+# ---------------------------------------------------------------------------
+detector_lib="${SCRATCH}/detector.sh"
+awk '
+  /^check_secrets_line_endings\(\)/,/^}$/  { print; next }
+  /^fix_secrets_line_endings\(\)/,/^}$/    { print; next }
+' "${SCRIPT}" > "${detector_lib}"
+
+# Stub log/warn/err for sourcing context.
+cat > "${SCRATCH}/stubs.sh" <<'EOF'
+log()  { printf '[detector] %s\n' "$1"; }
+warn() { printf '[detector] WARN: %s\n' "$1" >&2; }
+err()  { printf '[detector] ERROR: %s\n' "$1" >&2; return 1; }
+FIX_LINE_ENDINGS=0
+EOF
+
+run_detector() {
+  ( set +e
+    # shellcheck disable=SC1090,SC1091
+    . "${SCRATCH}/stubs.sh"
+    # shellcheck disable=SC1090,SC1091
+    . "${detector_lib}"
+    SECRETS_FILE="$1" FIX_LINE_ENDINGS="${2:-0}" check_secrets_line_endings
+    echo "rc=$?"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: no secrets file → no-op success
+# ---------------------------------------------------------------------------
+out=$(run_detector "${SCRATCH}/nonexistent")
+if [[ "${out}" == *"rc=0"* ]]; then
+  PASS=$((PASS+1))
+else
+  printf 'FAIL: missing secrets file should be no-op (got: %s)\n' "${out}" >&2
+  FAIL=$((FAIL+1))
+fi
+
+# ---------------------------------------------------------------------------
+# Case 2: LF-only secrets file → success
+# ---------------------------------------------------------------------------
+lf_file="${SCRATCH}/secrets-lf.env"
+printf 'ConnectionStrings__DefaultConnection="Host=localhost"\n# comment\n' > "${lf_file}"
+chmod 600 "${lf_file}"
+out=$(run_detector "${lf_file}")
+if [[ "${out}" == *"rc=0"* ]]; then
+  PASS=$((PASS+1))
+else
+  printf 'FAIL: LF-only file should pass (got: %s)\n' "${out}" >&2
+  FAIL=$((FAIL+1))
+fi
+
+# ---------------------------------------------------------------------------
+# Case 3: CRLF without --fix-line-endings → fail with line number, no leak
+# ---------------------------------------------------------------------------
+crlf_file="${SCRATCH}/secrets-crlf.env"
+printf '# header\r\nConnectionStrings__DefaultConnection="Host=localhost;Password=SECRET_TOKEN_DO_NOT_LEAK"\r\n' > "${crlf_file}"
+chmod 600 "${crlf_file}"
+
+out=$(run_detector "${crlf_file}" 0 2>&1)
+if [[ "${out}" == *"CRLF line endings detected"* ]] \
+   && [[ "${out}" == *":1"* || "${out}" == *":2"* ]] \
+   && [[ "${out}" != *"SECRET_TOKEN_DO_NOT_LEAK"* ]] \
+   && [[ "${out}" == *"rc=1"* ]]; then
+  PASS=$((PASS+1))
+else
+  printf 'FAIL: CRLF detector should fail with line number and no value leak. Got:\n%s\n' "${out}" >&2
+  FAIL=$((FAIL+1))
+fi
+
+# ---------------------------------------------------------------------------
+# Case 4: CRLF with --fix-line-endings → fixed in place, mode 600 preserved
+# ---------------------------------------------------------------------------
+fix_file="${SCRATCH}/secrets-fix.env"
+printf 'A=1\r\nB=2\r\n' > "${fix_file}"
+chmod 600 "${fix_file}"
+out=$(run_detector "${fix_file}" 1 2>&1)
+if [[ "${out}" == *"rc=0"* ]] && ! LC_ALL=C grep -q $'\r' "${fix_file}"; then
+  PASS=$((PASS+1))
+else
+  printf 'FAIL: --fix-line-endings should strip CR and exit 0. Got:\n%s\nFile bytes:\n' "${out}" >&2
+  od -c "${fix_file}" | head -3 >&2
+  FAIL=$((FAIL+1))
+fi
+
+# Mode 600 preserved?
+if [[ "$(stat -f '%Lp' "${fix_file}" 2>/dev/null || stat -c '%a' "${fix_file}")" == "600" ]]; then
+  PASS=$((PASS+1))
+else
+  printf 'FAIL: --fix-line-endings did not preserve mode 600 (got: %s)\n' \
+    "$(stat -f '%Lp' "${fix_file}" 2>/dev/null || stat -c '%a' "${fix_file}")" >&2
+  FAIL=$((FAIL+1))
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+TOTAL=$((PASS+FAIL))
+: "${TOTAL:?}"  # silence SC2034
+printf '\n[test-crlf-detector] %d passed, %d failed\n' "${PASS}" "${FAIL}"
+if (( FAIL > 0 )); then
+  printf 'FAIL — %d errors, 0 warnings\n' "${FAIL}"
+  exit 1
+fi
+printf 'PASS — 0 errors, 0 warnings\n'
+exit 0

--- a/tests/install/test-upgrade-roundtrip.sh
+++ b/tests/install/test-upgrade-roundtrip.sh
@@ -1,0 +1,432 @@
+#!/usr/bin/env bash
+#
+# test-upgrade-roundtrip.sh — exercise install.sh's stage-then-swap
+# atomicity and rollback (issue #223). Drives install.sh end-to-end with
+# PATH-shimmed dotnet, systemctl, launchctl, and migrate.sh so the test
+# requires neither .NET nor a real service manager.
+#
+# Cases:
+#   1. Fresh install                            — STAGE_DIR created, swap
+#      to BIN_DIR, version marker written, wrapper at ${PREFIX}/, no .old
+#      leftover.
+#   2. No-op reinstall                          — same version, swap still
+#      runs, no errors, marker unchanged.
+#   3. Upgrade (different version marker source)— logs "upgrade X -> Y".
+#   4. Publish failure                          — STAGE_DIR cleaned, live
+#      BIN_DIR untouched, exit non-zero.
+#   5. Migrate failure                          — STAGE_DIR cleaned, live
+#      BIN_DIR untouched, exit non-zero.
+#   6. Concurrent install                       — second invocation fails
+#      fast with "another install in progress".
+#   7. Symlink-trap                             — STAGE_DIR pre-created as
+#      symlink, install refuses.
+#   8. Wrapper survives swap                    — wrapper path lives at
+#      ${PREFIX}/launch-expertise-api.sh and is preserved across swap.
+#
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="${REPO_ROOT}/scripts/install.sh"
+[[ -x "${SCRIPT}" ]] || { echo "PRECONDITION_FAILURE: install.sh missing"; exit 2; }
+
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/install-roundtrip.XXXXXX")"
+SHIM_DIR="${SCRATCH}/shims"
+mkdir -p "${SHIM_DIR}"
+
+trap 'rm -rf "${SCRATCH}"' EXIT
+
+PASS=0
+FAIL=0
+
+# ---------------------------------------------------------------------------
+# Shims — drop ahead of PATH so install.sh sees fake dotnet/systemctl/etc.
+#
+# dotnet:    matches `--list-runtimes` and `publish`.
+# launchctl: no-op (record args).
+# systemctl: list-unit-files reports unconfigured; daemon-reload + enable
+#            + restart are no-ops.
+# nc, lsof:  exit nonzero (skip-friendly).
+# ---------------------------------------------------------------------------
+mk_shim() { local name="$1"; cat > "${SHIM_DIR}/${name}"; chmod +x "${SHIM_DIR}/${name}"; }
+
+mk_shim dotnet <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  --list-runtimes) printf 'Microsoft.AspNetCore.App 10.0.0 [%s]\n' "${ASPNETCORE_PATH:-/x}"; exit 0 ;;
+  --info)          printf 'fake-sdk\n'; exit 0 ;;
+  publish)
+    if [[ "${FAIL_PUBLISH:-0}" == "1" ]]; then
+      printf 'dotnet publish: simulated failure\n' >&2
+      exit 1
+    fi
+    # Find the --output argument
+    out=""
+    while (($#)); do [[ "$1" == "--output" ]] && { out="$2"; break; }; shift; done
+    [[ -n "${out}" ]] || { echo "fake dotnet publish: no --output" >&2; exit 1; }
+    mkdir -p "${out}"
+    : > "${out}/ExpertiseApi.dll"
+    printf '#!/usr/bin/env bash\necho fake-binary\n' > "${out}/ExpertiseApi"
+    chmod +x "${out}/ExpertiseApi"
+    exit 0
+    ;;
+esac
+exit 0
+EOF
+
+mk_shim launchctl <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+mk_shim systemctl <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  --user)
+    shift
+    case "$1" in
+      list-unit-files) exit 1 ;;   # "not installed"
+      daemon-reload|enable|restart) exit 0 ;;
+      is-enabled) exit 1 ;;
+    esac
+    ;;
+esac
+exit 0
+EOF
+
+mk_shim loginctl <<'EOF'
+#!/usr/bin/env bash
+printf 'Linger=yes\n'
+EOF
+
+# nc and lsof: pretend nothing is listening / not present
+mk_shim nc <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+
+# ---------------------------------------------------------------------------
+# A stub migrate.sh that just respects FAIL_MIGRATE — install.sh calls the
+# repo's real migrate.sh by SCRIPT_DIR, but that real script tries to source
+# the connection from secrets.env and exec the (fake) binary. The fake
+# binary above is a no-op shell script, so a "valid" connection passes
+# trivially. For the FAIL_MIGRATE case we override migrate.sh via a shim
+# also placed in PATH and invoked through install.sh's hard-coded
+# ${SCRIPT_DIR}/migrate.sh path. To do that we replace SCRIPT_DIR's
+# migrate.sh path via env override is not supported — so we use a
+# subshell-local copy of install.sh's SCRIPT_DIR-derived call: we point
+# install.sh at a temporary scripts/ directory that contains symlinks to
+# the real install.sh and download-models.sh, plus our overridable
+# migrate.sh.
+# ---------------------------------------------------------------------------
+ALT_SCRIPTS="${SCRATCH}/scripts"
+mkdir -p "${ALT_SCRIPTS}/service-templates"
+ln -sf "${REPO_ROOT}/scripts/download-models.sh" "${ALT_SCRIPTS}/download-models.sh"
+mkdir -p "${ALT_SCRIPTS}/lib"
+ln -sf "${REPO_ROOT}/scripts/lib/prefix-validation.sh" "${ALT_SCRIPTS}/lib/prefix-validation.sh"
+ln -sf "${REPO_ROOT}/scripts/service-templates/expertise-api.plist.tmpl"   "${ALT_SCRIPTS}/service-templates/expertise-api.plist.tmpl"
+ln -sf "${REPO_ROOT}/scripts/service-templates/expertise-api.service.tmpl" "${ALT_SCRIPTS}/service-templates/expertise-api.service.tmpl"
+
+# Copy install.sh verbatim (so ${BASH_SOURCE[0]} resolves SCRIPT_DIR to
+# ALT_SCRIPTS) and override the REPO_ROOT derivation to point at the real
+# repo so publish output paths still find sources.
+sed "s|REPO_ROOT=\"\$(cd \"\${SCRIPT_DIR}/..\" && pwd)\"|REPO_ROOT=\"${REPO_ROOT}\"|" \
+  "${SCRIPT}" > "${ALT_SCRIPTS}/install.sh"
+chmod +x "${ALT_SCRIPTS}/install.sh"
+INSTALL="${ALT_SCRIPTS}/install.sh"
+
+# Overridable migrate.sh
+write_migrate_stub() {
+  local fail="${1:-0}"
+  cat > "${ALT_SCRIPTS}/migrate.sh" <<EOF
+#!/usr/bin/env bash
+if [[ "${fail}" == "1" ]]; then
+  printf 'migrate: simulated failure\n' >&2
+  exit 1
+fi
+exit 0
+EOF
+  chmod +x "${ALT_SCRIPTS}/migrate.sh"
+}
+write_migrate_stub 0
+
+# A dummy models dir so ensure_models is a no-op
+seed_models() {
+  local prefix="$1"
+  mkdir -p "${prefix}/models"
+  : > "${prefix}/models/model.onnx"
+  : > "${prefix}/models/vocab.txt"
+}
+
+# Pre-set a valid-looking secrets file (LF, real-shaped connstring)
+seed_secrets() {
+  local config_dir="$1"
+  mkdir -p "${config_dir}"
+  cat > "${config_dir}/secrets.env" <<EOF
+# expertise-api-secrets-version=1
+ConnectionStrings__DefaultConnection="Host=127.0.0.1;Port=5432;Database=expertise;Username=expertise;Password=valid"
+EOF
+  chmod 600 "${config_dir}/secrets.env"
+}
+
+# Common install env. With --prefix, install.sh co-locates CONFIG_DIR
+# and LOG_DIR under PREFIX, so per-case config/log paths are ignored
+# (kept as positional args for documentation only).
+run_install() {
+  local prefix="$1"; shift
+  shift  # _config_dir (unused under --prefix layout)
+  shift  # _log_dir   (unused under --prefix layout)
+  PATH="${SHIM_DIR}:${PATH}" \
+  HOME="${SCRATCH}/home" \
+  FAIL_PUBLISH="${FAIL_PUBLISH:-0}" \
+  "${INSTALL}" --prefix "${prefix}" --allow-system-prefix --skip-preflight --publish-mode fdd "$@"
+}
+
+mkdir -p "${SCRATCH}/home"
+
+assert() {
+  local desc="$1"; shift
+  if "$@"; then PASS=$((PASS+1));
+  else printf 'FAIL: %s\n' "${desc}" >&2; FAIL=$((FAIL+1))
+  fi
+}
+
+# ===========================================================================
+# Case 1: Fresh install — full happy path
+# ===========================================================================
+PREFIX1="${SCRATCH}/c1/prefix"
+CONFIG1="${PREFIX1}"        # install.sh co-locates CONFIG_DIR=${PREFIX} under --prefix
+LOG1="${PREFIX1}/logs"
+mkdir -p "${PREFIX1}"
+seed_models "${PREFIX1}"
+seed_secrets "${CONFIG1}"
+write_migrate_stub 0
+
+if run_install "${PREFIX1}" "${CONFIG1}" "${LOG1}" >"${SCRATCH}/c1.log" 2>&1; then
+  assert "c1: BIN_DIR populated"        [ -f "${PREFIX1}/bin/ExpertiseApi.dll" ]
+  assert "c1: wrapper at PREFIX root"   [ -x "${PREFIX1}/launch-expertise-api.sh" ]
+  assert "c1: wrapper NOT in BIN_DIR"   [ ! -e "${PREFIX1}/bin/launch-expertise-api.sh" ]
+  assert "c1: version marker written"   [ -s "${PREFIX1}/.install-version" ]
+  assert "c1: no .new leftover"         [ ! -e "${PREFIX1}/bin.new" ]
+  assert "c1: no .old leftover"         [ ! -e "${PREFIX1}/bin.old" ]
+  assert "c1: lock released"            [ ! -e "${PREFIX1}/.install.lock" ]
+else
+  printf 'FAIL: c1 fresh install exited non-zero. Log:\n' >&2
+  cat "${SCRATCH}/c1.log" >&2
+  FAIL=$((FAIL+7))
+fi
+
+# ===========================================================================
+# Case 2: No-op reinstall — second run on the same PREFIX
+# ===========================================================================
+if run_install "${PREFIX1}" "${CONFIG1}" "${LOG1}" >"${SCRATCH}/c2.log" 2>&1; then
+  assert "c2: BIN_DIR still populated"  [ -f "${PREFIX1}/bin/ExpertiseApi.dll" ]
+  assert "c2: no .new leftover"         [ ! -e "${PREFIX1}/bin.new" ]
+  assert "c2: no .old leftover"         [ ! -e "${PREFIX1}/bin.old" ]
+  # Reinstall message in log
+  if grep -q 'version: reinstall' "${SCRATCH}/c2.log"; then
+    PASS=$((PASS+1))
+  else
+    printf 'FAIL: c2 should log "version: reinstall"\n' >&2; FAIL=$((FAIL+1))
+  fi
+else
+  printf 'FAIL: c2 reinstall exited non-zero. Log:\n' >&2
+  cat "${SCRATCH}/c2.log" >&2
+  FAIL=$((FAIL+4))
+fi
+
+# ===========================================================================
+# Case 3: Upgrade — bump marker manually to simulate an older install
+# ===========================================================================
+printf 'v0.0.1-old\n' > "${PREFIX1}/.install-version"
+if run_install "${PREFIX1}" "${CONFIG1}" "${LOG1}" >"${SCRATCH}/c3.log" 2>&1; then
+  if grep -qE 'version: upgrade v0\.0\.1-old -> ' "${SCRATCH}/c3.log"; then
+    PASS=$((PASS+1))
+  else
+    printf 'FAIL: c3 should log "version: upgrade v0.0.1-old -> <new>". Log:\n' >&2
+    grep version "${SCRATCH}/c3.log" >&2
+    FAIL=$((FAIL+1))
+  fi
+else
+  printf 'FAIL: c3 upgrade exited non-zero\n' >&2; FAIL=$((FAIL+1))
+fi
+
+# ===========================================================================
+# Case 4: Publish failure — STAGE_DIR cleaned, live tree intact
+# ===========================================================================
+PREFIX4="${SCRATCH}/c4/prefix"
+CONFIG4="${PREFIX4}"
+LOG4="${PREFIX4}/logs"
+mkdir -p "${PREFIX4}"
+# First a successful install so the live BIN_DIR exists
+seed_models "${PREFIX4}"
+seed_secrets "${CONFIG4}"
+write_migrate_stub 0
+run_install "${PREFIX4}" "${CONFIG4}" "${LOG4}" >/dev/null 2>&1 || { echo "c4 setup failed"; FAIL=$((FAIL+1)); }
+# Take a fingerprint of the live binary
+fp_before=$(cat "${PREFIX4}/bin/ExpertiseApi.dll" 2>/dev/null | md5sum 2>/dev/null || cat "${PREFIX4}/bin/ExpertiseApi.dll" | md5)
+
+# Now simulate publish failure
+FAIL_PUBLISH=1 run_install "${PREFIX4}" "${CONFIG4}" "${LOG4}" >"${SCRATCH}/c4.log" 2>&1
+rc=$?
+unset FAIL_PUBLISH
+assert "c4: install exited non-zero on publish fail" [ "${rc}" -ne 0 ]
+assert "c4: STAGE_DIR cleaned"   [ ! -e "${PREFIX4}/bin.new" ]
+assert "c4: live BIN_DIR present" [ -f "${PREFIX4}/bin/ExpertiseApi.dll" ]
+assert "c4: lock released"        [ ! -e "${PREFIX4}/.install.lock" ]
+fp_after=$(cat "${PREFIX4}/bin/ExpertiseApi.dll" 2>/dev/null | md5sum 2>/dev/null || cat "${PREFIX4}/bin/ExpertiseApi.dll" | md5)
+assert "c4: live binary unchanged" [ "${fp_before}" = "${fp_after}" ]
+
+# ===========================================================================
+# Case 5: Migrate failure — STAGE_DIR cleaned, live tree intact
+# ===========================================================================
+PREFIX5="${SCRATCH}/c5/prefix"
+CONFIG5="${PREFIX5}"
+LOG5="${PREFIX5}/logs"
+mkdir -p "${PREFIX5}"
+seed_models "${PREFIX5}"
+seed_secrets "${CONFIG5}"
+write_migrate_stub 0
+run_install "${PREFIX5}" "${CONFIG5}" "${LOG5}" >/dev/null 2>&1 || { echo "c5 setup failed"; FAIL=$((FAIL+1)); }
+fp5_before=$(cat "${PREFIX5}/bin/ExpertiseApi.dll" 2>/dev/null | md5sum 2>/dev/null || cat "${PREFIX5}/bin/ExpertiseApi.dll" | md5)
+
+write_migrate_stub 1
+run_install "${PREFIX5}" "${CONFIG5}" "${LOG5}" >"${SCRATCH}/c5.log" 2>&1
+rc=$?
+write_migrate_stub 0
+if [[ "${rc}" -eq 0 ]]; then
+  printf 'c5 DEBUG log:\n'
+  cat "${SCRATCH}/c5.log"
+fi
+assert "c5: install exited non-zero on migrate fail" [ "${rc}" -ne 0 ]
+assert "c5: STAGE_DIR cleaned"    [ ! -e "${PREFIX5}/bin.new" ]
+assert "c5: live BIN_DIR present" [ -f "${PREFIX5}/bin/ExpertiseApi.dll" ]
+fp5_after=$(cat "${PREFIX5}/bin/ExpertiseApi.dll" 2>/dev/null | md5sum 2>/dev/null || cat "${PREFIX5}/bin/ExpertiseApi.dll" | md5)
+assert "c5: live binary unchanged" [ "${fp5_before}" = "${fp5_after}" ]
+
+# ===========================================================================
+# Case 6: Concurrent install — second run blocked
+# ===========================================================================
+PREFIX6="${SCRATCH}/c6/prefix"
+mkdir -p "${PREFIX6}/.install.lock"
+out=$(run_install "${PREFIX6}" "${PREFIX6}" "${PREFIX6}/logs" 2>&1)
+rc=$?
+rmdir "${PREFIX6}/.install.lock" 2>/dev/null || true
+assert "c6: concurrent install rejected" [ "${rc}" -ne 0 ]
+if [[ "${out}" == *"another install in progress"* ]]; then PASS=$((PASS+1));
+else printf 'FAIL: c6 expected "another install in progress", got:\n%s\n' "${out}" >&2; FAIL=$((FAIL+1)); fi
+
+# ===========================================================================
+# Case 7: Symlink-trap — STAGE_DIR pre-created as symlink
+# ===========================================================================
+PREFIX7="${SCRATCH}/c7/prefix"
+CONFIG7="${PREFIX7}"
+LOG7="${PREFIX7}/logs"
+mkdir -p "${PREFIX7}"
+seed_models "${PREFIX7}"
+seed_secrets "${CONFIG7}"
+mkdir -p "${PREFIX7}"
+ln -s /tmp "${PREFIX7}/bin.new"
+out=$(run_install "${PREFIX7}" "${CONFIG7}" "${LOG7}" 2>&1)
+rc=$?
+rm -f "${PREFIX7}/bin.new"
+assert "c7: symlink staging rejected" [ "${rc}" -ne 0 ]
+if [[ "${out}" == *"symlink"* ]]; then PASS=$((PASS+1));
+else printf 'FAIL: c7 expected symlink rejection. Got:\n%s\n' "${out}" >&2; FAIL=$((FAIL+1)); fi
+
+# ===========================================================================
+# Case 8: Wrapper survives binary swap
+# ===========================================================================
+PREFIX8="${SCRATCH}/c8/prefix"
+CONFIG8="${PREFIX8}"
+LOG8="${PREFIX8}/logs"
+mkdir -p "${PREFIX8}"
+seed_models "${PREFIX8}"
+seed_secrets "${CONFIG8}"
+write_migrate_stub 0
+run_install "${PREFIX8}" "${CONFIG8}" "${LOG8}" >/dev/null 2>&1 || { echo "c8 setup failed"; FAIL=$((FAIL+1)); }
+wrapper_inode_before=$(stat -f '%i' "${PREFIX8}/launch-expertise-api.sh" 2>/dev/null \
+  || stat -c '%i' "${PREFIX8}/launch-expertise-api.sh" 2>/dev/null)
+run_install "${PREFIX8}" "${CONFIG8}" "${LOG8}" >"${SCRATCH}/c8.log" 2>&1
+rc=$?
+assert "c8: second install succeeded"        [ "${rc}" -eq 0 ]
+assert "c8: wrapper still at PREFIX root"    [ -x "${PREFIX8}/launch-expertise-api.sh" ]
+assert "c8: wrapper not in BIN_DIR"          [ ! -e "${PREFIX8}/bin/launch-expertise-api.sh" ]
+wrapper_inode_after=$(stat -f '%i' "${PREFIX8}/launch-expertise-api.sh" 2>/dev/null \
+  || stat -c '%i' "${PREFIX8}/launch-expertise-api.sh" 2>/dev/null)
+# Wrapper is regenerated each run (write_wrapper does mv tmp -> dst), so
+# the inode may legitimately change. The invariant we care about is that
+# the wrapper PATH still resolves to an executable file after swap.
+assert "c8: wrapper inode is real before and after" test -n "${wrapper_inode_before}${wrapper_inode_after}"
+
+# ===========================================================================
+# Case 9: Post-swap rollback runway is preserved
+#
+# After the redesign fix for shell-expert M1: ${BIN_DIR}.old must still
+# exist between atomic_swap and the SUCCESS=1 line in main(). We can
+# observe this indirectly by checking that a successful install removes
+# the .old (steady-state cleanup happens in the SUCCESS branch of the
+# trap, not inside atomic_swap).
+# ===========================================================================
+PREFIX9="${SCRATCH}/c9/prefix"
+CONFIG9="${PREFIX9}"
+LOG9="${PREFIX9}/logs"
+mkdir -p "${PREFIX9}"
+seed_models "${PREFIX9}"
+seed_secrets "${CONFIG9}"
+write_migrate_stub 0
+run_install "${PREFIX9}" "${CONFIG9}" "${LOG9}" >/dev/null 2>&1 || { echo "c9 first install failed"; FAIL=$((FAIL+1)); }
+run_install "${PREFIX9}" "${CONFIG9}" "${LOG9}" >"${SCRATCH}/c9.log" 2>&1
+rc=$?
+assert "c9: second install succeeded"  [ "${rc}" -eq 0 ]
+assert "c9: .old cleaned on success"   [ ! -e "${PREFIX9}/bin.old" ]
+assert "c9: .new cleaned on success"   [ ! -e "${PREFIX9}/bin.new" ]
+assert "c9: lock released"             [ ! -e "${PREFIX9}/.install.lock" ]
+
+# ===========================================================================
+# Case 10: --prefix validation now rejects catastrophic paths (parity with uninstall.sh)
+# ===========================================================================
+out=$(PATH="${SHIM_DIR}:${PATH}" HOME="${SCRATCH}/home" \
+  "${INSTALL}" --prefix "/etc/expertise-api" --skip-preflight --publish-mode fdd 2>&1)
+rc=$?
+assert "c10a: install rejects --prefix /etc/expertise-api" [ "${rc}" -ne 0 ]
+if [[ "${out}" == *"blocked"* ]]; then PASS=$((PASS+1)); else printf 'FAIL: c10a expected block message. Got:\n%s\n' "${out}" >&2; FAIL=$((FAIL+1)); fi
+
+out=$(PATH="${SHIM_DIR}:${PATH}" HOME="${SCRATCH}/home" \
+  "${INSTALL}" --prefix "/" --skip-preflight --publish-mode fdd 2>&1)
+rc=$?
+assert "c10b: install rejects --prefix /" [ "${rc}" -ne 0 ]
+
+out=$(PATH="${SHIM_DIR}:${PATH}" HOME="${SCRATCH}/home" \
+  "${INSTALL}" --prefix "/Users/foo/notexpertise" --skip-preflight --publish-mode fdd 2>&1)
+rc=$?
+assert "c10c: install rejects prefix missing expertise-api component (no --allow-system-prefix)" [ "${rc}" -ne 0 ]
+
+# ===========================================================================
+# Case 11: VERSION_MARKER symlink-trap defense
+# ===========================================================================
+PREFIX11="${SCRATCH}/c11/prefix"
+CONFIG11="${PREFIX11}"
+LOG11="${PREFIX11}/logs"
+mkdir -p "${PREFIX11}"
+seed_models "${PREFIX11}"
+seed_secrets "${CONFIG11}"
+write_migrate_stub 0
+ln -s /etc/hostname "${PREFIX11}/.install-version"
+out=$(run_install "${PREFIX11}" "${CONFIG11}" "${LOG11}" 2>&1)
+rc=$?
+rm -f "${PREFIX11}/.install-version"
+assert "c11: install rejects symlinked version marker" [ "${rc}" -ne 0 ]
+if [[ "${out}" == *"symlink"* ]]; then PASS=$((PASS+1)); else printf 'FAIL: c11 expected symlink rejection. Got:\n%s\n' "${out}" >&2; FAIL=$((FAIL+1)); fi
+
+# ===========================================================================
+# Summary
+# ===========================================================================
+TOTAL=$((PASS+FAIL))
+printf '\n[test-upgrade-roundtrip] %d passed, %d failed (of %d)\n' "${PASS}" "${FAIL}" "${TOTAL}"
+if (( FAIL > 0 )); then
+  printf 'FAIL — %d errors, 0 warnings\n' "${FAIL}"
+  exit 1
+fi
+printf 'PASS — 0 errors, 0 warnings\n'
+exit 0


### PR DESCRIPTION
## Summary

Hardens `scripts/install.sh` against upgrade-time footguns. The pre-rewrite installer wrote publish output directly into `${BIN_DIR}`, ran migrate after the binaries were already live, and silently crashed under `set -u` when `--prefix` was supplied. This PR introduces:

- **Atomic stage-then-swap.** Publish to `${BIN_DIR}.new`, migrate against the *staged* binaries (`scripts/migrate.sh --bin-dir`), only swap to `${BIN_DIR}` on migrate success. The redesign came from a pre-design fan-out (shell-expert + security-review-expert + dotnet-expert), where dotnet-expert pointed out that `migrate.sh` exec's the published binary's `migrate` verb (not `dotnet ef`), making the safer ordering obvious.
- **Trap-based cleanup with rollback runway.** Single `cleanup()` function branches on a `STAGE` variable (`init` / `preflight` / `version` / `models` / `config` / `staged` / `migrated` / `swapped` / `done`). Post-swap failures restore from `${BIN_DIR}.old`; pre-swap failures drop `${BIN_DIR}.new`. `OLD_DIR` cleanup is deferred to the SUCCESS branch so the rollback path is reachable through `install_service` and `write_install_version_marker`.
- **Wrapper relocated to `${PREFIX}/launch-expertise-api.sh`** (out of `${BIN_DIR}`) so it survives binary swaps. Service templates already use `@@WRAPPER@@` substitution and adapt. Legacy in-`BIN_DIR` wrapper swept for back-compat.
- **`${PREFIX}/.install-version` marker** via `git describe --tags --always --dirty` sanitized through `LC_ALL=C tr -cd '[:alnum:]._+-' | cut -c1-64`. Read at `main()` entry, logs `fresh install` / `reinstall (X)` / `upgrade X -> Y`. Symlink-trap on both read and write.
- **CRLF detector in preflight.** Fail-fast before publish; output is filename + line number only, never the matched content (avoids leaking secret values). Drops `grep -U` for busybox/Alpine compatibility. `--fix-line-endings` flag converts in place preserving mode 600 + original owner (BSD vs GNU stat branched; SUDO_UID handled).
- **`umask 077` wrapping** of `ensure_config_stubs` to close the ~10ms window where the secrets stub tmp file inherited the process umask.
- **secrets.env schema-version header.** `# expertise-api-secrets-version=1` on fresh install. Absent header treated as v0; not auto-mutated (operator-owned credential files require an explicit opt-in flag for forward migrations).
- **Concurrent-install lock via `mkdir`** (portable; no `flock`).
- **`scripts/lib/prefix-validation.sh`** — shared `normalize_prefix` + `validate_prefix` extracted from PR A's uninstall.sh. Both scripts now source the same library, closing the asymmetry surfaced by the pre-PR security review (install.sh had **no** `--prefix` validation; `--prefix /` would `mv /bin /bin.old`).
- **`--prefix` co-location.** When `--prefix DIR` is supplied, `CONFIG_DIR=DIR` and `LOG_DIR=DIR/logs` rather than per-OS XDG/macOS defaults. Fixes a latent `set -u` trip the new test harness caught on the first run.

Closes #223. PR B of the install/uninstall hardening track described in [`docs/install-upgrade-track.md`](https://github.com/TheSemicolon/agent-expertise-api/blob/dev/docs/install-upgrade-track.md).

## Test Plan

Three test suites, **93 assertions total, 100% pass**:

- `tests/install/test-crlf-detector.sh` (5 assertions) — LF-only passes; CRLF rejected with line number; secret values never leaked (asserts the literal `SECRET_TOKEN_DO_NOT_LEAK` does not appear in stderr); `--fix-line-endings` strips CR + preserves mode 600.
- `tests/install/test-upgrade-roundtrip.sh` (39 assertions) — PATH-shimmed `dotnet`/`systemctl`/`launchctl`/`loginctl`/`nc` so the harness runs without a working .NET environment. Cases:
  1. Fresh install — staging, swap, version marker, wrapper at PREFIX root, no .new/.old leftovers, lock released.
  2. No-op reinstall — logs `version: reinstall`.
  3. Upgrade — version-marker delta logged as `upgrade X -> Y`.
  4. Publish failure — STAGE_DIR cleaned; live `${BIN_DIR}` md5-fingerprint unchanged.
  5. Migrate failure — same invariants.
  6. Concurrent install — second invocation rejected with "another install in progress".
  7. Symlink-trap on `${BIN_DIR}.new` — install refuses.
  8. Wrapper survives binary swap — `${PREFIX}/launch-expertise-api.sh` still executable after second install.
  9. Post-swap rollback runway preserved — `${BIN_DIR}.old` cleaned only after SUCCESS branch.
  10. `--prefix` validation rejects `/etc/expertise-api`, `/`, and component-missing paths.
  11. `${PREFIX}/.install-version` symlink-trap defense.
- `tests/uninstall/test-prefix-guard.sh` (49 assertions, from PR A) — re-run to confirm no regression from the prefix-validation extraction.

Pre-design review fan-out (3 NEEDS_CHANGES with converging redesign):

- **shell-expert** identified the publish-before-migrate inversion and the wrapper-clobber.
- **security-review-expert** identified six security concerns (TOCTOU, umask window, `--fix-line-endings` mode/owner loss, CRLF output discipline, `git describe` injection, trap success-flag pattern).
- **dotnet-expert** identified that `migrate.sh` exec's the published binary (not `dotnet ef`), inverting the safer ordering; flagged wrapper clobber and `--bin-dir` flag need.

Pre-PR review fan-out (aggregate NEEDS_CHANGES, all folded in):

- **shell-expert** M1: `atomic_swap` cleaned `OLD_DIR` before post-swap steps ran, making the documented rollback branch dead code. Fixed by deferring `OLD_DIR` cleanup to the SUCCESS branch of the trap.
- **shell-expert** M2: `grep -U` not POSIX; busybox/Alpine silently rejects it, false-negative on the exact platforms the CRLF detector is meant to cover. Dropped `-U`.
- **security** M1: install.sh had no `--prefix` validation. Extracted shared lib; install.sh now inherits PR A's blocklist.
- **security** M2: `VERSION_MARKER` symlink-follow on read and write. Added `[[ -L ]]` guards.
- **linter** NEEDS_CHANGES: README MD029 ordered-list misnumbering. Renumbered + added the new step 6/8 split.
- Citation-currency caveat carried forward — reviewers flagged uncorroborated POSIX/Bash claims; `pi_config#151` tracks `web_fetch` enablement for research subagents.

Gates:

- `shellcheck`: clean (6 files)
- `bash tests/install/test-crlf-detector.sh`: 5/5 pass
- `bash tests/install/test-upgrade-roundtrip.sh`: 39/39 pass
- `bash tests/uninstall/test-prefix-guard.sh`: 49/49 pass
- `markdownlint-cli2`: 0 errors (2 files)
- `scripts/validate-pr.sh`: PASS

## Risk

- **Low** for user-mode upgrades — the design preserves prior binaries until migrate + service-install both succeed, and rolls back automatically on any post-swap failure. The wrapper relocation is invisible to operators (service templates regenerate automatically; uninstall.sh sweeps both old and new paths).
- **Low** for `--prefix`-overriding operators — co-locating `CONFIG_DIR=PREFIX` is the only behavior change, and it fixes a `set -u` crash that nobody could have relied on. README documents the contract.
- **Medium** for `--system` mode on multi-user hosts — the prefix-parent TOCTOU (#242) is still not addressed; the symlink check covers PREFIX itself but not its ancestors. Documented in PR A's README.
- **Backward compatibility** — operators with existing installs see the wrapper move from `${PREFIX}/bin/launch-expertise-api.sh` to `${PREFIX}/launch-expertise-api.sh` on the next install run. Service files are regenerated to reference the new path. The legacy wrapper is removed by both `install.sh` (on every successful run) and `uninstall.sh` (sweeps both paths).

## Follow-ups

- #242 — close PREFIX-parent TOCTOU in `--system` mode (multi-user-safety; depends on #145 LaunchDaemon thread for shared design).
- #241 — host-dependency bootstrap (PR C; depends on this PR and #243).
- pi_config#151 — register `web_fetch` tool so research subagents can cite first-party docs.
- Destructive-migration convention guardrail — doc-only, follow-up commit on `dev`.
- See [`docs/install-upgrade-track.md`](https://github.com/TheSemicolon/agent-expertise-api/blob/dev/docs/install-upgrade-track.md) for the consolidated multi-PR plan and session log.
