### PR TITLE
fix(install): leave no launchd override state across install and uninstall

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -897,7 +897,19 @@ install_launchd() {
   domain="gui/$(id -u)"
   launchctl bootout "${domain}/${label}" 2>/dev/null || true
   launchctl bootstrap "${domain}" "${plist_path}"
-  launchctl enable "${domain}/${label}"
+  # `launchctl enable` writes a PERSISTENT "=> enabled" override entry into
+  # launchd's LaunchDatabase — it does NOT merely flip runtime state, and no
+  # launchctl subcommand removes an override entry without root. An
+  # unconditional `enable` here therefore leaves a stale entry in
+  # `launchctl print-disabled gui/UID` that survives uninstall forever
+  # (observed on a CI macOS runner — #286). Only run it when the label is
+  # actually disabled (recovering from a manual `launchctl disable`), so a
+  # normal install→uninstall cycle never touches the LaunchDatabase.
+  if launchctl print-disabled "${domain}" 2>/dev/null \
+      | grep -F "\"${label}\"" | grep -qw disabled; then
+    launchctl enable "${domain}/${label}"
+    log "launchd: cleared disabled-override for ${label}"
+  fi
   launchctl kickstart -k "${domain}/${label}"
   log "launchd: bootstrapped + kickstarted"
 }

--- a/scripts/test/test-install-smoke.sh
+++ b/scripts/test/test-install-smoke.sh
@@ -545,9 +545,12 @@ fi
 #
 #     macOS: after uninstall.sh --yes --purge, `launchctl print-disabled
 #     gui/UID` must NOT contain the service label. This is the acceptance
-#     criterion for #286: the old code ran only `bootout`, leaving a stale
-#     disabled-override; the fix runs `enable` (clears any override) before
-#     `bootout` so the label disappears from print-disabled entirely.
+#     criterion for #286: launchd override entries (written by BOTH
+#     `launchctl enable` and `launchctl disable`) are persistent and cannot
+#     be removed without root, so the fix is to never write one — install.sh
+#     runs `enable` only when the label is actually disabled, and uninstall
+#     runs no enable/disable at all. A fresh install→uninstall cycle must
+#     therefore leave no entry for the label in print-disabled.
 #
 #     If `launchctl print-disabled` itself errors (e.g. sandbox restrictions
 #     on a CI runner), we treat it as SKIP — not a FAIL — and log the reason.

--- a/scripts/test/test-install-smoke.sh
+++ b/scripts/test/test-install-smoke.sh
@@ -28,6 +28,11 @@
 #      200 again post-restart (regression guard for #141 / PR #164).
 #   9. `expertise-apictl stop` completes cleanly.
 #  10. No orphan dotnet ExpertiseApi process remains after stop.
+#  11. uninstall.sh --yes --purge exits 0.
+#  11a. (macOS only) `launchctl print-disabled gui/UID` contains no entry
+#       for the service label after uninstall — regression guard for #286.
+#       SKIP (not FAIL) if print-disabled itself errors (sandbox constraint).
+#  12. (macOS only) install.sh --system exits 2 + mentions #145.
 #
 # Exit codes:
 #   0  — all assertions passed
@@ -535,7 +540,61 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 11. macOS-only: install.sh --system must hard-error exit 2 (preflight
+# 11. Uninstall — smoke uninstall.sh and assert no stale launchd override
+#     state remains (macOS) and no plist remains (macOS). Runs on all OS.
+#
+#     macOS: after uninstall.sh --yes --purge, `launchctl print-disabled
+#     gui/UID` must NOT contain the service label. This is the acceptance
+#     criterion for #286: the old code ran only `bootout`, leaving a stale
+#     disabled-override; the fix runs `enable` (clears any override) before
+#     `bootout` so the label disappears from print-disabled entirely.
+#
+#     If `launchctl print-disabled` itself errors (e.g. sandbox restrictions
+#     on a CI runner), we treat it as SKIP — not a FAIL — and log the reason.
+# ---------------------------------------------------------------------------
+_uninstall_label="com.thesemicolon.expertise-api"
+
+_uninstall_log="${TMPDIR:-/tmp}/.smoke-uninstall-$$.log"
+log "running uninstall.sh --yes --purge (prefix=${PREFIX})"
+if bash "${ROOT}/scripts/uninstall.sh" --yes --purge --prefix "${PREFIX}" \
+     > "${_uninstall_log}" 2>&1; then
+  PASS=$((PASS + 1))
+  printf 'PASS: uninstall.sh --yes --purge exit 0\n'
+else
+  rc=$?
+  FAIL=$((FAIL + 1))
+  printf 'FAIL: uninstall.sh --yes --purge exit %d\n' "$rc" >&2
+  tail -n 40 "${_uninstall_log}" >&2 || true
+fi
+
+# macOS-only: assert no stale launchd override entry remains after uninstall.
+case "$(uname -s)" in
+  Darwin)
+    # Capture print-disabled output; treat a command failure as a SKIP.
+    set +e
+    _pd_output=$(launchctl print-disabled "gui/$(id -u)" 2>&1)
+    _pd_rc=$?
+    set -e
+    if [ "${_pd_rc}" != "0" ]; then
+      log "SKIP: launchctl print-disabled exited ${_pd_rc} — sandbox restriction; cannot assert launchd override state"
+      log "SKIP: print-disabled output: ${_pd_output}"
+    elif printf '%s\n' "${_pd_output}" | grep -qF "${_uninstall_label}"; then
+      FAIL=$((FAIL + 1))
+      printf 'FAIL: launchd override entry for %s still present after uninstall\n' "${_uninstall_label}" >&2
+      printf 'FAIL: launchctl print-disabled gui/%s output:\n' "$(id -u)" >&2
+      printf '%s\n' "${_pd_output}" >&2
+    else
+      PASS=$((PASS + 1))
+      printf 'PASS: no launchd override entry for %s after uninstall\n' "${_uninstall_label}"
+    fi
+    ;;
+  *)
+    log "SKIP: launchd override assertion (not running on Darwin; uname=$(uname -s))"
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# 12. macOS-only: install.sh --system must hard-error exit 2 (preflight
 #     guard for #285) and print the expected ERROR line naming #145.
 #     This assertion is macOS-specific; on Linux --system errors at a
 #     different stage (install_service, exit 1) — that behavior is not

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -196,31 +196,23 @@ case "${OS}" in
     LABEL="com.thesemicolon.expertise-api"
     PLIST="${HOME}/Library/LaunchAgents/${LABEL}.plist"
     if [[ -f "${PLIST}" ]]; then
-      # Teardown sequence (man launchctl):
+      # Teardown sequence (#286, semantics verified on a CI macOS runner):
       #
-      # 1. `launchctl enable gui/UID/LABEL` — clears any disabled-override the
-      #    service may have accumulated in launchd's LaunchDatabase. Without this
-      #    step, a subsequent reinstall would write a new plist but launchd would
-      #    refuse to start the service because the stale disabled-override
-      #    persists even after the plist is gone.
+      # launchd override entries are PERSISTENT: BOTH `launchctl enable` and
+      # `launchctl disable` write an entry into the LaunchDatabase that shows
+      # up in `launchctl print-disabled gui/UID`, and no launchctl subcommand
+      # removes an override entry without root. The only way to leave no
+      # stale state is to never write one — so uninstall runs no
+      # enable/disable at all, and install.sh only runs `enable` when the
+      # label is actually listed as disabled.
       #
-      #    Note: we do NOT run `disable` here. Running `disable` during uninstall
-      #    ADDS a persistent disabled-override entry that shows up in
-      #    `launchctl print-disabled gui/UID` forever — exactly the stale-state
-      #    this fix targets. The documented way to clear an override entry is
-      #    `enable` (which either removes the disabled-override or marks it
-      #    enabled, both of which satisfy `print-disabled` not listing the label
-      #    for a non-existent service on modern macOS).
+      # 1. `launchctl bootout gui/UID/LABEL` — stops and unregisters the
+      #    service. Tolerates the service never having been loaded (|| true).
+      # 2. `rm -f PLIST` — after this, launchd has no path to re-load it.
       #
-      # 2. `launchctl bootout gui/UID/LABEL` — unregisters and stops the service.
-      #    Tolerates the service never having been loaded (|| true).
-      #
-      # 3. `rm -f PLIST` — removes the plist file. After this, launchd has no
-      #    path to re-load the service, and no override entry remains.
-      #
-      # This mirrors the symmetry with install_launchd (install.sh) which runs:
-      #   bootout (idempotent) → bootstrap → enable → kickstart
-      do_action launchctl enable "gui/$(id -u)/${LABEL}" 2>/dev/null || true
+      # If a disabled-override exists (operator ran `launchctl disable` by
+      # hand), it is left in place: removing it requires root, it is harmless
+      # once the plist is gone, and install.sh clears it on the next install.
       do_action launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true
       do_action rm -f "${PLIST}"
     else

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -196,6 +196,31 @@ case "${OS}" in
     LABEL="com.thesemicolon.expertise-api"
     PLIST="${HOME}/Library/LaunchAgents/${LABEL}.plist"
     if [[ -f "${PLIST}" ]]; then
+      # Teardown sequence (man launchctl):
+      #
+      # 1. `launchctl enable gui/UID/LABEL` — clears any disabled-override the
+      #    service may have accumulated in launchd's LaunchDatabase. Without this
+      #    step, a subsequent reinstall would write a new plist but launchd would
+      #    refuse to start the service because the stale disabled-override
+      #    persists even after the plist is gone.
+      #
+      #    Note: we do NOT run `disable` here. Running `disable` during uninstall
+      #    ADDS a persistent disabled-override entry that shows up in
+      #    `launchctl print-disabled gui/UID` forever — exactly the stale-state
+      #    this fix targets. The documented way to clear an override entry is
+      #    `enable` (which either removes the disabled-override or marks it
+      #    enabled, both of which satisfy `print-disabled` not listing the label
+      #    for a non-existent service on modern macOS).
+      #
+      # 2. `launchctl bootout gui/UID/LABEL` — unregisters and stops the service.
+      #    Tolerates the service never having been loaded (|| true).
+      #
+      # 3. `rm -f PLIST` — removes the plist file. After this, launchd has no
+      #    path to re-load the service, and no override entry remains.
+      #
+      # This mirrors the symmetry with install_launchd (install.sh) which runs:
+      #   bootout (idempotent) → bootstrap → enable → kickstart
+      do_action launchctl enable "gui/$(id -u)/${LABEL}" 2>/dev/null || true
       do_action launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true
       do_action rm -f "${PLIST}"
     else


### PR DESCRIPTION
## Summary

On macOS, a normal install→uninstall cycle left a persistent override entry for `com.thesemicolon.expertise-api` in launchd's LaunchDatabase (visible in `launchctl print-disabled gui/UID` forever). Root cause, proven by the first CI run of this PR: `launchctl enable` and `launchctl disable` both WRITE persistent override entries, and no launchctl subcommand removes one without root — so the unconditional `enable` in `install_launchd` was itself creating the stale state. The fix is to never write an override: `install.sh` now runs `enable` only when the label is actually listed as `disabled` (recovering from a manual `launchctl disable`), and `uninstall.sh` runs `bootout` + plist removal only. A pre-existing operator-made disabled-override is left in place (harmless once the plist is gone; cleared by the next install).

Closes #286

## Type of Change

- [x] `fix` — bug fix

## Test Plan

- Shell scripts only; no dotnet changes.
- `bash -n` (bash 3.2) passes on all three changed files; `shellcheck` clean on `install.sh` and `uninstall.sh`.
- `scripts/validate-pr.sh` passes (0 errors, 0 warnings).
- New macOS-only smoke assertion (11a): after `uninstall.sh --yes --purge`, asserts `launchctl print-disabled gui/UID` contains no entry for the label, printing the full output on failure; SKIP (not FAIL) if `print-disabled` itself errors. The CI macOS `install-smoke` job performs a real install + uninstall — this assertion is the empirical gate, and it is the same assertion that falsified the first iteration of this fix.

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files (smoke test has pre-existing findings only, in a diagnostic-only branch)
- [x] Database migrations are reversible (if applicable) — N/A
- [x] API changes are backward-compatible (if applicable) — N/A
- [x] CLAUDE.md updated (if commands, endpoints, or workflow changed) — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)