### PR TITLE
fix(plist): set ProcessType to Adaptive for background REST API

### DIFF
--- a/scripts/service-templates/expertise-api.plist.tmpl
+++ b/scripts/service-templates/expertise-api.plist.tmpl
@@ -34,8 +34,12 @@
   <key>ExitTimeOut</key>
   <integer>45</integer>
 
+  <!-- Adaptive: gets interactive CPU/I/O priority while handling requests and
+       drops to background priority when idle. Interactive would hold foreground
+       priority continuously, burning unnecessary CPU budget on a background REST
+       API and increasing thermal pressure on laptops. -->
   <key>ProcessType</key>
-  <string>Interactive</string>
+  <string>Adaptive</string>
 
   <key>StandardOutPath</key>
   <string>@@LOG_DIR@@/stdout.log</string>


### PR DESCRIPTION
## Summary

Changes `ProcessType` in `scripts/service-templates/expertise-api.plist.tmpl` from `Interactive` to `Adaptive`. `Interactive` grants foreground CPU and I/O priority continuously — inappropriate for a background REST API — which increases thermal pressure on laptops. `Adaptive` gives interactive priority only while the process is actively servicing requests and drops to background priority when idle. A code comment in the template explains the rationale. This completes item 1 of #288; item 2 (DOTNET_ROOT in the launch wrapper) already shipped in PR #293.

Closes #288

## Type of Change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [ ] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change (add `!` to PR title)

## Test Plan

- The restart-race and stop→start CI jobs (`apictl-restart-race` and `apictl-stop-start` in `ci.yml`) exercise the real rendered plist on macOS runners; those tests remain the functional gate for this change.
- `validate-pr.sh` passed clean (0 errors, 0 warnings) before push.
- `plutil -lint` is not applicable to the raw `.tmpl` file (it contains `@@PLACEHOLDER@@` tokens); the CI jobs render and install the real plist, which is the correct validation surface.
- No C# code changed; `dotnet test` is unaffected.

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files
- [x] Database migrations are reversible (if applicable)
- [x] API changes are backward-compatible (if applicable)
- [x] CLAUDE.md updated (if commands, endpoints, or workflow changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)