### PR TITLE
fix(release): accept pre- and post-rename cosign identities; update owner slug

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -414,6 +414,6 @@ jobs:
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.INFRA_DISPATCH_TOKEN }}
-          repository: TheSemicolon/agent-expertise-api-infra
+          repository: psmfd/agent-expertise-api-infra
           event-type: deploy
           client-payload: '{"image_tag": "v${{ needs.release.outputs.new-release-version }}"}'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,7 +326,7 @@ Scope shorthand (`read`, `draft`, `approve`, `admin`) expands to full scope stri
 | `release.yml` | Push to main | semantic-release version bump + tag, then Docker build linux/amd64+arm64, push to GHCR (only when a new version is released) |
 | `lint-pr-title.yml` | PR to dev | Validates PR title follows Conventional Commits format |
 
-GHCR image: `ghcr.io/thesemicolon/agent-expertise-api` (multi-arch: amd64 + arm64).
+GHCR image: `ghcr.io/psmfd/agent-expertise-api` (multi-arch: amd64 + arm64).
 
 ### Pre-flight PR validator
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # agent-expertise-api
 
-[![CI](https://github.com/TheSemicolon/agent-expertise-api/actions/workflows/ci.yml/badge.svg)](https://github.com/TheSemicolon/agent-expertise-api/actions/workflows/ci.yml)
-[![Release](https://github.com/TheSemicolon/agent-expertise-api/actions/workflows/release.yml/badge.svg)](https://github.com/TheSemicolon/agent-expertise-api/actions/workflows/release.yml)
+[![CI](https://github.com/psmfd/agent-expertise-api/actions/workflows/ci.yml/badge.svg)](https://github.com/psmfd/agent-expertise-api/actions/workflows/ci.yml)
+[![Release](https://github.com/psmfd/agent-expertise-api/actions/workflows/release.yml/badge.svg)](https://github.com/psmfd/agent-expertise-api/actions/workflows/release.yml)
 
 Self-hosted .NET 10 REST API for storing and serving expertise entries consumed by AI agents. Entries are a running log of issues/fixes, workarounds, caveats, and requirements — either domain-specific or shared across agent domains.
 
@@ -74,13 +74,13 @@ The document advertises the JWT Bearer security scheme (`components.securitySche
 
 Responses are cached for 5 minutes via `OutputCache` (policy `openapi-discovery`, vary-by-host) so anonymous spec-fetch loops cannot drive sustained CPU through repeated schema generation.
 
-A version-pinned copy is also attached as a release asset (`openapi.json` + `openapi.json.sha256`) on every GitHub Release for offline consumers and codegen pipelines that need byte-stable input. See the [release page](https://github.com/TheSemicolon/agent-expertise-api/releases) and Part D C8 in `docs/security/integration-threat-model.md`. The interactive Scalar UI remains gated to Development (`/scalar/v1`) because the in-browser bearer-token storage pattern carries the same XSS exposure as `/query` (issue #124).
+A version-pinned copy is also attached as a release asset (`openapi.json` + `openapi.json.sha256`) on every GitHub Release for offline consumers and codegen pipelines that need byte-stable input. See the [release page](https://github.com/psmfd/agent-expertise-api/releases) and Part D C8 in `docs/security/integration-threat-model.md`. The interactive Scalar UI remains gated to Development (`/scalar/v1`) because the in-browser bearer-token storage pattern carries the same XSS exposure as `/query` (issue #124).
 
 ### Calling from agent harnesses
 
 This API distinguishes agent-mediated traffic from interactive human callers for audit fidelity (Part D C6, [ADR-008](adrs/008-response-hygiene-and-actor-class.md)). The contract is one header plus one OIDC scope.
 
-**Header:** `X-Actor-Class: agent` set by any caller running inside an LLM-agent loop — the [#147](https://github.com/TheSemicolon/agent-expertise-api/issues/147) skill+curl pattern, the [#148](https://github.com/TheSemicolon/agent-expertise-api/issues/148) in-tree pi extension, or any future agent-mediated client. Interactive human callers (browser, ad-hoc terminal `curl`) omit the header.
+**Header:** `X-Actor-Class: agent` set by any caller running inside an LLM-agent loop — the [#147](https://github.com/psmfd/agent-expertise-api/issues/147) skill+curl pattern, the [#148](https://github.com/psmfd/agent-expertise-api/issues/148) in-tree pi extension, or any future agent-mediated client. Interactive human callers (browser, ad-hoc terminal `curl`) omit the header.
 
 **Scope:** the JWT must carry the `expertise.agent` scope. This is the IdP-signed signal; the header without the scope is treated as an unverified hint, logged as a warning, and the audit row falls back to `actorClass=Human` (the raw header is still persisted to the audit row's `actorClassHeader` column for forensic recovery).
 
@@ -337,15 +337,15 @@ ConnectionStrings__DefaultConnection=Host={server}.postgres.database.azure.com;P
 Docker images are published to GHCR when a release is cut from `main`:
 
 ```text
-ghcr.io/thesemicolon/agent-expertise-api:latest          # most recent stable release
-ghcr.io/thesemicolon/agent-expertise-api:v1.2.3          # immutable SemVer tag
-ghcr.io/thesemicolon/agent-expertise-api:1.2             # tracks the latest 1.2.x
+ghcr.io/psmfd/agent-expertise-api:latest          # most recent stable release
+ghcr.io/psmfd/agent-expertise-api:v1.2.3          # immutable SemVer tag
+ghcr.io/psmfd/agent-expertise-api:1.2             # tracks the latest 1.2.x
 ```
 
 The Helm chart is also published as an OCI artifact on every release:
 
 ```bash
-helm install expertise-api oci://ghcr.io/thesemicolon/charts/expertise-api \
+helm install expertise-api oci://ghcr.io/psmfd/charts/expertise-api \
   --version X.Y.Z \
   --namespace expertise-api --create-namespace \
   -f my-values.yaml
@@ -359,25 +359,25 @@ The image, the chart artifact, the `openapi.json` release asset, and the Archety
 
 ```bash
 # Verify image
-cosign verify ghcr.io/thesemicolon/agent-expertise-api:vX.Y.Z \
-  --certificate-identity 'https://github.com/TheSemicolon/agent-expertise-api/.github/workflows/release.yml@refs/heads/main' \
+cosign verify ghcr.io/psmfd/agent-expertise-api:vX.Y.Z \
+  --certificate-identity 'https://github.com/psmfd/agent-expertise-api/.github/workflows/release.yml@refs/heads/main' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
 # Verify chart artifact
-cosign verify ghcr.io/thesemicolon/charts/expertise-api:X.Y.Z \
-  --certificate-identity 'https://github.com/TheSemicolon/agent-expertise-api/.github/workflows/release.yml@refs/heads/main' \
+cosign verify ghcr.io/psmfd/charts/expertise-api:X.Y.Z \
+  --certificate-identity 'https://github.com/psmfd/agent-expertise-api/.github/workflows/release.yml@refs/heads/main' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
 # Verify openapi.json (download .sig + .pem alongside it from the release page)
 cosign verify-blob \
-  --certificate-identity 'https://github.com/TheSemicolon/agent-expertise-api/.github/workflows/release.yml@refs/heads/main' \
+  --certificate-identity 'https://github.com/psmfd/agent-expertise-api/.github/workflows/release.yml@refs/heads/main' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --signature openapi.json.sig \
   --certificate openapi.json.pem \
   openapi.json
 
 # Verify the Archetype A2 release tarball via its signed manifest (ADR-011).
-# Download expertise-api-vX.Y.Z-portable.tar.gz, expertise-api-vX.Y.Z.manifest.json,
+# Download expertise-api-X.Y.Z-portable.tar.gz, expertise-api-X.Y.Z.manifest.json,
 # .manifest.json.sig, .manifest.json.pem from the release page.
 # The leading `set -euo pipefail` is load-bearing — without it an operator
 # copy-pasting this block would see cosign verify-blob fail with non-zero
@@ -385,19 +385,21 @@ cosign verify-blob \
 # against an unverified manifest and could match attacker-coordinated bytes.
 set -euo pipefail
 cosign verify-blob \
-  --certificate-identity 'https://github.com/TheSemicolon/agent-expertise-api/.github/workflows/release.yml@refs/heads/main' \
+  --certificate-identity 'https://github.com/psmfd/agent-expertise-api/.github/workflows/release.yml@refs/heads/main' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --signature expertise-api-vX.Y.Z.manifest.json.sig \
-  --certificate expertise-api-vX.Y.Z.manifest.json.pem \
-  expertise-api-vX.Y.Z.manifest.json
+  --signature expertise-api-X.Y.Z.manifest.json.sig \
+  --certificate expertise-api-X.Y.Z.manifest.json.pem \
+  expertise-api-X.Y.Z.manifest.json
 
 # Manifest's artifacts.tarball.sha256 transitively binds the tarball.
-expected=$(jq -r .artifacts.tarball.sha256 expertise-api-vX.Y.Z.manifest.json)
-actual=$(sha256sum expertise-api-vX.Y.Z-portable.tar.gz | awk '{print $1}')
+expected=$(jq -r .artifacts.tarball.sha256 expertise-api-X.Y.Z.manifest.json)
+actual=$(sha256sum expertise-api-X.Y.Z-portable.tar.gz | awk '{print $1}')
 [ "$expected" = "$actual" ] || { echo 'TARBALL TAMPERED' >&2; exit 1; }
 ```
 
-All three recipes use `--certificate-identity` (exact match) rather than `--certificate-identity-regexp`. Cosign evaluates `--certificate-identity-regexp` with Go's `regexp.MatchString`, which is **unanchored** — a pattern ending `release.yml@refs/heads/main` substring-matches a malicious `release.yml@refs/heads/main-evil` cert SAN. Exact match removes that bypass surface; there is exactly one legitimate signing identity for this repo and exact match expresses it precisely. If [#138](https://github.com/TheSemicolon/agent-expertise-api/issues/138) introduces maintenance release branches, all three recipes broaden together — with right-anchored regexps (`...@refs/heads/(main|release/.*)$`) or repeated `--certificate-identity` flags, not unanchored patterns.
+**Pre-rename releases:** the repository owner was renamed `TheSemicolon` → `psmfd` in June 2026 (#294). Releases signed before the rename — v1.0.0 and earlier — carry the old workflow path in their Fulcio certificate, so verifying those assets requires `--certificate-identity 'https://github.com/TheSemicolon/agent-expertise-api/.github/workflows/release.yml@refs/heads/main'` instead. `scripts/verify-release.sh` and `install.sh --from-release` try both identities automatically (exact match each, first hit wins).
+
+All three recipes use `--certificate-identity` (exact match) rather than `--certificate-identity-regexp`. Cosign evaluates `--certificate-identity-regexp` with Go's `regexp.MatchString`, which is **unanchored** — a pattern ending `release.yml@refs/heads/main` substring-matches a malicious `release.yml@refs/heads/main-evil` cert SAN. Exact match removes that bypass surface; the legitimate signing identities for this repo form a tiny closed set (the current one, plus the pre-rename one for old releases) and exact match expresses that precisely. If [#138](https://github.com/psmfd/agent-expertise-api/issues/138) introduces maintenance release branches, all three recipes broaden together — with right-anchored regexps (`...@refs/heads/(main|release/.*)$`) or repeated `--certificate-identity` flags, not unanchored patterns.
 
 A missing or invalid signature exits non-zero — wire it into your deploy pipeline as a hard gate.
 
@@ -625,7 +627,7 @@ Under `--from-release` the installer:
 3. Downloads the tarball + manifest + cosign signature + Fulcio cert
    over hardened curl (TLS ≥1.2, `--proto =https`, bounded retries).
 4. `cosign verify-blob`s the manifest with exact-match identity
-   `https://github.com/TheSemicolon/agent-expertise-api/.github/workflows/release.yml@refs/heads/main`
+   `https://github.com/psmfd/agent-expertise-api/.github/workflows/release.yml@refs/heads/main`
    and the Sigstore public Rekor (`https://rekor.sigstore.dev`).
 5. Strict-checks `manifest.schemaVersion` (refuses unknown shapes; never silently forward-compat).
 6. Cross-checks `sha256sum(tarball) == manifest.artifacts.tarball.sha256`
@@ -647,10 +649,10 @@ recipe cannot drift via copy-paste.
 
 ```bash
 scripts/verify-release.sh \
-  --tarball     expertise-api-vX.Y.Z-portable.tar.gz \
-  --manifest    expertise-api-vX.Y.Z.manifest.json \
-  --signature   expertise-api-vX.Y.Z.manifest.json.sig \
-  --certificate expertise-api-vX.Y.Z.manifest.json.pem
+  --tarball     expertise-api-X.Y.Z-portable.tar.gz \
+  --manifest    expertise-api-X.Y.Z.manifest.json \
+  --signature   expertise-api-X.Y.Z.manifest.json.sig \
+  --certificate expertise-api-X.Y.Z.manifest.json.pem
 ```
 
 Deferred to follow-ups: `--tarball-url` mirror flag for air-gapped
@@ -703,7 +705,7 @@ The uninstaller defends against destructive `--prefix` mistakes:
   uninstaller does not currently verify that *ancestors* of the prefix
   are owned by root — if you operate a multi-user host, ensure
   `/opt/<your-parent>/` is root-owned and not group-writable. Tracking
-  in [#242](https://github.com/TheSemicolon/agent-expertise-api/issues/242).
+  in [#242](https://github.com/psmfd/agent-expertise-api/issues/242).
 - `--dry-run` forces a non-destructive run even with `--yes` and is the
   primary safety hook used by `tests/uninstall/test-prefix-guard.sh`.
   The plan reflects host state at dry-run invocation time; if the
@@ -744,7 +746,7 @@ when the workload becomes multi-process.
 Design rationale, footgun catalog (systemd `MemoryDenyWriteExecute`,
 launchd `EnvironmentVariables` secret-leak, Windows Virtual Account
 rationale, etc.) is captured in the synthesis doc at
-[`TheSemicolon/pi_config:notes/agent-expertise-api-hosting.md`](https://github.com/TheSemicolon/pi_config/blob/main/notes/agent-expertise-api-hosting.md).
+[`psmfd/pi_config:notes/agent-expertise-api-hosting.md`](https://github.com/psmfd/pi_config/blob/main/notes/agent-expertise-api-hosting.md).
 
 ## Testing
 

--- a/scripts/lib/release-consumer.sh
+++ b/scripts/lib/release-consumer.sh
@@ -19,11 +19,14 @@
 
 # ---------------------------------------------------------------------------
 # RELEASE_REPO — the {owner}/{repo} slug that owns the release artifacts.
-# Hard-coded; forks must edit. Mirrors the COSIGN_IDENTITY constant in
+# Hard-coded; forks must edit. Mirrors the COSIGN_IDENTITIES constant in
 # scripts/verify-release.sh — if you change one without the other the
 # verification step will refuse the install with a clear error.
+# (Owner renamed TheSemicolon -> psmfd, 2026-06, #294 — the old slug only
+# worked via GitHub's 301 redirect, which survives just until the old
+# name is reclaimed.)
 # ---------------------------------------------------------------------------
-readonly RELEASE_REPO="TheSemicolon/agent-expertise-api"
+readonly RELEASE_REPO="psmfd/agent-expertise-api"
 
 # ---------------------------------------------------------------------------
 # rc_source_verify_release — load constants + helpers from verify-release.sh
@@ -664,7 +667,7 @@ rc_write_post_install_markers() {
       "$ts" "${VERIFIED_APP_VERSION:-unknown}" \
       "${VERIFIED_MANIFEST_SHA:-unknown}" \
       "$(jq -r '.artifacts.tarball.sha256 // "unknown"' "${VERIFIED_MANIFEST_PATH:-/dev/null}" 2>/dev/null || echo unknown)" \
-      "${COSIGN_IDENTITY:-unknown}" \
+      "${VERIFIED_COSIGN_IDENTITY:-unknown}" \
       "${cosign_ver:-unknown}" \
       >> "$history"
   else

--- a/scripts/service-templates/expertise-api.service.tmpl
+++ b/scripts/service-templates/expertise-api.service.tmpl
@@ -1,6 +1,6 @@
 [Unit]
 Description=Agent Expertise API
-Documentation=https://github.com/TheSemicolon/agent-expertise-api
+Documentation=https://github.com/psmfd/agent-expertise-api
 # Ordering only — user units cannot Require= system targets.
 After=network-online.target
 

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -50,8 +50,18 @@ VERIFY_RELEASE_SOURCED=1
 # Forks must edit BOTH constants and the README recipe. The exact-match
 # semantics are deliberate: --certificate-identity-regexp is the foot-gun
 # this script's existence is designed to prevent.
+#
+# COSIGN_IDENTITIES is a space-separated scalar list (NOT an array — see
+# SUPPORTED_MANIFEST_SCHEMA_VERSIONS below for the bash 3.2 function-scoped
+# sourcing constraint). Each candidate is tried with an exact
+# --certificate-identity match, first hit wins. Two entries exist because
+# the repository owner was renamed TheSemicolon -> psmfd (2026-06, #294):
+# releases signed before the rename (v1.0.0 and earlier) carry the old
+# workflow path in their Fulcio certificate; releases signed after carry
+# the new one. Drop the legacy entry once pre-rename releases are no
+# longer install targets.
 # ---------------------------------------------------------------------------
-readonly COSIGN_IDENTITY='https://github.com/TheSemicolon/agent-expertise-api/.github/workflows/release.yml@refs/heads/main'
+readonly COSIGN_IDENTITIES='https://github.com/psmfd/agent-expertise-api/.github/workflows/release.yml@refs/heads/main https://github.com/TheSemicolon/agent-expertise-api/.github/workflows/release.yml@refs/heads/main'
 readonly COSIGN_OIDC_ISSUER='https://token.actions.githubusercontent.com'
 readonly REKOR_URL='https://rekor.sigstore.dev'
 
@@ -138,23 +148,37 @@ vr_cosign_verify_manifest() {
   [ -r "$cert" ]     || vr_die "certificate unreadable: $cert" 2
   [ -r "$manifest" ] || vr_die "manifest unreadable: $manifest" 2
 
-  vr_log "cosign verify-blob: identity=${COSIGN_IDENTITY}"
-  vr_log "                    issuer=${COSIGN_OIDC_ISSUER}"
+  vr_log "cosign verify-blob: issuer=${COSIGN_OIDC_ISSUER}"
   vr_log "                    rekor=${REKOR_URL}"
-  if ! cosign verify-blob \
-      --certificate-identity "$COSIGN_IDENTITY" \
-      --certificate-oidc-issuer "$COSIGN_OIDC_ISSUER" \
-      --rekor-url "$REKOR_URL" \
-      --signature "$sig" \
-      --certificate "$cert" \
-      "$manifest" >/dev/null 2>&1; then
+  # Try each pinned identity with EXACT-match semantics; first hit wins.
+  # Intentionally unquoted: scalar word-split (identities contain no spaces).
+  local identity verified=0
+  for identity in ${COSIGN_IDENTITIES}; do
+    vr_log "cosign verify-blob: trying identity=${identity}"
+    if cosign verify-blob \
+        --certificate-identity "$identity" \
+        --certificate-oidc-issuer "$COSIGN_OIDC_ISSUER" \
+        --rekor-url "$REKOR_URL" \
+        --signature "$sig" \
+        --certificate "$cert" \
+        "$manifest" >/dev/null 2>&1; then
+      verified=1
+      # Global (no `local`): release-consumer.sh records the matched
+      # identity in the .install-history audit line — shellcheck cannot
+      # see the cross-file reference.
+      # shellcheck disable=SC2034
+      VERIFIED_COSIGN_IDENTITY="$identity"
+      vr_log "cosign verify-blob: OK (identity=${identity})"
+      break
+    fi
+  done
+  if [ "$verified" != "1" ]; then
     vr_die "cosign verify-blob FAILED. Possible causes:
     1. Manifest tampered or signature does not match
-    2. Signer identity mismatch (expected: ${COSIGN_IDENTITY})
+    2. Signer identity mismatch (accepted: ${COSIGN_IDENTITIES})
     3. Rekor unreachable (try --from-source --i-accept-unverified-source
        fallback; structured offline-verify support tracked by #256)" 1
   fi
-  vr_log "cosign verify-blob: OK"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The repository owner rename (TheSemicolon → psmfd) left the `--from-release` trust roots pointing at the old owner: the pinned exact-match `COSIGN_IDENTITY` would reject every release signed after the rename, and `RELEASE_REPO` only worked via GitHub's 301 redirect. Verification now tries a closed, ordered set of exact-match identities (new owner first, legacy second for v1.0.0 and earlier — preserving the script's deliberate no-regexp stance), records the matched identity in the `.install-history` audit line, and all owner references move to `psmfd`: `RELEASE_REPO`, the infra deploy dispatch target in `release.yml`, the systemd unit Documentation URL, and README/CLAUDE.md links, GHCR paths, and cosign recipes (which also drop the v-prefixed asset names fixed in the consumer by #293, and gain a pre-rename identity note).

Closes #294.

## Type of Change

- [x] `fix` — bug fix

## Test Plan

- [x] `bash -n` + `shellcheck` clean on `verify-release.sh` and `release-consumer.sh`; `actionlint` clean on `release.yml`
- [x] This PR's path filter triggers the from-release smoke on both OSes, which installs v1.0.0 — proving the **legacy** identity branch verifies a real pre-rename release end-to-end
- [x] The **new** identity branch is exercised by the first post-rename release (it is first in the candidate list, so the common case costs one cosign call)
- [ ] `dotnet test` — N/A, no C# changes

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files
- [x] Database migrations — N/A
- [x] API changes — N/A
- [x] CLAUDE.md / README updated (GHCR path, links, verification recipes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
