### PR TITLE
feat(build): declare runtimeidentifiers and rollforward for portable publish

### DIFF
--- a/src/ExpertiseApi/ExpertiseApi.csproj
+++ b/src/ExpertiseApi/ExpertiseApi.csproj
@@ -21,6 +21,29 @@
     -->
     <OpenApiGenerateDocuments>true</OpenApiGenerateDocuments>
     <OpenApiDocumentsDirectory>$(MSBuildProjectDirectory)/artifacts/openapi</OpenApiDocumentsDirectory>
+
+    <!--
+      Portable RID-agnostic publish precondition for Archetype A2 (ADR-011).
+
+      `dotnet publish` without `--runtime` produces a single portable output (a
+      DLL invoked as `dotnet ExpertiseApi.dll`, no apphost). NuGet only copies
+      per-RID native binaries from `runtimes/<rid>/native/` into the published
+      output for RIDs declared in <RuntimeIdentifiers>. Microsoft.SemanticKernel
+      .Connectors.Onnx pulls Microsoft.ML.OnnxRuntime which ships native binaries
+      per platform; without an explicit list the portable tarball would crash at
+      startup on every host whose RID is not the publish host's.
+
+      List covers the platforms `scripts/install.sh` / `install.ps1` support.
+      Adding or removing a platform here MUST be paired with the matching change
+      in `.github/workflows/release.yml` test matrix and the install-script
+      preflight RID detection.
+
+      <RollForward>LatestMinor</RollForward> lets a 10.0.0 tarball survive a host
+      that has only 10.1.x of `Microsoft.AspNetCore.App` installed. Default policy
+      is `Minor` which suffices, but explicit is auditable and matches the ADR.
+    -->
+    <RuntimeIdentifiers>linux-x64;linux-arm64;osx-arm64;osx-x64;win-x64</RuntimeIdentifiers>
+    <RollForward>LatestMinor</RollForward>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ExpertiseApi/ExpertiseApi.csproj
+++ b/src/ExpertiseApi/ExpertiseApi.csproj
@@ -25,7 +25,7 @@
     <!--
       Portable RID-agnostic publish precondition for Archetype A2 (ADR-011).
 
-      `dotnet publish` without `--runtime` produces a single portable output (a
+      `dotnet publish` without a `runtime` flag produces a single portable output (a
       DLL invoked as `dotnet ExpertiseApi.dll`, no apphost). NuGet only copies
       per-RID native binaries from `runtimes/<rid>/native/` into the published
       output for RIDs declared in <RuntimeIdentifiers>. Microsoft.SemanticKernel


### PR DESCRIPTION
## Summary

D1 of ADR-011 implementation (#249). Precondition for D2 (release.yml portable publish + manifest + cosign sign-blob) and D3 (install.sh `--from-release` path).

Adds `<RuntimeIdentifiers>linux-x64;linux-arm64;osx-arm64;osx-x64;win-x64</RuntimeIdentifiers>` and `<RollForward>LatestMinor</RollForward>` to `src/ExpertiseApi/ExpertiseApi.csproj`.

Without an explicit `<RuntimeIdentifiers>` property, NuGet only copies per-RID native binaries from `runtimes/<rid>/native/` for the RIDs the publish was actually targeted at. **Microsoft.SemanticKernel.Connectors.Onnx** pulls Microsoft.ML.OnnxRuntime which ships native binaries per platform; a portable publish without this list would crash at startup on every host whose RID differs from the publish host's.

Per ADR-011 Implementation notes §ONNX `<RuntimeIdentifiers>` precondition (**HIGH** — promoted into the normative Consequences body during the ADR pre-PR review). Adding or removing a platform here MUST be paired with the matching change in `release.yml` (D2) and the install-script preflight RID detection (D3).

`<RollForward>LatestMinor</RollForward>` lets a 10.0.0 tarball survive a host that has only 10.1.x of `Microsoft.AspNetCore.App` installed. Default policy is `Minor` which suffices, but explicit is auditable and matches the ADR.

## Test Plan

- **Zero behavior change** to: `docker compose up` (image still uses `--runtime` via Dockerfile); Helm-deployed installs (same image); `dotnet run` (no publish); existing Archetype A2 installs from PR C1 (#248) — install.sh still runs `dotnet publish` against the host SDK and the SDK selects only the current RID's natives. The new property only activates when a future publish step (D2) elides `--runtime`, at which point NuGet honors `<RuntimeIdentifiers>` and packs all five RIDs' natives.
- **CI Build & Test** workflow validates the csproj parses and the existing test suite still runs. Local `dotnet build` not run — no .NET SDK on this host, which is exactly the gap ADR-011 closes.
- `scripts/validate-pr.sh` PASS (0 errors, 0 warnings).

## Risk

- **Lowest possible**. csproj declarative additions only.
- One worth-knowing: `dotnet restore` time on portable publish (D2 onward) increases because NuGet now resolves native runtime packages for all 5 RIDs instead of 1. CI cost only — not on the install hot path.

## Ladder context

| PR | Scope | Status |
|---|---|---|
| **D1 (this)** | csproj `<RuntimeIdentifiers>` + `<RollForward>` | This PR |
| D2 | `release.yml` portable publish + manifest JSON + cosign sign-blob + Release upload | Next |
| D3 | `install.sh` `--from-release` opt-in (cosign verify + bsdtar extract + downgrade defense); `scripts/verify-release.sh`; release-tarball-flow test | Next session (deserves full pre-design fan-out) |
| D4 | Cosign as managed dep in `bootstrap-*.sh`; default flip `--from-source` → `--from-release` | Gated on one release cycle of D2 green + D3 smoke test green per ADR-011 |

## Refs

- ADR: [`adrs/011-deployment-artifact-format.md`](https://github.com/TheSemicolon/agent-expertise-api/blob/main/adrs/011-deployment-artifact-format.md)
- Issue: #249 (implementation tracker), #245 (closed by ADR-011)
