### PR TITLE
fix(models): honor retry-after on rate-limited model downloads

### DIFF
--- a/scripts/download-models.sh
+++ b/scripts/download-models.sh
@@ -84,7 +84,13 @@ download_file() {
   log "Downloading ${display_name}..."
   local tmpfile
   tmpfile=$(mktemp "${dest}.XXXXXX")
-  curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors "${url}" -o "${tmpfile}" \
+  # No --retry-delay: a fixed delay makes curl IGNORE the server's
+  # Retry-After header, so Hugging Face 429 rate-limits burned all four
+  # attempts in ~15s and failed three CI smoke runs on 2026-06-11 (#295).
+  # Without it curl uses exponential backoff (1,2,4,... s) AND honors
+  # Retry-After on 429/503. --retry-max-time caps the worst case so a
+  # hard outage cannot stall the install indefinitely.
+  curl -fsSL --retry 8 --retry-max-time 300 --retry-all-errors "${url}" -o "${tmpfile}" \
     || { rm -f "${tmpfile}"; err "Failed to download ${filename} from ${url}"; }
   mv "${tmpfile}" "${dest}"
 


### PR DESCRIPTION
## Summary

`download-models.sh` retried downloads, but its fixed `--retry-delay 5` makes curl ignore the server's `Retry-After` header — so Hugging Face 429 rate-limits burned all four attempts in ~15 seconds and failed three otherwise-green CI smoke runs on 2026-06-11. Dropping the fixed delay restores curl's exponential backoff *and* its `Retry-After` handling on 429/503; attempts go to 8 with a 300s total-retry cap so a hard outage cannot hang an install. Benefits every consumer of the script: CI, operators, and `install.sh`.

Closes #295.

## Type of Change

- [x] `fix` — bug fix

## Test Plan

- [x] `bash -n` + `shellcheck` clean
- [x] The install-smoke jobs on this PR exercise the download path end-to-end on Linux and macOS
- [ ] `dotnet test` — N/A, no C# changes
- A deliberate 429 cannot be simulated in CI; the behavioral claim (fixed `--retry-delay` disables Retry-After handling) is per curl's documented `--retry` semantics

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files
- [x] Database migrations — N/A
- [x] API changes — N/A
- [x] CLAUDE.md — no command or workflow change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
