### PR TITLE
docs(claude-md): accurate ci workflow inventory, openapi gate, single-test and pi commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,11 +322,20 @@ Scope shorthand (`read`, `draft`, `approve`, `admin`) expands to full scope stri
 
 | Workflow | Trigger | What it does |
 | -------- | ------- | ------------ |
-| `ci.yml` | PR to main, push to dev | `dotnet build` + `dotnet test` |
-| `release.yml` | Push to main | semantic-release version bump + tag, then Docker build linux/amd64+arm64, push to GHCR (only when a new version is released) |
+| `ci.yml` | PRs to main/dev, push to dev | Ten jobs: build & test (SCA vulnerable-package check, openapi.json artifact check, `dotnet format analyzers` gate), pi extension typecheck + tests, Helm lint + render tests, release-manifest generator, apictl restart-race (macOS + Debian 13), apictl stop→start lifecycle (macOS), install-smoke `--from-source` (Linux + macOS), OpenAPI breaking-change gate (PR-only, see below) |
+| `install-smoke-from-release.yml` | Push to dev / PRs, path-filtered to the release-consumer chain | `install.sh --from-release` end-to-end against the latest cosign-signed release (Linux + macOS) — E3 of the readiness track; gates the D4 default-flip per ADR-011 |
+| `release.yml` | Push to main | semantic-release version bump + tag, Docker build linux/amd64+arm64 to GHCR, cosign-signed A2 tarball + manifest as release assets, Helm chart OCI push, deploy dispatch to the infra repo (only when a new version is released) |
 | `lint-pr-title.yml` | PR to dev | Validates PR title follows Conventional Commits format |
+| `openapi-label-cleanup.yml` | PR merged | Auto-removes the `breaking-change-approved` label so it cannot carry into later branches |
+| `dependabot-auto-merge.yml` | Dependabot PRs | Auto-merges patch/minor dependency bumps |
+
+CodeQL, Trivy, and Hadolint run in separate workflows — see [Security Scanning](#security-scanning).
 
 GHCR image: `ghcr.io/psmfd/agent-expertise-api` (multi-arch: amd64 + arm64).
+
+### OpenAPI breaking-change gate
+
+The build emits the OpenAPI document to `src/ExpertiseApi/artifacts/openapi/ExpertiseApi.json` (build-time emission; `release.yml` attaches it as a release asset). On every PR, the `openapi-diff` job in `ci.yml` builds the spec from both the PR head and the base SHA and runs `oasdiff breaking` between them. Breaking API changes **fail the check** unless the PR carries the `breaking-change-approved` label (which `openapi-label-cleanup.yml` strips on merge). If an endpoint change is intentionally breaking, apply that label rather than reworking the diff.
 
 ### Pre-flight PR validator
 
@@ -357,8 +366,14 @@ dotnet test ExpertiseApi.slnx --filter "FullyQualifiedName~Unit"
 # Run integration tests only
 dotnet test ExpertiseApi.slnx --filter "FullyQualifiedName~Integration"
 
+# Run a single test class or method
+dotnet test ExpertiseApi.slnx --filter "FullyQualifiedName~<ClassOrMethodName>"
+
 # Helm chart render tests
 bash helm/expertise-api/tests/test-render.sh
+
+# pi extension typecheck + tests (mirrors the ci.yml job)
+cd .pi/extensions/expertise-api && npm ci && npm run typecheck && npm test
 ```
 
 ### Test Project Structure


### PR DESCRIPTION
## Summary

Brings CLAUDE.md's CI/CD section in line with reality: `ci.yml` was described as "build + test" when it runs ten jobs, and three workflows were undocumented — including the `openapi-diff` breaking-change gate, which a future contributor would hit with no documented explanation or bypass (`breaking-change-approved` label). Also adds the new E3 from-release smoke workflow, how to run a single test, and the pi extension typecheck/test commands.

## Type of Change

- [x] `docs` — documentation only

## Test Plan

- No testable behavior changed (documentation only). Workflow inventory cross-checked against `.github/workflows/` on current dev.

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files
- [x] Database migrations — N/A
- [x] API changes — N/A
- [x] CLAUDE.md updated — this PR is that update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
