### PR TITLE
feat(release): publish portable tarball and cosign-signed manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,23 @@ jobs:
       - name: Helm render tests
         run: bash helm/expertise-api/tests/test-render.sh
 
+  release-manifest-generator:
+    name: release manifest generator (unit)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    # Targeted single-script CI step for tests/install/test-generate-manifest.sh.
+    # The broader tests/install/ suite is wired into CI by #166 (end-to-end
+    # install smoke). This step exists to give the ADR-011 / D2 manifest
+    # generator regression coverage on every PR without waiting on #166.
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run generate-manifest unit tests
+        run: bash tests/install/test-generate-manifest.sh
+
   apictl-restart-race-macos:
     name: apictl restart race regression (macOS)
     runs-on: macos-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,6 +279,127 @@ jobs:
             "$out_dir/openapi.json.pem" \
             --repo "${{ github.repository }}"
 
+      # ---- Portable publish tarball + cosign-signed manifest (ADR-011) -----
+      # D2 of #249. Emits the artifacts that Archetype A2 installs will
+      # consume once D3 ships the install.sh `--from-release` path.
+      #
+      # Shape: one portable RID-agnostic tarball (no apphost, dotnet runs
+      # the dll directly via the existing wrapper fallback in install.sh),
+      # plus a JSON manifest describing it, plus cosign keyless sign-blob
+      # over the MANIFEST (not the tarball — manifest covers tarball by
+      # SHA + cross-RID integrity + version-monotonicity in one signature).
+      #
+      # ONNX native binaries for all five RIDs ship in the same tarball
+      # because csproj declares <RuntimeIdentifiers>linux-x64;linux-arm64;
+      # osx-arm64;osx-x64;win-x64</RuntimeIdentifiers> (PR D1 / #251).
+      # Without that property the portable publish would crash at startup
+      # on every host whose RID differs from the runner's.
+      #
+      # The deterministic-tarball flags (--sort, --owner/group=0,
+      # --numeric-owner, --mtime from commit timestamp, gzip -n) make the
+      # tarball SHA reproducible from source for a given commit — useful
+      # for forensic verification but NOT load-bearing for cosign trust
+      # (trust comes from the signature, not the SHA).
+      - name: Publish portable tarball + signed manifest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: v${{ needs.release.outputs.new-release-version }}
+          NEW_VERSION: ${{ needs.release.outputs.new-release-version }}
+          GIT_SHA: ${{ github.sha }}
+        # Ordered after every other artifact step so a failure here cannot
+        # leave the release with image+chart+openapi signed but a partial
+        # tarball artifact. Tarball upload is the last contents:write step
+        # in the job other than the dispatch (which is metadata-only).
+        run: |
+          set -euo pipefail
+
+          # Reproducibility belt-and-suspenders. tar's sort/owner/mtime flags
+          # already pin most non-determinism; pinning umask + locale + TZ
+          # makes the contract robust to GitHub Actions runner image bumps.
+          # (dotnet publish honors Deterministic=true + ContinuousIntegrationBuild=true
+          # below — SOURCE_DATE_EPOCH below is consumed only by `tar`.)
+          umask 022
+          export LC_ALL=C TZ=UTC
+
+          # Portable RID-agnostic publish. NO --runtime. UseAppHost=false
+          # keeps the tarball cross-platform; install.sh runs the dll via
+          # `dotnet ExpertiseApi.dll` through its existing wrapper.
+          # Deterministic + ContinuousIntegrationBuild + DebugType=embedded
+          # produce stable bytes from a given source rev.
+          out_pub=dist/publish
+          mkdir -p "$out_pub"
+          dotnet publish src/ExpertiseApi/ExpertiseApi.csproj \
+            --configuration Release \
+            --no-self-contained \
+            -p:UseAppHost=false \
+            -p:Deterministic=true \
+            -p:ContinuousIntegrationBuild=true \
+            -p:DebugType=embedded \
+            --output "$out_pub"
+
+          # Sanity: ONNX runtimes/ subtree must contain the five RIDs we
+          # declared, AND each native dir must be non-empty. Directory
+          # existence alone is insufficient — a csproj that lists an RID
+          # but produces an empty native dir would crash at runtime on
+          # that host. If this fails, the csproj property was reverted or
+          # the bge-micro-v2 model dir lacks its native sidecar.
+          for rid in linux-x64 linux-arm64 osx-arm64 osx-x64 win-x64; do
+            native_dir="$out_pub/runtimes/$rid/native"
+            if [ ! -d "$native_dir" ] || [ -z "$(ls -A "$native_dir" 2>/dev/null)" ]; then
+              printf >&2 'ERROR: portable publish missing or empty: %s\n' "$native_dir"
+              printf >&2 '  the csproj <RuntimeIdentifiers> property may have been removed (ADR-011 / PR D1)\n'
+              exit 1
+            fi
+          done
+
+          # Deterministic tarball. Mtime from the release commit lets two
+          # CI runs of the same commit produce byte-identical archives.
+          # SOURCE_DATE_EPOCH is consumed by `tar --mtime="@${SOURCE_DATE_EPOCH}"`
+          # only — .NET determinism is driven by the Deterministic +
+          # ContinuousIntegrationBuild MSBuild properties already set above.
+          SOURCE_DATE_EPOCH=$(git log -1 --format=%ct HEAD)
+          export SOURCE_DATE_EPOCH
+          tarball="dist/expertise-api-${NEW_VERSION}-portable.tar.gz"
+          tar --sort=name \
+              --owner=0 --group=0 --numeric-owner \
+              --mtime="@${SOURCE_DATE_EPOCH}" \
+              --format=ustar \
+              -C "$out_pub" -cf - . \
+            | gzip -n -9 > "$tarball"
+          sha256sum "$tarball" | awk '{print $1}' > "${tarball}.sha256"
+
+          # Manifest — requiredRuntime.minVersion sourced from the just-
+          # generated runtimeconfig.json, never hand-set (ADR-011 sub-
+          # decision "Signing scope"). The generator is unit-tested by
+          # tests/install/test-generate-manifest.sh.
+          manifest="dist/expertise-api-${NEW_VERSION}.manifest.json"
+          bash scripts/build/generate-manifest.sh \
+            --publish-dir "$out_pub" \
+            --app-version "$NEW_VERSION" \
+            --git-sha "$GIT_SHA" \
+            --tarball "$tarball" \
+            --source-date-epoch "$SOURCE_DATE_EPOCH" \
+            --openapi-sha-file dist/openapi/openapi.json.sha256 \
+            --output "$manifest"
+
+          # cosign sign-blob over the manifest. Signature binds bytes; the
+          # manifest's tarballSha256 transitively binds the tarball.
+          # Same Fulcio/Rekor keyless OIDC ceremony as image/chart/openapi.
+          cosign sign-blob --yes \
+            --output-signature "${manifest}.sig" \
+            --output-certificate "${manifest}.pem" \
+            "$manifest"
+
+          # Upload tarball, sha256 sidecar, manifest, sig, cert. Pinned
+          # to the immutable release tag created earlier in the job.
+          gh release upload "$TAG" \
+            "$tarball" \
+            "${tarball}.sha256" \
+            "$manifest" \
+            "${manifest}.sig" \
+            "${manifest}.pem" \
+            --repo "${{ github.repository }}"
+
       - name: Dispatch deploy to infra repo
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ The chart version equals the application version (e.g. `0.4.2` chart serves the 
 
 ### Supply-chain verification (cosign keyless OIDC)
 
-The image, the chart artifact, and the `openapi.json` release asset are all signed via Sigstore keyless OIDC (the workflow's GitHub Actions OIDC token, no long-lived keys). Verify before installing or consuming:
+The image, the chart artifact, the `openapi.json` release asset, and the Archetype A2 release tarball + manifest are all signed via Sigstore keyless OIDC (the workflow's GitHub Actions OIDC token, no long-lived keys). Verify before installing or consuming:
 
 ```bash
 # Verify image
@@ -339,6 +339,26 @@ cosign verify-blob \
   --signature openapi.json.sig \
   --certificate openapi.json.pem \
   openapi.json
+
+# Verify the Archetype A2 release tarball via its signed manifest (ADR-011).
+# Download expertise-api-vX.Y.Z-portable.tar.gz, expertise-api-vX.Y.Z.manifest.json,
+# .manifest.json.sig, .manifest.json.pem from the release page.
+# The leading `set -euo pipefail` is load-bearing — without it an operator
+# copy-pasting this block would see cosign verify-blob fail with non-zero
+# exit, the shell would continue, and the SHA cross-check below would run
+# against an unverified manifest and could match attacker-coordinated bytes.
+set -euo pipefail
+cosign verify-blob \
+  --certificate-identity 'https://github.com/TheSemicolon/agent-expertise-api/.github/workflows/release.yml@refs/heads/main' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --signature expertise-api-vX.Y.Z.manifest.json.sig \
+  --certificate expertise-api-vX.Y.Z.manifest.json.pem \
+  expertise-api-vX.Y.Z.manifest.json
+
+# Manifest's artifacts.tarball.sha256 transitively binds the tarball.
+expected=$(jq -r .artifacts.tarball.sha256 expertise-api-vX.Y.Z.manifest.json)
+actual=$(sha256sum expertise-api-vX.Y.Z-portable.tar.gz | awk '{print $1}')
+[ "$expected" = "$actual" ] || { echo 'TARBALL TAMPERED' >&2; exit 1; }
 ```
 
 All three recipes use `--certificate-identity` (exact match) rather than `--certificate-identity-regexp`. Cosign evaluates `--certificate-identity-regexp` with Go's `regexp.MatchString`, which is **unanchored** — a pattern ending `release.yml@refs/heads/main` substring-matches a malicious `release.yml@refs/heads/main-evil` cert SAN. Exact match removes that bypass surface; there is exactly one legitimate signing identity for this repo and exact match expresses it precisely. If [#138](https://github.com/TheSemicolon/agent-expertise-api/issues/138) introduces maintenance release branches, all three recipes broaden together — with right-anchored regexps (`...@refs/heads/(main|release/.*)$`) or repeated `--certificate-identity` flags, not unanchored patterns.

--- a/docs/install-upgrade-track.md
+++ b/docs/install-upgrade-track.md
@@ -2,7 +2,7 @@
 
 Persistent TODO for the multi-PR effort that gets the native-service install path (Archetype A2) ready for pi-agent integration. Updated at the end of every working session.
 
-**Last updated:** 2026-05-22 (PRs A+B+C1 merged; ADR-011 in flight as docs PR)
+**Last updated:** 2026-05-22 (PRs A+B+C1 merged; ADR-011 merged; D1 + D2 in flight)
 **Driver issue:** [#230 readiness sweep](https://github.com/TheSemicolon/agent-expertise-api/issues/230)
 **Goal:** make `scripts/install.sh` safe, upgrade-aware, and capable of bootstrapping host dependencies on macOS (primary) and Linux, so the pi-agent integration session has a turn-key target.
 
@@ -24,7 +24,9 @@ Persistent TODO for the multi-PR effort that gets the native-service install pat
 | **C1** | PR C1 — macOS Homebrew bootstrap + shared library | #241 | ☑ merged as `afaba45` (#248) | `bootstrap-common.sh` + `bootstrap-macos.sh`. ‘Install the SDK’ short-term default per #245; ADR-011 records the long-term migration. 139/139 tests pass. |
 | C2 | PR C2 — Debian/Ubuntu bootstrap | #246 | ☐ unblocked, scope updated by ADR-011 | Under ADR-011 Option B: bootstrap surface reduces from ‘Microsoft feed + GPG pinning’ to ‘cosign + bsdtar’. WSL warn-and-refuse for Postgres unchanged. |
 | C3 | PR C3 — RHEL/Fedora bootstrap | #247 | ☐ unblocked, scope updated by ADR-011 | Same scope contraction as C2 under ADR-011 Option B. |
-| ADR | ADR for deployment artifact format | #245 | ◐ in flight (this PR) | `adrs/011-deployment-artifact-format.md`. Endorses Option B (CI publishes a portable cosign-signed tarball; install.sh cosign-verifies + bsdtar-extracts) with Option A retained as `--from-source`. Implementation tracked separately. |
+| ADR | ADR for deployment artifact format | #245 | ☑ merged as `fcb3c19` (#250) | `adrs/011-deployment-artifact-format.md`. Endorses Option B (CI publishes a portable cosign-signed tarball; install.sh cosign-verifies + bsdtar-extracts) with Option A retained as `--from-source`. Implementation tracked as #249. |
+| D1 | csproj `<RuntimeIdentifiers>` + `<RollForward>` precondition | #249 | ◐ in flight (PR #251) | One-line csproj addition. Hard precondition for D2 portable publish (ONNX RID natives). Zero behavior change to docker/helm/`dotnet run`/existing A2 installs. |
+| D2 | release.yml portable publish + manifest + cosign sign-blob | #249 | ◐ in flight (this PR) | Adds `scripts/build/generate-manifest.sh` + 26-assertion test suite; release.yml publish/manifest/sign/upload steps; README §Supply-chain verification stanza for the tarball-via-manifest recipe; CI `release-manifest-generator` job seeds #166 incrementally. |
 | T | Upgrade-roundtrip test | (landed w/ B) | ☑ in PR B | `tests/install/test-upgrade-roundtrip.sh` (39 assertions). Extend in C1 for `--install-deps` paths. |
 
 Status legend: ☐ todo · ◐ in progress · ☑ merged · ✗ abandoned.

--- a/scripts/build/generate-manifest.sh
+++ b/scripts/build/generate-manifest.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+#
+# scripts/build/generate-manifest.sh — produces the release manifest JSON
+# that anchors cosign-signed verification for Archetype A2 installs.
+# Companion to ADR-011 (cosign-signed published tarball over SDK-on-host).
+#
+# Invoked from .github/workflows/release.yml after the portable
+# `dotnet publish` step and after the deterministic tarball is built.
+# Reads the published runtimeconfig.json for the runtime floor (NEVER
+# hand-set — ADR-011 sub-decision "Signing scope"), computes the tarball
+# SHA-256, and emits a flat JSON document signed by `cosign sign-blob`.
+#
+# Schema fields (schemaVersion=1):
+#   schemaVersion        manifest schema version; bump on breaking change
+#   appVersion           semantic-release version, no leading "v"
+#   gitSha               source commit the artifacts were built from
+#   publishMode          "portable" (RID-agnostic) or "self-contained"
+#   targetFramework      net10.0 / etc., from runtimeconfig
+#   requiredRuntime      { name, minVersion, rollForward } sourced from
+#                        publish/<App>.runtimeconfig.json — installer
+#                        compares with `sort -V` against the host's
+#                        installed runtime floor
+#   sdkUsedToPublish     informational; aids reproducibility forensics
+#   buildTimestamp       commit time (SOURCE_DATE_EPOCH derived), not
+#                        wall-clock — keeps the manifest deterministic
+#                        across reruns of the same source rev
+#   artifacts.tarball    { name, sha256, sizeBytes } — primary asset
+#   artifacts.openapiSha256  sidecar sha for openapi.json if attached
+#
+# Exit codes:
+#   0  manifest written
+#   1  argument / environment error
+#   2  runtimeconfig missing or malformed (HIGH — manifest with hand-set
+#      requiredRuntime is exactly the failure mode ADR-011 calls out)
+#   3  jq / sha256sum / required tool missing
+#
+# Usage:
+#   generate-manifest.sh \
+#       --publish-dir dist/publish \
+#       --app-version 1.2.3 \
+#       --git-sha "$GITHUB_SHA" \
+#       --tarball dist/expertise-api-1.2.3-portable.tar.gz \
+#       --source-date-epoch "$(git log -1 --format=%ct HEAD)" \
+#       [--openapi-sha-file dist/openapi/openapi.json.sha256] \
+#       --output dist/expertise-api-1.2.3.manifest.json
+#
+
+set -euo pipefail
+
+# bash >= 4 required: mapfile + indirect-expansion semantics. The shebang
+# is `env bash` so this only matters for contributors whose `env bash`
+# resolves to /bin/bash on stock macOS (3.2). Ubuntu / Homebrew bash are 4+.
+if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then
+  printf 'generate-manifest: requires bash >= 4 (got %s)\n' "${BASH_VERSION:-unknown}" >&2
+  exit 3
+fi
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+PUBLISH_DIR=""
+APP_VERSION=""
+GIT_SHA=""
+TARBALL=""
+SOURCE_DATE_EPOCH=""
+OPENAPI_SHA_FILE=""
+OUTPUT=""
+SDK_VERSION_OVERRIDE=""
+PUBLISH_MODE="portable"
+
+usage() {
+  sed -n '4,49p' "$0"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --publish-dir)        PUBLISH_DIR="${2:?--publish-dir requires a value}"; shift 2 ;;
+    --app-version)        APP_VERSION="${2:?--app-version requires a value}"; shift 2 ;;
+    --git-sha)            GIT_SHA="${2:?--git-sha requires a value}"; shift 2 ;;
+    --tarball)            TARBALL="${2:?--tarball requires a value}"; shift 2 ;;
+    --source-date-epoch)  SOURCE_DATE_EPOCH="${2:?--source-date-epoch requires a value}"; shift 2 ;;
+    --openapi-sha-file)   OPENAPI_SHA_FILE="${2:?--openapi-sha-file requires a value}"; shift 2 ;;
+    --output)             OUTPUT="${2:?--output requires a value}"; shift 2 ;;
+    --sdk-version)        SDK_VERSION_OVERRIDE="${2:?--sdk-version requires a value}"; shift 2 ;;
+    --publish-mode)       PUBLISH_MODE="${2:?--publish-mode requires a value}"; shift 2 ;;
+    -h|--help)            usage; exit 0 ;;
+    *)                    printf 'generate-manifest: unknown argument: %s\n' "$1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+for var in PUBLISH_DIR APP_VERSION GIT_SHA TARBALL SOURCE_DATE_EPOCH OUTPUT; do
+  if [ -z "${!var}" ]; then
+    printf 'generate-manifest: missing required --%s (or its env equivalent)\n' \
+      "$(printf '%s' "$var" | tr '[:upper:]_' '[:lower:]-')" >&2
+    exit 1
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Tool preconditions
+# ---------------------------------------------------------------------------
+for tool in jq sha256sum stat; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    printf 'generate-manifest: required tool missing: %s\n' "$tool" >&2
+    exit 3
+  fi
+done
+
+# stat on BSD (macOS) uses -f, on GNU (Linux) uses -c. Detect and pick.
+file_size() {
+  local f=$1
+  if stat -c%s "$f" >/dev/null 2>&1; then
+    stat -c%s "$f"
+  else
+    stat -f%z "$f"
+  fi
+}
+
+[ -d "$PUBLISH_DIR" ] || { printf 'generate-manifest: publish dir not found: %s\n' "$PUBLISH_DIR" >&2; exit 1; }
+[ -f "$TARBALL" ]     || { printf 'generate-manifest: tarball not found: %s\n' "$TARBALL" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Locate runtimeconfig.json — there must be exactly one in PUBLISH_DIR
+# matching *.runtimeconfig.json. Refuse if zero or many (ambiguous shape
+# indicates the publish layout has drifted and this script's invariant
+# is broken). Capture-first avoids the well-known process-substitution
+# exit-code-not-propagated trap under `set -e`.
+# ---------------------------------------------------------------------------
+if ! runtimeconfigs_raw=$(find "$PUBLISH_DIR" -maxdepth 1 -type f -name '*.runtimeconfig.json' | sort); then
+  printf 'generate-manifest: find failed under %s\n' "$PUBLISH_DIR" >&2
+  exit 2
+fi
+mapfile -t runtimeconfigs <<< "$runtimeconfigs_raw"
+# `<<<` always feeds at least one (possibly empty) line; collapse the empty case
+if [ "${#runtimeconfigs[@]}" -eq 1 ] && [ -z "${runtimeconfigs[0]}" ]; then
+  runtimeconfigs=()
+fi
+case ${#runtimeconfigs[@]} in
+  0)
+    printf 'generate-manifest: no *.runtimeconfig.json in %s — was the publish step run?\n' "$PUBLISH_DIR" >&2
+    exit 2
+    ;;
+  1)
+    runtime_config=${runtimeconfigs[0]}
+    ;;
+  *)
+    printf 'generate-manifest: multiple *.runtimeconfig.json in %s (ambiguous):\n' "$PUBLISH_DIR" >&2
+    printf '  %s\n' "${runtimeconfigs[@]}" >&2
+    exit 2
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# requiredRuntime sourced from runtimeconfig (NEVER hand-set — ADR-011)
+# ---------------------------------------------------------------------------
+required_runtime_name=$(jq -r '.runtimeOptions.framework.name // empty' "$runtime_config")
+required_runtime_version=$(jq -r '.runtimeOptions.framework.version // empty' "$runtime_config")
+required_runtime_rollforward=$(jq -r '.runtimeOptions.rollForward // "Minor"' "$runtime_config")
+target_framework=$(jq -r '.runtimeOptions.tfm // empty' "$runtime_config")
+
+if [ -z "$required_runtime_name" ] || [ -z "$required_runtime_version" ] || [ -z "$target_framework" ]; then
+  printf 'generate-manifest: runtimeconfig %s missing framework.name/version or tfm — refusing to emit manifest with synthesized values\n' \
+    "$runtime_config" >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# SDK version — informational. Operators do not gate on this; it's
+# present for reproducibility forensics ("which SDK built this artifact?").
+# Override-able for tests that don't have dotnet on PATH.
+# ---------------------------------------------------------------------------
+if [ -n "$SDK_VERSION_OVERRIDE" ]; then
+  sdk_version=$SDK_VERSION_OVERRIDE
+elif command -v dotnet >/dev/null 2>&1; then
+  sdk_version=$(dotnet --version 2>/dev/null || printf 'unknown')
+else
+  sdk_version=unknown
+fi
+
+# ---------------------------------------------------------------------------
+# Tarball measurements
+# ---------------------------------------------------------------------------
+tarball_name=$(basename "$TARBALL")
+tarball_sha=$(sha256sum "$TARBALL" | awk '{print $1}')
+tarball_size=$(file_size "$TARBALL")
+
+# Optional sidecar — openapi.json sha. Skipped if file absent (don't fail
+# the manifest; openapi attachment is a separate concern).
+openapi_sha=""
+if [ -n "$OPENAPI_SHA_FILE" ] && [ -f "$OPENAPI_SHA_FILE" ]; then
+  openapi_sha=$(awk '{print $1}' "$OPENAPI_SHA_FILE")
+fi
+
+# ---------------------------------------------------------------------------
+# Build timestamp — derived from SOURCE_DATE_EPOCH, never wall clock.
+# Two reruns of this script against the same source rev produce byte-
+# identical manifests, which lets operators sanity-check by hashing.
+# ---------------------------------------------------------------------------
+# Validate SOURCE_DATE_EPOCH is a positive integer before feeding to date(1)
+case "$SOURCE_DATE_EPOCH" in
+  ''|*[!0-9]*) printf 'generate-manifest: --source-date-epoch must be a positive integer, got: %s\n' "$SOURCE_DATE_EPOCH" >&2; exit 1 ;;
+esac
+
+if date -u -d "@$SOURCE_DATE_EPOCH" +%Y-%m-%dT%H:%M:%SZ >/dev/null 2>&1; then
+  build_timestamp=$(date -u -d "@$SOURCE_DATE_EPOCH" +%Y-%m-%dT%H:%M:%SZ)
+else
+  # BSD date (macOS) — different invocation
+  build_timestamp=$(date -u -r "$SOURCE_DATE_EPOCH" +%Y-%m-%dT%H:%M:%SZ)
+fi
+
+# ---------------------------------------------------------------------------
+# Emit manifest. jq -n with --arg keeps the JSON literal-safe (no string
+# interpolation; embedded quotes/backslashes in any value are properly
+# escaped by jq).
+# ---------------------------------------------------------------------------
+manifest_json=$(jq -n \
+  --arg schemaVersion "1" \
+  --arg appVersion "$APP_VERSION" \
+  --arg gitSha "$GIT_SHA" \
+  --arg publishMode "$PUBLISH_MODE" \
+  --arg targetFramework "$target_framework" \
+  --arg required_name "$required_runtime_name" \
+  --arg required_min "$required_runtime_version" \
+  --arg required_rf "$required_runtime_rollforward" \
+  --arg sdk "$sdk_version" \
+  --arg buildTimestamp "$build_timestamp" \
+  --arg tarballName "$tarball_name" \
+  --arg tarballSha "$tarball_sha" \
+  --argjson tarballSize "$tarball_size" \
+  --arg openapiSha "$openapi_sha" \
+  '{
+    schemaVersion: $schemaVersion,
+    appVersion: $appVersion,
+    gitSha: $gitSha,
+    publishMode: $publishMode,
+    targetFramework: $targetFramework,
+    requiredRuntime: {
+      name: $required_name,
+      minVersion: $required_min,
+      rollForward: $required_rf
+    },
+    sdkUsedToPublish: $sdk,
+    buildTimestamp: $buildTimestamp,
+    artifacts: ({
+      tarball: {
+        name: $tarballName,
+        sha256: $tarballSha,
+        sizeBytes: $tarballSize
+      }
+    } + (if $openapiSha == "" then {} else { openapiSha256: $openapiSha } end))
+  }')
+
+# Atomic write — never half-flush a manifest cosign is about to sign.
+mkdir -p "$(dirname "$OUTPUT")"
+tmp=$(mktemp "${OUTPUT}.XXXXXX")
+trap 'rm -f "$tmp"' EXIT
+printf '%s\n' "$manifest_json" > "$tmp"
+mv "$tmp" "$OUTPUT"
+trap - EXIT
+
+printf 'generate-manifest: wrote %s (%s bytes)\n' "$OUTPUT" "$(file_size "$OUTPUT")"

--- a/tests/install/test-generate-manifest.sh
+++ b/tests/install/test-generate-manifest.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+#
+# tests/install/test-generate-manifest.sh — exercise the release-manifest
+# generator (scripts/build/generate-manifest.sh) without invoking dotnet,
+# git, or cosign. Companion to ADR-011 and the D2 release-pipeline
+# changes (issue #249).
+#
+# Cases:
+#   1. Happy path with a realistic runtimeconfig — manifest is valid JSON
+#      with all required fields populated from the runtimeconfig.
+#   2. Missing runtimeconfig — exits 2, refuses to synthesize values.
+#   3. Malformed runtimeconfig (missing framework.version) — exits 2.
+#   4. Multiple runtimeconfigs in publish dir — exits 2 (ambiguous shape).
+#   5. Missing required CLI argument — exits 1.
+#   6. Non-integer SOURCE_DATE_EPOCH — exits 1.
+#   7. Determinism: two runs against the same input produce byte-identical
+#      manifests (the load-bearing property of SOURCE_DATE_EPOCH-derived
+#      timestamps).
+#   8. Tarball SHA is computed correctly (cross-check against sha256sum).
+#   9. Tarball size is reported correctly.
+#  10. Optional openapi sha sidecar — present when file exists, omitted
+#      when --openapi-sha-file absent or path does not exist.
+#  11. Schema invariants — jq queries for each field assert presence
+#      and type (string vs number vs object). Lock the manifest shape
+#      so install.sh (D3) can rely on it.
+#  12. requiredRuntime.minVersion is sourced verbatim from runtimeconfig
+#      (hand-set value would be exactly the ADR-011 footgun this script
+#      exists to prevent).
+#
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+GEN="${SCRIPT_DIR}/scripts/build/generate-manifest.sh"
+[ -x "$GEN" ] || { echo "FAIL: generate-manifest.sh missing or not executable" >&2; exit 2; }
+
+# Preconditions — same tools the script itself requires
+for tool in jq sha256sum; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "SKIP: $tool not available" >&2; exit 0; }
+done
+# Fixture builder uses GNU-tar long opts (--sort, --owner=, --group=,
+# --numeric-owner, --format=ustar). On macOS the default `tar` is bsdtar
+# and silently rejects these. Prefer `gtar` if available; SKIP cleanly
+# otherwise so the suite stays informative on developer macOS without
+# masking failures inside the fixture.
+if command -v gtar >/dev/null 2>&1; then
+  TAR_BIN=gtar
+elif tar --version 2>/dev/null | grep -qi 'gnu tar'; then
+  TAR_BIN=tar
+else
+  echo "SKIP: GNU tar (gtar or system tar) not available — install via brew install gnu-tar" >&2
+  exit 0
+fi
+
+SCRATCH="$(mktemp -d -t generate-manifest.XXXXXX)"
+trap 'rm -rf "${SCRATCH}"' EXIT
+
+PASS=0
+FAIL=0
+assert() {
+  local name="$1"; shift
+  if "$@"; then
+    PASS=$((PASS+1))
+  else
+    printf 'FAIL: %s\n' "$name" >&2
+    FAIL=$((FAIL+1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Fixture builder — minimal publish layout
+# ---------------------------------------------------------------------------
+build_fixture() {
+  local case_dir=$1
+  local runtimeconfig_content=${2:-DEFAULT}
+  local publish=${case_dir}/publish
+  mkdir -p "$publish"
+
+  if [ "$runtimeconfig_content" = "DEFAULT" ]; then
+    cat > "${publish}/ExpertiseApi.runtimeconfig.json" <<'JSON'
+{
+  "runtimeOptions": {
+    "tfm": "net10.0",
+    "rollForward": "LatestMinor",
+    "framework": {
+      "name": "Microsoft.AspNetCore.App",
+      "version": "10.0.0"
+    }
+  }
+}
+JSON
+  elif [ "$runtimeconfig_content" = "NONE" ]; then
+    : # caller wants no runtimeconfig at all
+  else
+    printf '%s' "$runtimeconfig_content" > "${publish}/ExpertiseApi.runtimeconfig.json"
+  fi
+
+  # Tiny payload so the tarball isn't empty
+  printf 'placeholder dll\n' > "${publish}/ExpertiseApi.dll"
+
+  # Deterministic tarball — matches what release.yml does for real.
+  # stderr deliberately NOT redirected: a tar failure here would otherwise
+  # produce an empty tarball that the SHA cross-check below would still
+  # "pass" against (both sides hashing the same garbage bytes).
+  "$TAR_BIN" --sort=name --owner=0 --group=0 --numeric-owner \
+      --mtime='2020-01-01 00:00:00 UTC' \
+      --format=ustar \
+      -C "$publish" -cf - . \
+    | gzip -n -9 > "${case_dir}/artifact.tar.gz"
+
+  printf '%s\n' "$publish"
+}
+
+run_gen() {
+  # Wrapper that always provides --sdk-version (tests run without dotnet)
+  "$GEN" --sdk-version test-9.9.9 "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: happy path
+# ---------------------------------------------------------------------------
+case1=${SCRATCH}/case1
+publish=$(build_fixture "$case1")
+out=${case1}/manifest.json
+rc=0
+run_gen \
+  --publish-dir "$publish" \
+  --app-version "1.2.3" \
+  --git-sha "abc123def456" \
+  --tarball "${case1}/artifact.tar.gz" \
+  --source-date-epoch "1577836800" \
+  --output "$out" >/dev/null 2>&1 || rc=$?
+assert "case 1: exit 0 on happy path" [ "$rc" -eq 0 ]
+assert "case 1: manifest file created" [ -f "$out" ]
+assert "case 1: manifest is valid JSON" bash -c "jq -e . '$out' >/dev/null"
+
+# ---------------------------------------------------------------------------
+# Case 11: schema invariants — fields, types, values (do early so the
+# manifest from case 1 is freshly minted)
+# ---------------------------------------------------------------------------
+assert "case 11: schemaVersion == '1'"     bash -c "[ \"\$(jq -r .schemaVersion       '$out')\" = '1' ]"
+assert "case 11: appVersion == '1.2.3'"    bash -c "[ \"\$(jq -r .appVersion          '$out')\" = '1.2.3' ]"
+assert "case 11: gitSha == 'abc123def456'" bash -c "[ \"\$(jq -r .gitSha              '$out')\" = 'abc123def456' ]"
+assert "case 11: publishMode == 'portable'" bash -c "[ \"\$(jq -r .publishMode        '$out')\" = 'portable' ]"
+assert "case 11: targetFramework == 'net10.0'" bash -c "[ \"\$(jq -r .targetFramework '$out')\" = 'net10.0' ]"
+assert "case 11: requiredRuntime is an object" bash -c "[ \"\$(jq -r '.requiredRuntime | type' '$out')\" = 'object' ]"
+assert "case 11: artifacts.tarball is an object" bash -c "[ \"\$(jq -r '.artifacts.tarball | type' '$out')\" = 'object' ]"
+assert "case 11: artifacts.tarball.sizeBytes is a number" bash -c "[ \"\$(jq -r '.artifacts.tarball.sizeBytes | type' '$out')\" = 'number' ]"
+assert "case 11: openapiSha256 absent when --openapi-sha-file omitted (case 1 happy path)" \
+  bash -c "[ \"\$(jq -r '.artifacts | has(\"openapiSha256\")' '$out')\" = 'false' ]"
+
+# ---------------------------------------------------------------------------
+# Case 12: requiredRuntime sourced from runtimeconfig verbatim (ADR-011)
+# ---------------------------------------------------------------------------
+assert "case 12: requiredRuntime.name == fixture value" \
+  bash -c "[ \"\$(jq -r .requiredRuntime.name '$out')\" = 'Microsoft.AspNetCore.App' ]"
+assert "case 12: requiredRuntime.minVersion == fixture value" \
+  bash -c "[ \"\$(jq -r .requiredRuntime.minVersion '$out')\" = '10.0.0' ]"
+assert "case 12: requiredRuntime.rollForward == fixture value" \
+  bash -c "[ \"\$(jq -r .requiredRuntime.rollForward '$out')\" = 'LatestMinor' ]"
+
+# ---------------------------------------------------------------------------
+# Case 8 + 9: tarball sha and size are correct
+# ---------------------------------------------------------------------------
+expected_sha=$(sha256sum "${case1}/artifact.tar.gz" | awk '{print $1}')
+expected_size=$(wc -c < "${case1}/artifact.tar.gz" | tr -d ' ')
+got_sha=$(jq -r .artifacts.tarball.sha256 "$out")
+got_size=$(jq -r .artifacts.tarball.sizeBytes "$out")
+assert "case 8: tarball sha matches sha256sum" [ "$expected_sha" = "$got_sha" ]
+assert "case 9: tarball size matches wc -c"     [ "$expected_size" = "$got_size" ]
+
+# ---------------------------------------------------------------------------
+# Case 7: determinism — re-run produces identical manifest
+# ---------------------------------------------------------------------------
+out2=${case1}/manifest2.json
+run_gen \
+  --publish-dir "$publish" \
+  --app-version "1.2.3" \
+  --git-sha "abc123def456" \
+  --tarball "${case1}/artifact.tar.gz" \
+  --source-date-epoch "1577836800" \
+  --output "$out2" >/dev/null 2>&1
+assert "case 7: two runs produce byte-identical manifest" cmp -s "$out" "$out2"
+
+# ---------------------------------------------------------------------------
+# Case 10a: openapi sha sidecar present
+# ---------------------------------------------------------------------------
+sha_file=${case1}/openapi.json.sha256
+printf 'deadbeefcafebabe1234567890abcdef\n' > "$sha_file"
+out3=${case1}/manifest_with_openapi.json
+run_gen \
+  --publish-dir "$publish" \
+  --app-version "1.2.3" \
+  --git-sha "abc123def456" \
+  --tarball "${case1}/artifact.tar.gz" \
+  --source-date-epoch "1577836800" \
+  --openapi-sha-file "$sha_file" \
+  --output "$out3" >/dev/null 2>&1
+assert "case 10a: openapiSha256 present when sidecar exists" \
+  bash -c "[ \"\$(jq -r '.artifacts.openapiSha256 // empty' '$out3')\" = 'deadbeefcafebabe1234567890abcdef' ]"
+
+# ---------------------------------------------------------------------------
+# Case 10b: openapi sha sidecar absent path silently omitted
+# ---------------------------------------------------------------------------
+out4=${case1}/manifest_no_sidecar.json
+run_gen \
+  --publish-dir "$publish" \
+  --app-version "1.2.3" \
+  --git-sha "abc123def456" \
+  --tarball "${case1}/artifact.tar.gz" \
+  --source-date-epoch "1577836800" \
+  --openapi-sha-file "${case1}/does-not-exist.sha256" \
+  --output "$out4" >/dev/null 2>&1
+assert "case 10b: openapiSha256 omitted when sidecar missing" \
+  bash -c "[ \"\$(jq -r '.artifacts | has(\"openapiSha256\")' '$out4')\" = 'false' ]"
+
+# ---------------------------------------------------------------------------
+# Case 2: missing runtimeconfig — exit 2
+# ---------------------------------------------------------------------------
+case2=${SCRATCH}/case2
+mkdir -p "${case2}/publish"
+printf 'placeholder\n' > "${case2}/publish/ExpertiseApi.dll"
+"$TAR_BIN" --sort=name --owner=0 --group=0 --numeric-owner --mtime='2020-01-01 00:00:00 UTC' --format=ustar \
+  -C "${case2}/publish" -cf - . | gzip -n > "${case2}/artifact.tar.gz"
+rc=0
+run_gen \
+  --publish-dir "${case2}/publish" \
+  --app-version "1.2.3" \
+  --git-sha "abc" \
+  --tarball "${case2}/artifact.tar.gz" \
+  --source-date-epoch "1577836800" \
+  --output "${case2}/manifest.json" >/dev/null 2>&1 || rc=$?
+assert "case 2: missing runtimeconfig exits 2" [ "$rc" -eq 2 ]
+
+# ---------------------------------------------------------------------------
+# Case 3: malformed runtimeconfig (no framework.version)
+# ---------------------------------------------------------------------------
+case3=${SCRATCH}/case3
+publish3=$(build_fixture "$case3" '{"runtimeOptions":{"tfm":"net10.0","framework":{"name":"Microsoft.AspNetCore.App"}}}')
+rc=0
+run_gen \
+  --publish-dir "$publish3" \
+  --app-version "1.2.3" \
+  --git-sha "abc" \
+  --tarball "${case3}/artifact.tar.gz" \
+  --source-date-epoch "1577836800" \
+  --output "${case3}/manifest.json" >/dev/null 2>&1 || rc=$?
+assert "case 3: malformed runtimeconfig exits 2" [ "$rc" -eq 2 ]
+
+# ---------------------------------------------------------------------------
+# Case 4: multiple runtimeconfigs — ambiguous
+# ---------------------------------------------------------------------------
+case4=${SCRATCH}/case4
+publish4=$(build_fixture "$case4")
+cp "${publish4}/ExpertiseApi.runtimeconfig.json" "${publish4}/Other.runtimeconfig.json"
+rc=0
+run_gen \
+  --publish-dir "$publish4" \
+  --app-version "1.2.3" \
+  --git-sha "abc" \
+  --tarball "${case4}/artifact.tar.gz" \
+  --source-date-epoch "1577836800" \
+  --output "${case4}/manifest.json" >/dev/null 2>&1 || rc=$?
+assert "case 4: multiple runtimeconfigs exits 2 (ambiguous)" [ "$rc" -eq 2 ]
+
+# ---------------------------------------------------------------------------
+# Case 5: missing required CLI argument
+# ---------------------------------------------------------------------------
+rc=0
+run_gen --publish-dir /tmp >/dev/null 2>&1 || rc=$?
+assert "case 5: missing required args exits 1" [ "$rc" -eq 1 ]
+
+# ---------------------------------------------------------------------------
+# Case 6: non-integer SOURCE_DATE_EPOCH
+# ---------------------------------------------------------------------------
+case6=${SCRATCH}/case6
+publish6=$(build_fixture "$case6")
+rc=0
+run_gen \
+  --publish-dir "$publish6" \
+  --app-version "1.2.3" \
+  --git-sha "abc" \
+  --tarball "${case6}/artifact.tar.gz" \
+  --source-date-epoch "not-a-number" \
+  --output "${case6}/manifest.json" >/dev/null 2>&1 || rc=$?
+assert "case 6: non-integer SOURCE_DATE_EPOCH exits 1" [ "$rc" -eq 1 ]
+
+# ---------------------------------------------------------------------------
+# Case 12b: mutation-style proof — changing fixture's framework.version
+# produces a different manifest. Locks the verbatim-sourcing invariant
+# beyond the static greps below (which only fire on shell-assignment
+# literals, not on `--arg required_min "<const>"` regressions).
+# ---------------------------------------------------------------------------
+case12b=${SCRATCH}/case12b
+publish12b=$(build_fixture "$case12b" '{"runtimeOptions":{"tfm":"net10.0","rollForward":"LatestMinor","framework":{"name":"Microsoft.AspNetCore.App","version":"11.0.42"}}}')
+out_mut=${case12b}/manifest.json
+run_gen \
+  --publish-dir "$publish12b" \
+  --app-version "1.2.3" \
+  --git-sha "abc123def456" \
+  --tarball "${case12b}/artifact.tar.gz" \
+  --source-date-epoch "1577836800" \
+  --output "$out_mut" >/dev/null 2>&1
+assert "case 12b: mutated fixture.framework.version flows into manifest" \
+  bash -c "[ \"\$(jq -r .requiredRuntime.minVersion '$out_mut')\" = '11.0.42' ]"
+assert "case 12b: manifest from mutated fixture differs from case 1" \
+  bash -c "! cmp -s '$out' '$out_mut'"
+
+# ---------------------------------------------------------------------------
+# Case 13: --publish-mode self-contained plumbs through correctly
+# ---------------------------------------------------------------------------
+case13=${SCRATCH}/case13
+publish13=$(build_fixture "$case13")
+out13=${case13}/manifest.json
+run_gen \
+  --publish-dir "$publish13" \
+  --app-version "1.2.3" \
+  --git-sha "abc" \
+  --tarball "${case13}/artifact.tar.gz" \
+  --source-date-epoch "1577836800" \
+  --publish-mode "self-contained" \
+  --output "$out13" >/dev/null 2>&1
+assert "case 13: publishMode override flows into manifest" \
+  bash -c "[ \"\$(jq -r .publishMode '$out13')\" = 'self-contained' ]"
+
+# ---------------------------------------------------------------------------
+# Static lint-time guard: refuse to emit a manifest that hand-sets
+# requiredRuntime — the script must always read it from runtimeconfig.
+# Grep-based defense (mirrors the argv-leak guard in test-bootstrap-common).
+# ---------------------------------------------------------------------------
+assert "static guard: no hardcoded requiredRuntime.minVersion in generator" \
+  bash -c "! grep -E 'requiredRuntime.minVersion[[:space:]]*=[[:space:]]*\"?[0-9]' '$GEN'"
+assert "static guard: requiredRuntime sourced via jq from runtimeconfig" \
+  bash -c "grep -qE 'jq -r .{0,2}\.runtimeOptions\.framework\.version' '$GEN'"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n'
+printf 'test-generate-manifest.sh: %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

**D2 of ADR-011 implementation (#249)**. Builds the supply side of the cosign-trust-root migration that install.sh will consume in D3.

After this PR every release uploads — alongside the existing image + chart + openapi.json assets — five new artifacts:

| File | Purpose |
|---|---|
| `expertise-api-vX.Y.Z-portable.tar.gz` | Portable RID-agnostic publish (no apphost, no `--runtime`); contains ONNX natives for all five RIDs from PR D1's `<RuntimeIdentifiers>` |
| `expertise-api-vX.Y.Z-portable.tar.gz.sha256` | Sidecar sha for cosign-less mirrors (informational only — cosign is the trust gate) |
| `expertise-api-vX.Y.Z.manifest.json` | Schema v1 manifest: `appVersion`, `gitSha`, `publishMode`, `targetFramework`, `requiredRuntime.{name,minVersion,rollForward}`, `sdkUsedToPublish`, `buildTimestamp`, `artifacts.tarball.{name,sha256,sizeBytes}` |
| `expertise-api-vX.Y.Z.manifest.json.sig` | Cosign keyless OIDC signature (same Fulcio identity as image/chart/openapi) |
| `expertise-api-vX.Y.Z.manifest.json.pem` | Fulcio cert chain |

**Why sign the manifest, not the tarball** (ADR-011 sub-decision §Signing scope): the manifest's `artifacts.tarball.sha256` transitively binds the tarball to one cosign signature. Same signature covers cross-RID integrity (one sig spans all RID tarballs by content hash), version monotonicity (downgrade defense in D3 reads `manifest.appVersion`), and SBOM alignment (publish-time SDK version + git SHA + runtimeconfig-derived runtime floor).

**`requiredRuntime.minVersion` is sourced from `ExpertiseApi.runtimeconfig.json`** (`runtimeOptions.framework.version`), **never hand-set** — the exact failure mode ADR-011 calls out. Locked by test case 12 (round-trip) + case 12b (mutation-style proof: a mutated fixture's `framework.version` flows verbatim into the manifest and the resulting manifest is bit-different from the happy-path manifest) + two static-grep guards.

## Files

| Status | Path | Purpose |
|---|---|---|
| new | `scripts/build/generate-manifest.sh` | Release-manifest generator (~260 lines bash; atomic write; jq-safe JSON; SOURCE_DATE_EPOCH validation; BSD-vs-GNU stat/date detection; bash >= 4 guard) |
| new | `tests/install/test-generate-manifest.sh` | 30-assertion unit test (12 schema, 4 hash/size/determinism, 2 openapi-sidecar branches, 5 error-path cases, 2 mutation/plumbing, 2 publishMode override, 2 static-grep guards, 1 absent-flag assertion) |
| edit | `.github/workflows/release.yml` | New "Publish portable tarball + signed manifest" step group |
| edit | `.github/workflows/ci.yml` | New `release-manifest-generator` job (single-purpose, partial seed for #166) |
| edit | `README.md` | §Supply-chain verification stanza for tarball-via-manifest recipe |
| edit | `docs/install-upgrade-track.md` | D1/D2 in-flight status row |

## Test Plan

- **`tests/install/test-generate-manifest.sh`** — 30/30 green locally with GNU tar; SKIPs cleanly on macOS bsdtar-only hosts (informative SKIP, no false PASS); will run on every PR via the new `release-manifest-generator` CI job.
- **`scripts/validate-pr.sh`** PASS (0 errors / 0 warnings).
- **Pre-PR fan-out** (3 parallel subagents): `shell-expert` PASS_WITH_WARNINGS (4 M + 6 L + 6 I); `security-review-expert` PASS_WITH_WARNINGS (1 M + 2 L + 2 I); `linter` PASS. All load-bearing findings folded; details in commit message.
- **The new release.yml step runs only at release time** (push to main triggering semantic-release) — it cannot be exercised on this PR. The first observed run will be the next release after merge; that observation is the first half of ADR-011's binding-flip gate.

## Risk

- **Release-pipeline expansion**: adds ~120 lines to `release.yml`. If `dotnet publish --no-self-contained -p:UseAppHost=false` or `cosign sign-blob` fails on the runner, the release will be left with image + chart + openapi already signed but **no tarball artifacts**. This degrades closed — verifiers cannot complete the cosign chain against a missing manifest, so installers fall back to `--from-source` (Option A). No silent failure mode.
- **Determinism contract**: pinned `umask 022` + `LC_ALL=C` + `TZ=UTC` + commit-time `SOURCE_DATE_EPOCH` → tar `--mtime`. Bytes reproducible across runner image bumps, not just across reruns. **Not load-bearing for cosign trust** — trust comes from the signature, not the SHA. Per ADR-011 §Implementation notes "Reproducibility is a nice-to-have separate from cosign trust."
- **Per-RID sanity check** tightened per security-review-expert finding: `runtimes/<rid>/native` must exist **and be non-empty** for all five RIDs declared by PR D1. A csproj edit that lists an RID but produces an empty native dir now fails the release pipeline rather than producing a tarball that crashes at startup on that host.
- **D3 dependency**: this PR alone does not enable `--from-release` installs. D3 implements the consumer side.

## Ladder context

| PR | Scope | Status |
|---|---|---|
| D1 | csproj `<RuntimeIdentifiers>` + `<RollForward>` | **#251 in flight** (this depends on it logically, but doesn't conflict if landed in either order — D2 inherits D1 once both merge) |
| **D2 (this)** | release.yml portable publish + manifest JSON + cosign sign-blob + Release upload | **This PR** |
| D3 | install.sh `--from-release` opt-in (cosign verify + bsdtar extract + downgrade defense + runtime semver tighten); `scripts/verify-release.sh`; release-tarball-flow test | Next session (deserves full pre-design fan-out + checkmarx) |
| D4 | Cosign as managed dep in `bootstrap-*.sh`; default flip `--from-source` → `--from-release` | Gated on one release cycle of D2 green + D3 smoke test green per ADR-011 |

## Partial credit toward #166

The new `release-manifest-generator` CI job is single-purpose (one script, no Postgres, no dotnet) and validates the manifest generator on every PR. The broader `tests/install/*.sh` suite remains local-only pending **#166**'s full CI wiring (Postgres service container + per-OS matrix). Two-line follow-up in #166 will absorb this targeted job into the umbrella step.

## Refs

- ADR: [`adrs/011-deployment-artifact-format.md`](https://github.com/TheSemicolon/agent-expertise-api/blob/main/adrs/011-deployment-artifact-format.md)
- Tracker: [`docs/install-upgrade-track.md`](docs/install-upgrade-track.md) (D1/D2 rows)
- Issue: **#249** (implementation), #245 (closed by ADR-011)
- Stacked on: **#251** (D1 csproj precondition)
