### PR TITLE
fix(release): make chart-sync step idempotent for partial-release retry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,18 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add helm/expertise-api/Chart.yaml
-          git commit -m "chore(helm): sync chart version + appVersion to ${NEW_VERSION} [skip ci]"
-          git push
+          # Idempotent: skip the commit if the chart is already at NEW_VERSION.
+          # This case arises during a release.yml retry after a partial-release
+          # cleanup where the v<NEW_VERSION> tag was deleted but the prior
+          # run's chart-sync commit remains on main. Without this guard,
+          # `git commit` exits 1 on "nothing to commit" and the whole job
+          # fails, gating Build & Push from ever running.
+          if git diff --cached --quiet; then
+            echo "chart already at ${NEW_VERSION}; sync is a no-op (likely a retry after partial-release cleanup)"
+          else
+            git commit -m "chore(helm): sync chart version + appVersion to ${NEW_VERSION} [skip ci]"
+            git push
+          fi
 
   build-and-push:
     name: Build & Push Docker Image


### PR DESCRIPTION
## Summary

Guards `release.yml`'s "Sync Chart.yaml version + appVersion" step behind a `git diff --cached --quiet` check so it no-ops cleanly when the chart is already at NEW_VERSION (instead of failing the whole job with `git commit`'s "nothing to commit" exit 1).

## Why

Surfaced during the v1.0.0 recovery cycle (#269, #270). After tag/release deletion forces a release.yml retry, the prior run's chart-sync commit (`7613da1` for v1.0.0) is still on `main`. The retry's `yq -i` produces no diff → `git commit` exits 1 → `set -e` propagates → job fails → Build & Push gated, never runs → another partial release.

Without this fix, every partial-release retry hits the same trap and we cannot recover via the documented path.

## Test Plan

- `yamllint .github/workflows/release.yml` clean
- The fix is verified by the subsequent v1.0.0 retry actually completing (out-of-PR test, by construction)

## Risk

**Low.** Purely additive guard around an existing two-line block. The success path (commit + push when there IS a diff) is unchanged. The new branch (log + skip when there is NOT a diff) is exactly what a hand-operated rerun would do.