### PR TITLE
chore: promote dev to main for v1.0.0 release (retry)

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "10.0.100",
-    "rollForward": "latestPatch",
+    "rollForward": "latestFeature",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
## Summary

Re-promote dev → main after #269 / #270 fixed the SDK feature-band drift that broke the first attempt (#268).

Only delta from #268: one commit `9b9b819 fix(release): bump global.json rollForward to latestFeature (#270)`. All other content is identical to PR #268's body.

v1.0.0 tag + GitHub Release were deleted post-failure (no consumers existed), so semantic-release will re-detect the same MAJOR bump from the same 3 `!`-marked commits and re-create v1.0.0 with full artifact set.

## What this triggers

1. Semantic Release → re-creates v1.0.0 tag + GitHub Release
2. Docker build → succeeds with SDK 10.0.300 (now accepted by `latestFeature` rollforward)
3. Multi-arch image push to GHCR
4. cosign keyless sign image digest
5. Helm chart package + push to GHCR OCI + cosign sign
6. openapi.json attached to release + cosign sign
7. **D2 portable tarball + signed manifest** — first prod run

## Test Plan

- Pre-merge: CI green on dev tip (PR #270 verified all 16 checks)
- Local merge result: 1 file changed, no conflicts
- Post-merge: watch release.yml live; on success run `scripts/verify-release.sh` against v1.0.0

## Risk

**Medium** (down from High on #268). The known failure surface (Docker SDK pin) is patched. Remaining risk is the D2 stanza which has only ever run in unit-test harness.

## Merge instructions

`gh pr merge --merge` (preserves dev parent for semantic-release commit walk).