### PR TITLE
fix(release): bump global.json rollForward to latestFeature

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "10.0.100",
-    "rollForward": "latestPatch",
+    "rollForward": "latestFeature",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
## Summary

One-line fix: `global.json` `rollForward: latestPatch` → `latestFeature`.

Unblocks the Docker build inside `release.yml` after `mcr.microsoft.com/dotnet/sdk:10.0` rotated to ship SDK `10.0.300` (new feature band). The existing `latestPatch` setting only matched within the same feature band (`10.0.1xx`); `latestFeature` matches across feature bands within the same `major.minor`, restoring compatibility with the floating tag.

Restores the documented intent in CLAUDE.md ("Prerequisites" \u2014 "latestFeature rollforward").

## Test Plan

- CI on dev runs `actions/setup-dotnet` with the exact 10.0.100 SDK \u2014 unaffected
- Docker build inside release.yml is the failure surface; this fix is verified by the subsequent dev \u2192 main re-promotion run

## Risk

**Low.** Single-character semantic change in a config file. Already the documented intent. `latestFeature` is the more permissive rollforward; cannot reject any SDK that `latestPatch` accepted.

## Follows

- #269 (recovery option 1)
- ADR-011 (deployment artifact format)