### PR TITLE
fix(install): hard-error --system on macos until launchdaemon support

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -392,6 +392,16 @@ preflight() {
   STAGE="preflight"
   log "pre-flight: OS=${OS} RID=${RID} scope=${INSTALL_SCOPE} mode=${PUBLISH_MODE}"
 
+  # Guard: macOS system-scope is not yet implemented. LaunchDaemon support
+  # (root-owned /Library/LaunchDaemons/, reboot survival) is tracked by #145.
+  # Hard-error here — before any filesystem mutation — so no partial install
+  # artifacts exist when this exit path is taken. Exit 2 = precondition
+  # failure per scripts/script-output-conventions.md.
+  if [[ "${OS}" == "macos" && "${INSTALL_SCOPE}" == "system" ]]; then
+    printf '[install] ERROR: --system is not supported on macOS (see #145 for LaunchDaemon support). Use the default user-LaunchAgent mode (omit --system).\n' >&2
+    exit 2
+  fi
+
   if [[ "${PUBLISH_MODE}" == "fdd" ]]; then
     command -v dotnet >/dev/null 2>&1 \
       || err "dotnet CLI not found in PATH (required for fdd; pass --publish-mode scd to skip)"

--- a/scripts/test/test-install-smoke.sh
+++ b/scripts/test/test-install-smoke.sh
@@ -464,6 +464,51 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 11. macOS-only: install.sh --system must hard-error exit 2 (preflight
+#     guard for #285) and print the expected ERROR line naming #145.
+#     This assertion is macOS-specific; on Linux --system errors at a
+#     different stage (install_service, exit 1) — that behavior is not
+#     the subject of this fix and is tested separately.
+# ---------------------------------------------------------------------------
+case "$(uname -s)" in
+  Darwin)
+    # Do NOT pass --skip-preflight: the guard lives in preflight() and must
+    # fire before --skip-preflight would bypass it. The guard is the FIRST
+    # check in preflight(), so no real host probes run on this code path.
+    # Use a sub-directory of ${PREFIX} (which contains "expertise-api" as a
+    # path component) so prefix-validation passes without --allow-system-prefix.
+    #
+    # Capture stdout+stderr WITHOUT || true so that $? reflects install.sh's
+    # exit code, not `true`. set +e / set -e wraps the subshell to prevent
+    # the outer set -u pipeline from aborting on the expected non-zero exit.
+    set +e
+    _system_err_output=$(bash "${ROOT}/scripts/install.sh" \
+      --prefix "${PREFIX}/_system_guard_probe" \
+      --system \
+      2>&1)
+    _system_rc=$?
+    set -e
+    if [ "${_system_rc}" = "2" ]; then
+      PASS=$((PASS + 1))
+      printf 'PASS: install.sh --system exits 2 on macOS\n'
+    else
+      FAIL=$((FAIL + 1))
+      printf 'FAIL: install.sh --system exited %d on macOS (expected 2)\n' "${_system_rc}" >&2
+    fi
+    if printf '%s\n' "${_system_err_output}" | grep -qF '#145'; then
+      PASS=$((PASS + 1))
+      printf 'PASS: install.sh --system error output names #145\n'
+    else
+      FAIL=$((FAIL + 1))
+      printf 'FAIL: install.sh --system error output did not mention #145 (got: %s)\n' "${_system_err_output}" >&2
+    fi
+    ;;
+  *)
+    log "SKIP: --system macOS preflight guard test (not running on Darwin; uname=$(uname -s))"
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -71,6 +71,15 @@ case "$(uname -s)" in
   *)      err "unsupported OS: $(uname -s) — use uninstall.ps1 on Windows" ;;
 esac
 
+# Guard: macOS system-scope is not yet implemented. LaunchDaemon support
+# (root-owned /Library/LaunchDaemons/) is tracked by #145. Hard-error here
+# so uninstall.sh --system cannot silently target the wrong service path.
+# Exit 2 = precondition failure per scripts/script-output-conventions.md.
+if [ "${OS}" = "macos" ] && [ "${INSTALL_SCOPE}" = "system" ]; then
+  printf '[uninstall] ERROR: --system is not supported on macOS (see #145 for LaunchDaemon support). Use the default user-LaunchAgent mode (omit --system).\n' >&2
+  exit 2
+fi
+
 # ----------------------------------------------------------------------------
 # Prefix normalization + validation
 #


### PR DESCRIPTION
## Summary

On macOS, `install.sh --system` silently fell through to the user-LaunchAgent path — the operator asked for a system-wide LaunchDaemon and got a login-session-scoped service with no warning. Both `install.sh` and `uninstall.sh` now hard-error (exit 2) at preflight on Darwin + `--system`, before any filesystem mutation, with an ERROR message pointing at #145 (the opt-in LaunchDaemon track). A Darwin-only smoke assertion validates the exit code and the #145 reference; it SKIPs on Linux, where `--system` remains valid.

Closes #285.

## Type of Change

- [x] `fix` — bug fix

## Test Plan

- [x] New smoke assertion (exit 2 + `#145` in stderr) in `scripts/test/test-install-smoke.sh`, runs in the existing `install-smoke-macos` CI job
- [x] `bash -n` + `shellcheck` clean on changed files (3 pre-existing harness findings untouched)
- [ ] `dotnet test` — N/A, no C# changes
- Guard sits first in `preflight()`; the only residual on the exit path is the empty `${PREFIX}` dir from lock acquisition (cleanup trap releases the lock)

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files
- [x] Database migrations — N/A
- [x] API changes — N/A
- [x] CLAUDE.md / README — README already documents macOS as "launchd LaunchAgent (per-user)"; no doc claims `--system` works on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
