### PR TITLE
fix(migrate): standalone env exports, serilog flush on cli verbs, deps-flag test quoting

### DIFF
--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -74,6 +74,21 @@ else
   warn "no secrets file at ${SECRETS_FILE} — relying on environment"
 fi
 
+# Mirror the launch wrapper's env exports so the migrate verb's DI graph
+# matches the runtime graph exactly. Program.cs registers IEmbeddingGenerator
+# only if File.Exists(Onnx:ModelPath) && File.Exists(Onnx:VocabPath); without
+# these exports the default ${baseDir}/models/ path is wrong for a staged or
+# installed layout, causing EmbeddingService DI validation to fail at startup
+# before any migration runs (issue #262).
+#
+# Honour any value already in the environment (allows CI or the operator to
+# override without editing this script). The fallback uses ${PREFIX}/models/
+# which matches the install layout written by install.sh's write_wrapper().
+export ASPNETCORE_ENVIRONMENT="${ASPNETCORE_ENVIRONMENT:-Production}"
+MODEL_DIR="${PREFIX}/models"
+export Onnx__ModelPath="${Onnx__ModelPath:-${MODEL_DIR}/model.onnx}"
+export Onnx__VocabPath="${Onnx__VocabPath:-${MODEL_DIR}/vocab.txt}"
+
 # Fail-fast guard: a missing or placeholder connection string would cause
 # the migrate verb to hang on connection-establishment (Npgsql default
 # Timeout=15s) and print a generic Npgsql error. Better to surface the

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -433,6 +433,17 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
 
 var app = builder.Build();
 
+// Top-level Serilog flush guard — wraps ALL post-Build() paths (one-shot CLI
+// verbs AND the long-running web host) so the Console sink's async buffer is
+// always drained before process exit. Without this outer try/finally the CLI
+// verb branches (`return;` below) bypass the web-host `finally` at the bottom
+// of this file, causing Serilog to swallow every buffered log entry when
+// stdout is not a TTY (i.e. piped output, CI, journalctl). Documented pattern:
+// https://github.com/serilog/serilog-aspnetcore#two-stage-initialization
+// Fixes issue #263.
+try
+{
+
 if (MigrateCommand.IsMigrateRequested(args))
 {
     // Surfaces a non-zero exit code so scripts/install.{sh,ps1} and
@@ -547,7 +558,9 @@ catch (Exception ex)
     Log.Fatal(ex, "Application terminated unexpectedly");
     Environment.ExitCode = 1;
 }
-finally { await Log.CloseAndFlushAsync(); }
+
+} // end outer try — web-host path
+finally { await Log.CloseAndFlushAsync(); } // outer finally — drains Serilog for ALL paths
 
 // WebApplicationFactory<Program> requires Program to be visible to the test
 // assembly via the C# type system. [InternalsVisibleTo] does not satisfy the

--- a/tests/install/test-install-deps-flag.sh
+++ b/tests/install/test-install-deps-flag.sh
@@ -16,19 +16,31 @@ assert() {
   local name="$1"; shift
   if "$@"; then PASS=$((PASS+1)); else printf 'FAIL: %s\n' "${name}" >&2; FAIL=$((FAIL+1)); fi
 }
+# assert_contains NAME HAYSTACK NEEDLE
+# Use case/in for substring matching to avoid re-parsing $HAYSTACK through
+# bash -c "[[ '...' == *'...'* ]]", which breaks when the haystack contains
+# apostrophes (e.g. "manifest's"). case/in never re-parses the value.
+# Fixes issue #266.
+assert_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  case "${haystack}" in
+    *"${needle}"*) PASS=$((PASS+1)) ;;
+    *) printf 'FAIL: %s\n' "${name}" >&2; FAIL=$((FAIL+1)) ;;
+  esac
+}
 
 # 1. --upgrade-deps without --install-deps must hard-error before any work.
 out=$("${INSTALL}" --upgrade-deps --prefix /tmp/expertise-api-test --skip-preflight 2>&1)
 rc=$?
 assert "upgrade-deps alone exits non-zero" [ "${rc}" -ne 0 ]
-assert "upgrade-deps alone names the requirement" bash -c "[[ '${out}' == *'requires --install-deps'* ]]"
+assert_contains "upgrade-deps alone names the requirement" "${out}" "requires --install-deps"
 
 # 2. --help must mention both flags.
 out=$("${INSTALL}" --help 2>&1)
 rc=$?
 assert "--help exits 0" [ "${rc}" -eq 0 ]
-assert "--help mentions --install-deps" bash -c "[[ '${out}' == *'--install-deps'* ]]"
-assert "--help mentions --upgrade-deps" bash -c "[[ '${out}' == *'--upgrade-deps'* ]]"
+assert_contains "--help mentions --install-deps" "${out}" "--install-deps"
+assert_contains "--help mentions --upgrade-deps" "${out}" "--upgrade-deps"
 
 # 3. --install-deps alone is accepted by the parser (the bootstrap itself
 #    requires a real OS environment, so we don't actually run it here; we


### PR DESCRIPTION
## Summary

Three coupled fixes from the E1 smoke fallout: (1) `scripts/migrate.sh` now mirrors the launch wrapper's env exports (`ASPNETCORE_ENVIRONMENT`, `Onnx__ModelPath`, `Onnx__VocabPath`, override-able from the environment) so a standalone migrate run passes DI validation instead of failing on the missing ONNX model path; (2) `Program.cs` wraps all post-`Build()` paths — the one-shot CLI verbs and the web host — in a single outer `try/finally` so `Log.CloseAndFlushAsync()` drains Serilog for migrate/reembed/rehash too (logs were swallowed whenever stdout was not a TTY); (3) `tests/install/test-install-deps-flag.sh` assertions no longer break on apostrophes (replaced `bash -c "[[ '...' ]]"` with a `case`-based `assert_contains` helper).

Closes #262. Closes #263. Closes #266.

## Type of Change

- [x] `fix` — bug fix

## Test Plan

- [x] `tests/install/test-install-deps-flag.sh` runs locally: 7/7 PASS (was 5/7)
- [x] `bash -n` + `shellcheck` clean on changed shell scripts
- [ ] `dotnet test` locally — **not run: no .NET SDK on the authoring machine.** The Program.cs change is a structural try/finally hoist (no new logic); CI build + test + `dotnet format analyzers` gate on this PR is the executable verification
- [x] `migrate.ps1` audited: already exports the ONNX paths; flush fix lives in the binary, so no ps1 change needed

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files
- [x] Database migrations — N/A (no schema change)
- [x] API changes — N/A
- [x] CLAUDE.md — migrate verb contract (exit 0 no-op / 1 failure) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
