### PR TITLE
docs(install-track): record v1.0.0 cut and surface 'next session starts here'

### DIFF
--- a/docs/install-upgrade-track.md
+++ b/docs/install-upgrade-track.md
@@ -2,9 +2,49 @@
 
 Persistent TODO for the multi-PR effort that gets the native-service install path (Archetype A2) ready for pi-agent integration. Updated at the end of every working session.
 
-**Last updated:** 2026-05-23 (PRs A+B+C1 merged; ADR-011 merged; D1+D2+D2.1+D3 merged; E1+E2 merged; D4-macOS-cosign in flight; #166 + #215 closed)
+**Last updated:** 2026-05-23 (v1.0.0 SHIPPED with signed artifacts — first prod release.yml run; D4-macOS-cosign merged; #166 + #215 + #269 closed)
 **Driver issue:** [#230 readiness sweep](https://github.com/TheSemicolon/agent-expertise-api/issues/230)
 **Goal:** make `scripts/install.sh` safe, upgrade-aware, and capable of bootstrapping host dependencies on macOS (primary) and Linux, so the pi-agent integration session has a turn-key target.
+
+## Next session starts here 👇
+
+**State as of 2026-05-23 23:59 UTC:**
+
+- `dev` is **clean**, ~3 commits ahead of `main` (the recovery PRs #270/#272 + this tracker commit).
+- `main` is at `v1.0.0` tagged + published with full artifact set:
+  - Docker image `ghcr.io/thesemicolon/agent-expertise-api:v1.0.0` (multi-arch, cosign-signed)
+  - Helm chart `ghcr.io/thesemicolon/charts/expertise-api:1.0.0` (cosign-signed)
+  - Portable tarball `expertise-api-1.0.0-portable.tar.gz` (263 MB) + manifest + cosign sig (ADR-011 Option B)
+  - openapi.json + sha256 + cosign sig
+  - **End-to-end cosign verify-blob PASSED** locally via `scripts/verify-release.sh` against the published artifacts — D2 stanza confirmed working in prod OIDC.
+
+### Top of stack (do these first next session)
+
+1. **E3 (#260)** is now fully unblocked — we have a real signed v1.0.0 to verify against. Write the workflow that runs `install.sh --from-release --version v1.0.0`, cosign-verifies the manifest, extracts the tarball, runs the install, asserts post-install markers (`.install-mode == release`, `.install-version-semver` non-empty). Path-filter trigger on `scripts/install.sh`, `scripts/verify-release.sh`, `scripts/lib/release-consumer.sh`, `.github/workflows/release.yml`. Required green on `dev` for one release cycle to gate D4 default-flip.
+
+2. **D4 default-flip (#249)** — gated on E3 green. When ready: PR that flips `install.sh`'s default install mode from `--from-source` to `--from-release`. ADR-011 binding-flip rule applies. macOS-cosign half already landed (#267, `549e6cc`); Linux halves still bundled with C2/C3.
+
+3. **C2 (#246) / C3 (#247)** — Debian/Ubuntu + RHEL/Fedora bootstrap modules. Scope contracted to `cosign + bsdtar` per ADR-011 Option B. WSL warn-and-refuse for Postgres unchanged. Can be done in parallel with E3 since they don't share files.
+
+### Other open follow-ups (lower priority)
+
+- **#262/#263** — install.sh `migrate` env-mirror + log-flush bugs surfaced during D3 review.
+- **#242** — PREFIX-parent TOCTOU in `--system` mode (bundled with #145 LaunchDaemon work).
+- **#255/#256/#257** — D3 follow-ups (`--tarball-url`, `--allow-offline-verify`, SemVer §11 comparator).
+- **#266** — pre-existing apostrophe parsing bug in `tests/install/test-install-deps-flag.sh`. Trivial fix, surfaced during PR #267 pre-PR.
+- **#183** — release.yml re-run idempotency (broader than #269's specific fix; can now reference the v1.0.0 recovery as a worked example).
+
+### Hard-won lessons from the v1.0.0 cut (worth remembering)
+
+1. **First-prod release.yml exposed 2 latent defects** that no unit test could catch:
+   - **SDK feature-band drift** — `global.json` `latestPatch` rollforward only matches within the same feature band (10.0.1xx). When MS rotated the `mcr.microsoft.com/dotnet/sdk:10.0` floating tag to 10.0.300, Docker build broke. Fixed in #270 by switching to `latestFeature` (which is what CLAUDE.md documents anyway).
+   - **chart-sync non-idempotency** — the "Sync Chart.yaml version + appVersion" step ran `git commit` unconditionally; on a partial-release retry the chart is already at NEW_VERSION, commit exits 1, `set -e` propagates, build job is gated off. Fixed in #272 with `git diff --cached --quiet` guard.
+2. **Recovery procedure that worked**: file issue → fix on dev → PR → merge → `gh release delete v1.0.0 --cleanup-tag --yes` → re-merge dev → main. The destructive option is acceptable when the broken release has no consumers (no GHCR artifacts published yet).
+3. **dev → main promotion mechanics:**
+   - Use `git merge -X theirs` to favor dev wholesale when dev is a functional superset of main (was true for us; verified by spot-checking that dev contained the equivalent of every main-only hotfix).
+   - Use `gh pr merge --merge` (NOT `--squash`) on the promotion PR so semantic-release can walk both parents and see `!` commits.
+   - There WILL be conflicts on any non-trivial dev → main promotion if any commits ever go direct-to-main. Don't assume a fast-forward.
+4. **Don't forget the chart-sync commit's persistence** during recovery. After `gh release delete --cleanup-tag`, the chart-sync commit remains on main's history and bites the retry unless the workflow is idempotent (now is, post-#272).
 
 ## Out of scope for this track
 
@@ -28,10 +68,10 @@ Persistent TODO for the multi-PR effort that gets the native-service install pat
 | D1 | csproj `<RuntimeIdentifiers>` + `<RollForward>` precondition | #249 | ☑ merged as `a54aabf` (#251) | One-line csproj addition. Hard precondition for D2 portable publish (ONNX RID natives). Zero behavior change to docker/helm/`dotnet run`/existing A2 installs. |
 | D2 | release.yml portable publish + manifest + cosign sign-blob | #249 | ☑ merged as `6929bdb` (#252) | `scripts/build/generate-manifest.sh` + 30-assertion test suite; release.yml publish/manifest/sign/upload steps; README §Supply-chain verification stanza for the tarball-via-manifest recipe; CI `release-manifest-generator` job seeds #166 incrementally. First D2 production run gates the D4 default-flip per ADR-011. |
 | D3 | install.sh `--from-release` opt-in (cosign verify + bsdtar extract + downgrade defense + runtime semver tighten) | #249 | ☑ merged as `88d20b1` (#258) | Load-bearing PR. Ships `scripts/verify-release.sh` (sanctioned cosign-verify entrypoint), `scripts/lib/release-consumer.sh` (fetch/verify/inspect/extract/markers), install.sh wiring (`--from-release` / `--from-source` / `--version` / `--allow-downgrade` / `--accept-republished-version` / `--skip-release-api-crosscheck`), and `tests/install/test-release-tarball-flow.sh` (39 assertions). Pre-PR fan-out folded 2 HIGH + 4 MED + 5 LOW. Follow-up flags deferred to #255 (`--tarball-url`) and #256 (`--allow-offline-verify`); SemVer §11 comparator deferred to #257. |
-| D4 | Cosign as managed dep in `bootstrap-*.sh`; default flip `--from-source` → `--from-release` | #249 | ◐ macOS half in flight (`feat/macos-bootstrap-cosign`); Linux halves bundle with C2/C3; default-flip still gated | macOS half adds `_macos_ensure_cosign` to `bootstrap-macos.sh` (Homebrew, idempotent, honors any cosign on PATH — not just brew-managed). bsdtar intentionally not installed (macOS `/usr/bin/tar` IS bsdtar; release-consumer.sh::rc_select_tar already auto-detects). Linux halves still pending in C2 (#246) / C3 (#247). **Default flip itself still gated** on (a) one release cycle of D2 green publishing manifest+sig artifacts; (b) E3 (#260) `--from-release` smoke green on macOS + Ubuntu runners — the macOS-cosign-in-bootstrap PR explicitly does NOT flip the default. ADR-011 binding-flip rule. |
+| D4 | Cosign as managed dep in `bootstrap-*.sh`; default flip `--from-source` → `--from-release` | #249 | ◐ macOS half landed (#267, `549e6cc`); Linux halves bundle with C2/C3; default-flip still gated | macOS half adds `_macos_ensure_cosign` to `bootstrap-macos.sh` (Homebrew, idempotent, honors any cosign on PATH). bsdtar intentionally not installed (macOS `/usr/bin/tar` IS bsdtar; release-consumer.sh::rc_select_tar already auto-detects). Linux halves still pending in C2 (#246) / C3 (#247). **Default flip itself still gated** on E3 (#260) green for one release cycle. D2 production-verified by the v1.0.0 cut on 2026-05-23. |
 | E1 | install.sh end-to-end smoke (Linux / systemd-user / postgres-17 in privileged container) | #166 | ☑ merged as `122542d` (#261) | Ships `scripts/test/Dockerfile.install-smoke` (debian13 + systemd + postgres17 + dotnet-sdk-10) + `scripts/test/test-install-smoke.sh` (12-assertion harness) + new `install-smoke-linux` job in `ci.yml`. Covers the primary AC of #166 (Linux + Postgres + service install + restart + health + orphan check). Container approach mirrors the existing apictl-restart-race-debian13 precedent (privileged systemd-in-container with cgroup v2 unified mount + host-uid 1000 user); deviates from #166's suggested GHA `services:` shape because the smoke needs systemd-user for service-install/restart parity with real hosts, which GHA's host runner does not give cleanly. Harness is OS-agnostic by design so E2 (macOS) reuses it without modification. First run on dev: 1m58s, all 12 assertions PASS. |
 | E2 | macOS install.sh smoke (`brew install postgresql@17`, reuses E1 harness) | #259 | ☑ merged as `731cba3` (#264) | Closes the stretch AC of #166. Adds `install-smoke-macos` to `ci.yml` (macos-latest / arm64, brew-installed postgresql@17 + pgvector, no privileged container). Reuses `scripts/test/test-install-smoke.sh` — the macOS branches seeded in E1 (`start_postgres_macos`, Darwin psql dispatch, BSD-pgrep guard) ran for the first time and exposed one harness bug: hardcoded `DOTNET_ROOT=/usr/share/dotnet` overrode the GHA-runner's `/Users/runner/.dotnet`, breaking the FDD apphost. Fixed in the same PR (honor caller `DOTNET_ROOT`; per-OS fallback). Pre-PR fan-out (code-review + security + linter) PASS; two Info-level hardening notes folded in (postgresql@14 collision check + pgvector hard-fail probe). First green run on dev: 1m58s wall clock, 12/12 assertions PASS. |
-| E3 | `--from-release` install.sh smoke (both OSes; gates D4 default-flip) | #260 | ☐ deferred (depends on E1 + a real signed release on main) | Runs `install.sh --from-release --version vX.Y.Z` against the latest cosign-signed release. Path-filter trigger on `scripts/install.sh`, `scripts/verify-release.sh`, `scripts/lib/release-consumer.sh`, `.github/workflows/release.yml`. Asserts D3 post-install markers (`.install-mode == release`, `.install-version-semver` non-empty). Required green for one release cycle on `dev` to unblock D4. |
+| E3 | `--from-release` install.sh smoke (both OSes; gates D4 default-flip) | #260 | ☐ **unblocked 2026-05-23** — v1.0.0 signed release now exists on `main` to verify against | Runs `install.sh --from-release --version v1.0.0` against the latest cosign-signed release. Path-filter trigger on `scripts/install.sh`, `scripts/verify-release.sh`, `scripts/lib/release-consumer.sh`, `.github/workflows/release.yml`. Asserts D3 post-install markers (`.install-mode == release`, `.install-version-semver` non-empty). Required green for one release cycle on `dev` to unblock D4. Local `scripts/verify-release.sh` against published v1.0.0 already PASSed end-to-end (signature + Fulcio identity + sha256). |
 | T | Upgrade-roundtrip test | (landed w/ B) | ☑ in PR B | `tests/install/test-upgrade-roundtrip.sh` (39 assertions). Extend in C1 for `--install-deps` paths. |
 
 Status legend: ☐ todo · ◐ in progress · ☑ merged · ✗ abandoned.
@@ -132,6 +172,8 @@ Status legend: ☐ todo · ◐ in progress · ☑ merged · ✗ abandoned.
 - Doc-sync pairs touched: README Archetype A2 section, CLAUDE.md Quick Start.
 
 ## Session log
+
+- **2026-05-23 (late)** — **v1.0.0 SHIPPED.** First production release with full signed artifact set. Cut path: PR #267 (macOS-cosign-in-bootstrap, `549e6cc`) → PR #268 (dev → main promotion attempt 1, `13020009`; merged but exposed two release.yml defects) → PR #270 (`global.json` rollForward `latestPatch` → `latestFeature`, `9b9b819`; fixes SDK feature-band drift) → PR #271 (retry 1; exposed chart-sync non-idempotency) → PR #272 (chart-sync idempotency guard, `30e58fb`) → PR #273 (retry 2 — **all green**). v1.0.0 tag/release deleted twice during recovery; no consumers affected (no artifacts had been published to GHCR at delete time). Final release: Docker multi-arch + signed, Helm chart + signed, openapi.json + signed, **portable tarball + manifest + cosign sig (D2 first prod run)**. End-to-end `scripts/verify-release.sh` against v1.0.0 PASS locally (cosign verify-blob OK, identity = `release.yml@refs/heads/main`, issuer = `token.actions.githubusercontent.com`, Rekor inclusion, sha256 cross-check OK). Issue #269 filed during the recovery and closed by the chain above. Unblocks E3 (#260) and D4 default-flip (#249).
 
 - **2026-05-23** — PR E2 (#264) merged to dev as `731cba3`. Closes #259 and #166 (both primary + stretch ACs now covered). Post-merge CI green: CI 1m54s / CodeQL 2m40s / Security 24s. macOS smoke first run: 1m58s, 12/12 PASS. Bug surfaced & fixed in the same PR: harness's hardcoded `DOTNET_ROOT=/usr/share/dotnet` (Linux container path) broke FDD apphost on macOS GHA runners; fix honors caller `DOTNET_ROOT` with per-OS fallback. Unblocks #260 (E3 `--from-release` smoke on both OSes, gates D4 default-flip per ADR-011).
 - **2026-05-23** — PR E1 (#261) merged to dev as `122542d`. #166 primary AC closed (Linux). Post-merge CI green: CI 1m58s / CodeQL 2m39s / Security 26s. Unblocks E2 (#259 macOS smoke, reuses harness unchanged) and E3 (#260 `--from-release` smoke, gates D4 default-flip).


### PR DESCRIPTION
## Summary

Doc-only update to the install/upgrade tracker after the v1.0.0 release shipped on 2026-05-23.

## What changes

- **Header**: `Last updated` line + new `Next session starts here` section at the top with current state, top of stack (E3 \u2192 D4 \u2192 C2/C3), lower-priority follow-ups, and hard-won lessons from the v1.0.0 cut.
- **D4 row**: macOS half marked landed (#267); D2 marked production-verified by the v1.0.0 cut; default-flip gating simplified to E3.
- **E3 row**: \u2610 deferred \u2192 \u2610 **unblocked 2026-05-23** (real signed v1.0.0 now exists to verify against).
- **Session log**: full recap of the 6-PR cut path (#267 \u2192 #268 \u2192 #270 \u2192 #271 \u2192 #272 \u2192 #273) and the two latent release.yml defects exposed.

## Test Plan

Doc-only. `markdownlint` will run in CI.

## Risk

**None.** Doc-only change to a session-tracker file.