### PR TITLE
chore(scripts): portability polish for shasum fallback and em-dash literals

### DIFF
--- a/scripts/lib/bootstrap-common.sh
+++ b/scripts/lib/bootstrap-common.sh
@@ -62,7 +62,7 @@ bc_refuse_xtrace() {
   # than try to set +x mid-flight, because a parent shell may re-enable
   # it. Document the constraint and exit.
   case $- in
-    *x*) err "refuse to bootstrap with xtrace (set -x) enabled \u2014 it would leak the generated DB password" ;;
+    *x*) err "refuse to bootstrap with xtrace (set -x) enabled — it would leak the generated DB password" ;;
   esac
 }
 
@@ -152,11 +152,11 @@ bc_write_connection_string_if_absent() {
   local host="$1" port="$2" db="$3" user="$4" pw="$5"
   [[ -n "${SECRETS_FILE:-}" ]] || err "SECRETS_FILE unset; bootstrap-common bug"
   if [[ -L "${SECRETS_FILE}" ]]; then
-    err "${SECRETS_FILE} is a symlink \u2014 refusing to write (potential write redirection)"
+    err "${SECRETS_FILE} is a symlink — refusing to write (potential write redirection)"
   fi
   if [[ -f "${SECRETS_FILE}" ]] \
      && grep -q '^ConnectionStrings__DefaultConnection=' "${SECRETS_FILE}"; then
-    log "secrets: ConnectionStrings__DefaultConnection already set \u2014 leaving untouched"
+    log "secrets: ConnectionStrings__DefaultConnection already set — leaving untouched"
     return 1
   fi
   # Same-filesystem temp file so the rename is atomic.
@@ -202,7 +202,7 @@ bc_append_install_deps_history() {
   local taken="$1" skipped="$2"
   local history="${PREFIX}/.install-deps-history"
   if [[ -L "${history}" ]]; then
-    warn "${history} is a symlink \u2014 refusing to append audit line"
+    warn "${history} is a symlink — refusing to append audit line"
     return 0
   fi
   local ts

--- a/scripts/lib/bootstrap-macos.sh
+++ b/scripts/lib/bootstrap-macos.sh
@@ -134,11 +134,11 @@ _macos_ensure_dotnet_sdk() {
     local sdk_ver
     sdk_ver=$(dotnet --list-sdks 2>/dev/null | awk '$1 ~ /^10\./ { print $1; exit }')
     if (( ${UPGRADE_DEPS:-0} == 0 )); then
-      log "dotnet SDK 10.x present (${sdk_ver}) \u2014 skip"
+      log "dotnet SDK 10.x present (${sdk_ver}) — skip"
       _MACOS_TAKEN_SKIPPED+="${_MACOS_TAKEN_SKIPPED:+,}dotnet-sdk:skip"
       return 0
     fi
-    log "dotnet SDK 10.x present (${sdk_ver}) \u2014 --upgrade-deps will refresh via brew"
+    log "dotnet SDK 10.x present (${sdk_ver}) — --upgrade-deps will refresh via brew"
   fi
   log "installing .NET 10 SDK via Homebrew cask (dotnet-sdk)"
   if brew list --cask dotnet-sdk >/dev/null 2>&1; then
@@ -151,7 +151,7 @@ _macos_ensure_dotnet_sdk() {
       || err "brew install --cask dotnet-sdk failed; install manually from https://dot.net and re-run without --install-deps"
   fi
   command -v dotnet >/dev/null 2>&1 \
-    || err "dotnet still not on PATH after brew install \u2014 check 'brew doctor' and ensure /usr/local/share/dotnet or /opt/homebrew/* is in PATH"
+    || err "dotnet still not on PATH after brew install — check 'brew doctor' and ensure /usr/local/share/dotnet or /opt/homebrew/* is in PATH"
   dotnet --list-sdks 2>/dev/null | awk '$1 ~ /^10\./ { found=1 } END { exit !found }' \
     || err "no .NET 10.x SDK detected after install (dotnet --list-sdks shows: $(dotnet --list-sdks 2>&1))"
   _MACOS_TAKEN_SKIPPED+="${_MACOS_TAKEN_SKIPPED:+,}dotnet-sdk:installed"
@@ -181,7 +181,7 @@ _macos_ensure_postgres() {
         || log "${_MACOS_PG_FORMULA} already at latest (no-op upgrade)"
       _MACOS_TAKEN_SKIPPED+="${_MACOS_TAKEN_SKIPPED:+,}postgres:upgraded"
     else
-      log "${_MACOS_PG_FORMULA} present \u2014 skip"
+      log "${_MACOS_PG_FORMULA} present — skip"
       _MACOS_TAKEN_SKIPPED+="${_MACOS_TAKEN_SKIPPED:+,}postgres:skip"
     fi
   else
@@ -232,7 +232,7 @@ _macos_ensure_pgvector() {
       brew upgrade pgvector 2>/dev/null || log "pgvector already at latest"
       _MACOS_TAKEN_SKIPPED+="${_MACOS_TAKEN_SKIPPED:+,}pgvector:upgraded"
     else
-      log "pgvector present \u2014 skip"
+      log "pgvector present — skip"
       _MACOS_TAKEN_SKIPPED+="${_MACOS_TAKEN_SKIPPED:+,}pgvector:skip"
     fi
     return 0
@@ -283,17 +283,17 @@ _macos_ensure_cosign() {
       # Honor it under BOTH UPGRADE_DEPS=0 and UPGRADE_DEPS=1 — the
       # operator owns the upgrade cadence for tools they manage out-
       # of-band. `--upgrade-deps` is scoped to brew-managed deps.
-      log "cosign present on PATH (${v:-unknown version}, not brew-managed) \u2014 skip"
+      log "cosign present on PATH (${v:-unknown version}, not brew-managed) — skip"
       _MACOS_TAKEN_SKIPPED+="${_MACOS_TAKEN_SKIPPED:+,}cosign:skip-external"
       return 0
     fi
     # Brew-managed cosign present.
     if (( ${UPGRADE_DEPS:-0} == 1 )); then
-      log "cosign brew-managed (${v:-unknown}) \u2014 --upgrade-deps will brew-upgrade"
+      log "cosign brew-managed (${v:-unknown}) — --upgrade-deps will brew-upgrade"
       brew upgrade cosign 2>/dev/null || log "cosign already at latest (no-op upgrade)"
       _MACOS_TAKEN_SKIPPED+="${_MACOS_TAKEN_SKIPPED:+,}cosign:upgraded"
     else
-      log "cosign brew-managed and present (${v:-unknown version}) \u2014 skip"
+      log "cosign brew-managed and present (${v:-unknown version}) — skip"
       _MACOS_TAKEN_SKIPPED+="${_MACOS_TAKEN_SKIPPED:+,}cosign:skip"
     fi
     return 0
@@ -302,7 +302,7 @@ _macos_ensure_cosign() {
   brew install cosign \
     || err "brew install cosign failed; install manually from https://docs.sigstore.dev/cosign/installation/ and re-run without --install-deps"
   command -v cosign >/dev/null 2>&1 \
-    || err "cosign not on PATH after brew install \u2014 check 'brew doctor' and ensure /usr/local/bin or /opt/homebrew/bin is in PATH"
+    || err "cosign not on PATH after brew install — check 'brew doctor' and ensure /usr/local/bin or /opt/homebrew/bin is in PATH"
   _MACOS_TAKEN_SKIPPED+="${_MACOS_TAKEN_SKIPPED:+,}cosign:installed"
 }
 
@@ -336,7 +336,7 @@ _macos_ensure_database_and_role() {
   # Existing connection string? Skip everything (never rotate).
   if [[ -f "${SECRETS_FILE}" ]] \
      && grep -q '^ConnectionStrings__DefaultConnection=' "${SECRETS_FILE}"; then
-    log "secrets.env already configured \u2014 skipping role/db/extension creation to avoid password rotation"
+    log "secrets.env already configured — skipping role/db/extension creation to avoid password rotation"
     _MACOS_TAKEN_SKIPPED+="${_MACOS_TAKEN_SKIPPED:+,}role:skip,db:skip,vector:skip,secrets:skip"
     return 0
   fi
@@ -412,7 +412,7 @@ COMMIT;
 }
 
 # ---------------------------------------------------------------------------
-# bootstrap_macos_run \u2014 orchestrator
+# bootstrap_macos_run — orchestrator
 # ---------------------------------------------------------------------------
 
 # Aggregator string for the audit trail. Modules append `name:action` tokens.

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -95,6 +95,20 @@ vr_err()  { printf '[verify-release] ERROR: %s\n' "$1" >&2; }
 vr_die()  { vr_err "$1"; exit "${2:-1}"; }
 
 # ---------------------------------------------------------------------------
+# vr_sha256_of — portable SHA-256: sha256sum (Linux) or shasum -a 256 (macOS).
+# Mirrors the sha256_of helper in scripts/download-models.sh.
+# ---------------------------------------------------------------------------
+vr_sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    vr_die "no sha256 tool found (need sha256sum or shasum)" 2
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # vr_require_cosign — assert cosign present + meets COSIGN_MIN_VERSION.
 # ---------------------------------------------------------------------------
 vr_require_cosign() {
@@ -215,8 +229,7 @@ vr_validate_manifest_schema() {
 # ---------------------------------------------------------------------------
 vr_crosscheck_tarball_sha() {
   local tarball=$1 manifest=$2
-  command -v sha256sum >/dev/null 2>&1 || vr_die "sha256sum required" 2
-  command -v jq        >/dev/null 2>&1 || vr_die "jq required" 2
+  command -v jq >/dev/null 2>&1 || vr_die "jq required" 2
 
   local expected actual
   expected=$(jq -r '.artifacts.tarball.sha256 // empty' "$manifest")
@@ -229,7 +242,7 @@ vr_crosscheck_tarball_sha() {
   if [ "${#expected}" -ne 64 ]; then
     vr_die "manifest artifacts.tarball.sha256 length != 64: ${expected}" 1
   fi
-  actual=$(sha256sum "$tarball" | awk '{print $1}')
+  actual=$(vr_sha256_of "$tarball")
   if [ "$expected" != "$actual" ]; then
     vr_die "TARBALL TAMPERED — manifest declares sha256=${expected} but tarball is sha256=${actual}" 1
   fi


### PR DESCRIPTION
## Summary

Add a portable `vr_sha256_of` helper to `scripts/verify-release.sh` that prefers `sha256sum` (Linux) and falls back to `shasum -a 256` (macOS), replacing the hard `sha256sum` requirement that broke on macOS hosts. Replace all `—` ASCII escape sequences in `scripts/lib/bootstrap-common.sh` and `scripts/lib/bootstrap-macos.sh` with literal UTF-8 em-dash characters so the strings render correctly on bash 3.2 (macOS), which does not expand `\uNNNN` in double-quoted strings.

Closes #289

## Type of Change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [x] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [ ] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change (add `!` to PR title)

## Test Plan

- `bash -n scripts/verify-release.sh` — syntax clean
- `bash -n scripts/lib/bootstrap-common.sh` — syntax clean
- `bash -n scripts/lib/bootstrap-macos.sh` — syntax clean
- `shellcheck` passes on all three files (pre-existing SC2034/SC2086 suppressions unchanged)
- Confirmed no remaining `—` escape sequences in `scripts/` via `grep -rn u2014`
- `scripts/validate-pr.sh --title "chore(scripts): portability polish for shasum fallback and em-dash literals" --branch chore/scripts-portability-polish --base dev` — PASS
- No dotnet/Docker-dependent tests affected (shell-only changes)

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files
- [x] Database migrations are reversible (if applicable) — N/A
- [x] API changes are backward-compatible (if applicable) — N/A
- [x] CLAUDE.md updated (if commands, endpoints, or workflow changed) — N/A (no command changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)