### PR TITLE
fix(release): harden manifest generator against frameworks-array runtimeconfig shape

### DIFF
--- a/scripts/build/generate-manifest.sh
+++ b/scripts/build/generate-manifest.sh
@@ -152,9 +152,20 @@ esac
 
 # ---------------------------------------------------------------------------
 # requiredRuntime sourced from runtimeconfig (NEVER hand-set — ADR-011)
+#
+# .NET runtimeconfig.json supports two mutually-exclusive shapes:
+#   * runtimeOptions.framework  (singular object) — single shared framework
+#   * runtimeOptions.frameworks (array)           — multiple shared frameworks
+# For a vanilla Microsoft.NET.Sdk.Web app on net10.0 the SDK historically
+# emits the singular form, but the array form is well-formed and SDK behavior
+# is version-sensitive. Defensive: accept both, normalize to an array, then
+# filter to Microsoft.AspNetCore.App (the floor install.sh checks installed
+# runtimes against — NOT Microsoft.NETCore.App, which is a lower-level floor
+# that would give D3's preflight the wrong answer).
 # ---------------------------------------------------------------------------
-required_runtime_name=$(jq -r '.runtimeOptions.framework.name // empty' "$runtime_config")
-required_runtime_version=$(jq -r '.runtimeOptions.framework.version // empty' "$runtime_config")
+framework_jq='(.runtimeOptions.frameworks // [.runtimeOptions.framework // empty]) | map(select(.name == "Microsoft.AspNetCore.App")) | .[0]'
+required_runtime_name=$(jq -r "${framework_jq} | .name // empty" "$runtime_config")
+required_runtime_version=$(jq -r "${framework_jq} | .version // empty" "$runtime_config")
 required_runtime_rollforward=$(jq -r '.runtimeOptions.rollForward // "Minor"' "$runtime_config")
 target_framework=$(jq -r '.runtimeOptions.tfm // empty' "$runtime_config")
 

--- a/tests/install/test-generate-manifest.sh
+++ b/tests/install/test-generate-manifest.sh
@@ -324,14 +324,80 @@ assert "case 13: publishMode override flows into manifest" \
   bash -c "[ \"\$(jq -r .publishMode '$out13')\" = 'self-contained' ]"
 
 # ---------------------------------------------------------------------------
+# Case 14: runtimeconfig.json with `frameworks` ARRAY form (single entry).
+# .NET SDK is permitted to emit either singular `.framework` (the typical
+# Microsoft.NET.Sdk.Web shape) OR an array `.frameworks` shape. The
+# defensive jq path must accept both and produce the same manifest. This
+# is the principal regression test for the runtimeconfig-shape-tolerance
+# refactor (D2.1 / generate-manifest defensive jq).
+# ---------------------------------------------------------------------------
+case14=${SCRATCH}/case14
+publish14=$(build_fixture "$case14" '{"runtimeOptions":{"tfm":"net10.0","rollForward":"LatestMinor","frameworks":[{"name":"Microsoft.AspNetCore.App","version":"10.0.0"}]}}')
+out14=${case14}/manifest.json
+run_gen \
+  --publish-dir "$publish14" \
+  --app-version "1.2.3" \
+  --git-sha "abc" \
+  --tarball "${case14}/artifact.tar.gz" \
+  --source-date-epoch "1577836800" \
+  --output "$out14" >/dev/null 2>&1
+assert "case 14: frameworks-array form yields requiredRuntime.name = AspNetCore.App" \
+  bash -c "[ \"\$(jq -r .requiredRuntime.name '$out14')\" = 'Microsoft.AspNetCore.App' ]"
+assert "case 14: frameworks-array form yields requiredRuntime.minVersion = 10.0.0" \
+  bash -c "[ \"\$(jq -r .requiredRuntime.minVersion '$out14')\" = '10.0.0' ]"
+
+# ---------------------------------------------------------------------------
+# Case 15: runtimeconfig.json with `frameworks` array containing BOTH
+# Microsoft.NETCore.App and Microsoft.AspNetCore.App. The filter MUST pick
+# AspNetCore.App (NETCore.App is a lower-level floor that would give
+# install.sh's preflight the wrong answer).
+# ---------------------------------------------------------------------------
+case15=${SCRATCH}/case15
+publish15=$(build_fixture "$case15" '{"runtimeOptions":{"tfm":"net10.0","frameworks":[{"name":"Microsoft.NETCore.App","version":"10.0.0"},{"name":"Microsoft.AspNetCore.App","version":"10.0.5"}]}}')
+out15=${case15}/manifest.json
+run_gen \
+  --publish-dir "$publish15" \
+  --app-version "1.2.3" \
+  --git-sha "abc" \
+  --tarball "${case15}/artifact.tar.gz" \
+  --source-date-epoch "1577836800" \
+  --output "$out15" >/dev/null 2>&1
+assert "case 15: multi-framework array picks AspNetCore.App, not NETCore.App" \
+  bash -c "[ \"\$(jq -r .requiredRuntime.name '$out15')\" = 'Microsoft.AspNetCore.App' ]"
+assert "case 15: multi-framework array picks AspNetCore.App version (10.0.5), not NETCore (10.0.0)" \
+  bash -c "[ \"\$(jq -r .requiredRuntime.minVersion '$out15')\" = '10.0.5' ]"
+
+# ---------------------------------------------------------------------------
+# Case 16: runtimeconfig.json with frameworks-array containing ONLY
+# Microsoft.NETCore.App (no AspNetCore.App). install.sh preflight checks
+# the AspNetCore floor; emitting a manifest with no AspNetCore floor
+# would either misdirect preflight or silently pass garbage. Refuse to
+# emit (exit 2 + actionable error message).
+# ---------------------------------------------------------------------------
+case16=${SCRATCH}/case16
+publish16=$(build_fixture "$case16" '{"runtimeOptions":{"tfm":"net10.0","frameworks":[{"name":"Microsoft.NETCore.App","version":"10.0.0"}]}}')
+out16=${case16}/manifest.json
+run_gen --publish-dir "$publish16" --app-version "1.2.3" --git-sha "abc" \
+  --tarball "${case16}/artifact.tar.gz" --source-date-epoch "1577836800" \
+  --output "$out16" >/dev/null 2>&1 && rc=0 || rc=$?
+assert "case 16: refuses when frameworks array lacks AspNetCore.App" \
+  bash -c "[ '$rc' -ne 0 ]"
+assert "case 16: did not produce a manifest file" \
+  bash -c "[ ! -s '$out16' ]"
+
+# ---------------------------------------------------------------------------
 # Static lint-time guard: refuse to emit a manifest that hand-sets
 # requiredRuntime — the script must always read it from runtimeconfig.
 # Grep-based defense (mirrors the argv-leak guard in test-bootstrap-common).
 # ---------------------------------------------------------------------------
 assert "static guard: no hardcoded requiredRuntime.minVersion in generator" \
   bash -c "! grep -E 'requiredRuntime.minVersion[[:space:]]*=[[:space:]]*\"?[0-9]' '$GEN'"
-assert "static guard: requiredRuntime sourced via jq from runtimeconfig" \
-  bash -c "grep -qE 'jq -r .{0,2}\.runtimeOptions\.framework\.version' '$GEN'"
+assert "static guard: requiredRuntime sourced via jq from runtimeconfig (D2.1 framework_jq form)" \
+  bash -c "grep -qF 'framework_jq' '$GEN'"
+assert "static guard: defensive filter pins Microsoft.AspNetCore.App" \
+  bash -c "grep -qF 'Microsoft.AspNetCore.App' '$GEN'"
+assert "static guard: accepts both singular .framework AND array .frameworks shapes" \
+  bash -c "grep -qF '.runtimeOptions.frameworks' '$GEN' && grep -qF '.runtimeOptions.framework' '$GEN'"
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
## Summary

**D2.1 precursor to D3 (#249)** — surfaced during D3 pre-design fan-out by `dotnet-expert`.

.NET `runtimeconfig.json` supports two mutually-exclusive shapes for the shared-framework reference:

- `runtimeOptions.framework` *(singular object)* — single shared framework
- `runtimeOptions.frameworks` *(array of objects)* — multiple shared frameworks

For a vanilla `Microsoft.NET.Sdk.Web` project on `net10.0` the SDK historically emits the **singular** form. We cannot empirically verify the .NET 10 SDK shape this turn (no local dotnet, no container runtime, no D2 release artifact yet — `release.yml` only runs on push to `main` and no release has cut since D2 merged as `6929bdb`).

`dotnet-expert`'s recommendation, regardless of which shape the SDK actually emits today: **harden the jq path defensively to accept BOTH shapes and EXPLICITLY filter to `Microsoft.AspNetCore.App`** rather than blindly reading `.framework.version`.

### Why this matters for D3 specifically

`install.sh` preflight (D3 work) will compare `manifest.requiredRuntime.minVersion` against installed ASP.NET Core runtimes via `dotnet --list-runtimes | awk '$1=="Microsoft.AspNetCore.App"'`. If D2 silently emitted the **`Microsoft.NETCore.App`** floor (a lower-level dependency, usually with the same version but conceptually different) the preflight would pass on a host with sufficient `.NETCore.App` but **insufficient `AspNetCore.App`**, and the service would fail at launch with hostfxr's *"no compatible framework"* error.

## Files

| Status | Path | Purpose |
|---|---|---|
| edit | `scripts/build/generate-manifest.sh` | Replace `.runtimeOptions.framework.{name,version}` direct reads with normalized jq path: `(.runtimeOptions.frameworks // [.runtimeOptions.framework // empty]) \| map(select(.name == "Microsoft.AspNetCore.App")) \| .[0]`. 8-line comment documents the SDK version-sensitivity and the AspNetCore-vs-NETCore filter rationale. **No behavior change for the singular-`.framework` case** (the typical `Microsoft.NET.Sdk.Web` shape). |
| edit | `tests/install/test-generate-manifest.sh` | Cases 14, 15, 16 + 2 expanded static guards (see below) |

### Test additions

- **Case 14** — `frameworks` array with single `AspNetCore.App` entry yields the same manifest as the singular form.
- **Case 15** — `frameworks` array with **both** `NETCore.App` + `AspNetCore.App` filters to `AspNetCore.App` (distinct versions: `10.0.0` vs `10.0.5`, so the test proves the *filter*, not just iteration order).
- **Case 16** — `frameworks` array with **only** `NETCore.App` refuses to emit (exit 2, no output file).
- **Updated static guards** — grep for the new `$framework_jq` variable shape, the `Microsoft.AspNetCore.App` filter constant, and the both-shapes acceptance pattern.

## Test Plan

```text
tests/install/test-generate-manifest.sh: 38 passed, 0 failed
  (was 30; +6 new assertions across cases 14-16, +2 expanded static guards)
```

| Gate | Result |
|---|---|
| `shellcheck` | clean |
| `scripts/validate-pr.sh` | PASS (0 errors / 0 warnings) |
| CI release-manifest-generator job (from PR #252) | will exercise the new cases on this PR |

## Risk

- **Behavior preserved for the expected singular `.framework` case.** Cases 1, 12, 12b, 13 all still pass — those exercise the singular form.
- **No change to release.yml.** The portable-publish step still produces whatever shape the .NET 10 SDK chooses; this PR only changes how the generator *interprets* what it finds.
- **Manifest schema unchanged.** Consumers (D3 install.sh) see the same `requiredRuntime.{name,version}` shape regardless of input.

## Ladder context

| PR | Scope | Status |
|---|---|---|
| D1 (#251) | csproj `<RuntimeIdentifiers>` + `<RollForward>` | ✅ merged `a54aabf` |
| D2 (#252) | release.yml portable publish + manifest + cosign sign-blob | ✅ merged `6929bdb` |
| **D2.1 (this)** | Defensive jq for runtimeconfig shape — unblocks D3 | **This PR** |
| D3 | install.sh `--from-release` opt-in + verify-then-extract + downgrade defense | next turn (full pre-PR fan-out per ADR-011 + #249 AC: shell + security + checkmarx) |
| D4 | Cosign as managed dep in bootstrap; default flip `--from-source` → `--from-release` | gated per ADR-011 |

## Refs

- ADR: [`adrs/011-deployment-artifact-format.md`](https://github.com/TheSemicolon/agent-expertise-api/blob/main/adrs/011-deployment-artifact-format.md) §"Manifest source-of-truth"
- Issue: **#249** (D3 unblocks once this lands)
- Surfaced by: D3 pre-design fan-out (`dotnet-expert` Q3) as a CONDITIONAL blocker for D3
