### PR TITLE
fix(apictl): make logs command prefix-aware on macos and linux

### DIFF
--- a/scripts/expertise-apictl
+++ b/scripts/expertise-apictl
@@ -41,6 +41,51 @@ detect_os() {
 
 OS="$(detect_os)"
 
+# ---------------------------------------------------------------------------
+# resolve_log_dir — determine the log directory for the current install.
+#
+# Precedence (highest to lowest):
+#   1. EXPERTISE_API_LOG_DIR env var (explicit override, cheapest escape hatch)
+#   2. ${XDG_CONFIG_HOME:-${HOME}/.config}/expertise-api/install.env written
+#      by install.sh at install time (recorded-at-install; correct for
+#      --prefix installs where log dir diverges from the OS default path)
+#   3. OS-default path (backward-compat fallback for pre-existing installs
+#      that predate the install.env file)
+#
+# The install.env file is written to a stable, non-prefix-dependent XDG
+# config location so apictl can probe it without knowing which --prefix was
+# used at install time. It contains plain key=value lines (no quoting, no
+# subshells). We read it with grep+sed — never `source` — so we do not
+# execute arbitrary shell from disk.
+# ---------------------------------------------------------------------------
+resolve_log_dir() {
+  # Layer 1: explicit env override
+  if [[ -n "${EXPERTISE_API_LOG_DIR:-}" ]]; then
+    printf '%s' "${EXPERTISE_API_LOG_DIR}"
+    return 0
+  fi
+
+  # Layer 2: recorded-at-install value from the stable XDG config location.
+  local xdg_config install_env recorded
+  xdg_config="${XDG_CONFIG_HOME:-${HOME}/.config}"
+  install_env="${xdg_config}/expertise-api/install.env"
+  if [[ -f "${install_env}" ]]; then
+    recorded=$(grep -m1 '^EXPERTISE_API_LOG_DIR=' "${install_env}" \
+               | sed 's/^EXPERTISE_API_LOG_DIR=//' 2>/dev/null || true)
+    if [[ -n "${recorded}" ]]; then
+      printf '%s' "${recorded}"
+      return 0
+    fi
+  fi
+
+  # Layer 3: OS default (preserves behaviour for installs without the file)
+  case "${OS}" in
+    macos)          printf '%s' "${HOME}/Library/Logs/expertise-api" ;;
+    linux)          printf '%s' "${XDG_STATE_HOME:-${HOME}/.local/state}/expertise-api" ;;
+    wsl_to_windows) printf '%s' "${HOME}/.local/state/expertise-api" ;;
+  esac
+}
+
 cmd_start() {
   case "${OS}" in
     linux)          systemctl --user start "${SERVICE}.service" ;;
@@ -147,7 +192,9 @@ cmd_logs() {
         journalctl --user -u "${SERVICE}.service" -n "${lines}" --no-pager
       fi ;;
     macos)
-      local logfile="${HOME}/Library/Logs/expertise-api/stdout.log"
+      local log_dir logfile
+      log_dir="$(resolve_log_dir)"
+      logfile="${log_dir}/stdout.log"
       [[ -f "${logfile}" ]] || err "no log file at ${logfile}"
       if (( follow == 1 )); then
         tail -n "${lines}" -f "${logfile}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -552,6 +552,37 @@ write_install_version_marker() {
 }
 
 # ---------------------------------------------------------------------------
+# Install-env marker — records resolved path layout so expertise-apictl can
+# discover prefix-aware paths (e.g. LOG_DIR) without re-deriving them.
+#
+# Written to a STABLE, non-prefix-dependent location so apictl can probe it
+# without knowing which --prefix was used at install time:
+#   ${XDG_CONFIG_HOME:-${HOME}/.config}/expertise-api/install.env
+#
+# For a single-user install (the only supported mode) there is one active
+# install at a time, so the "last install wins" property is correct.
+#
+# File contains plain key=value assignments (no quoting, no subshells).
+# apictl reads it with grep+sed, not source, so no shell-execution risk.
+# chmod 644: no secrets — paths only.
+# ---------------------------------------------------------------------------
+write_install_env() {
+  local xdg_config_dir env_dir env_file
+  xdg_config_dir="${XDG_CONFIG_HOME:-${HOME}/.config}"
+  env_dir="${xdg_config_dir}/expertise-api"
+  env_file="${env_dir}/install.env"
+  mkdir -p "${env_dir}"
+  if [[ -L "${env_file}" ]]; then
+    err "${env_file} exists as a symlink — refusing to write"
+  fi
+  printf 'EXPERTISE_API_LOG_DIR=%s\n' "${LOG_DIR}" > "${env_file}.tmp"
+  printf 'EXPERTISE_API_PREFIX=%s\n'  "${PREFIX}"  >> "${env_file}.tmp"
+  mv -f -- "${env_file}.tmp" "${env_file}"
+  chmod 644 "${env_file}"
+  log "install-env: ${env_file}"
+}
+
+# ---------------------------------------------------------------------------
 # Publish (staged)
 # ---------------------------------------------------------------------------
 publish_app_staged() {
@@ -929,6 +960,7 @@ main() {
   atomic_swap
   install_service
   write_install_version_marker
+  write_install_env
   # D3 (#249) — post-swap mode/semver/history markers. Written AFTER
   # atomic_swap so they only reflect committed installs (a rollback path
   # that runs cleanup() before SUCCESS=1 will not have touched them).

--- a/scripts/test/test-install-smoke.sh
+++ b/scripts/test/test-install-smoke.sh
@@ -409,6 +409,21 @@ if [ "${SMOKE_INSTALL_MODE}" = "release" ]; then
 fi
 
 # ---------------------------------------------------------------------------
+# 4d. install.env written by install.sh records EXPERTISE_API_LOG_DIR (#287).
+#     Stored at ${XDG_CONFIG_HOME:-${HOME}/.config}/expertise-api/install.env
+#     so expertise-apictl can locate it without knowing which --prefix was
+#     used at install time. The smoke always uses --prefix so
+#     LOG_DIR == ${PREFIX}/logs; verify that the file records exactly that.
+# ---------------------------------------------------------------------------
+INSTALL_ENV_FILE="${XDG_CONFIG_HOME:-${HOME}/.config}/expertise-api/install.env"
+assert "post-install install.env exists at XDG config location" \
+  test -f "${INSTALL_ENV_FILE}"
+assert "post-install install.env records EXPERTISE_API_LOG_DIR" \
+  bash -c "grep -q '^EXPERTISE_API_LOG_DIR=' '${INSTALL_ENV_FILE}' 2>/dev/null"
+assert "post-install install.env EXPERTISE_API_LOG_DIR points to prefix logs dir" \
+  bash -c "grep -qF 'EXPERTISE_API_LOG_DIR=${PREFIX}/logs' '${INSTALL_ENV_FILE}' 2>/dev/null"
+
+# ---------------------------------------------------------------------------
 # 5. Service is active under systemd-user (Linux) / launchd (macOS).
 #    apictl status is the OS-agnostic shim.
 # ---------------------------------------------------------------------------
@@ -443,6 +458,17 @@ assert "/health/live returns 200 within ${READY_TIMEOUT_SECONDS}s" \
 # ---------------------------------------------------------------------------
 assert "/health/ready returns 200" \
   wait_for_http "${BASE_URL}/health/ready" 10
+
+# ---------------------------------------------------------------------------
+# 7b. apictl logs -n 1 succeeds with the prefix install layout (#287).
+#     This is the core regression guard: before the fix, macOS logs would
+#     hardcode ${HOME}/Library/Logs/expertise-api and miss ${PREFIX}/logs.
+#     On macOS the fix causes apictl to read LOG_DIR from install.env (written
+#     in step 4d). On Linux journalctl is path-agnostic. Both platforms must
+#     pass. The service must be running (checked in 7) for logs to exist.
+# ---------------------------------------------------------------------------
+assert "apictl logs -n 1 exits 0 (prefix-aware log path, #287 regression guard)" \
+  bash -c "'${APICTL}' logs -n 1 >/dev/null 2>&1"
 
 # ---------------------------------------------------------------------------
 # 8. apictl restart preserves readiness (regression for #141 / PR #164)


### PR DESCRIPTION
## Summary

`expertise-apictl logs` hardcoded `${HOME}/Library/Logs/expertise-api/stdout.log` on macOS, so any install made with `--prefix` reported "no log file" because the actual log directory is `${PREFIX}/logs`. This PR records the resolved log directory in a stable XDG config file at install time and teaches `expertise-apictl` to read it with a three-layer precedence: explicit env override > recorded value > OS default. The fix also extends the install smoke test with assertions verifying the recorded value and a direct `apictl logs -n 1` regression guard against the prefix install. `status` and `health` were audited — neither hardcodes a path, so no changes were needed there.

Closes #287

## Type of Change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [ ] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change (add `!` to PR title)

## Test Plan

- `bash -n` syntax-clean and `shellcheck`-clean on all three changed files
- `scripts/validate-pr.sh` passes (PASS — 0 errors, 0 warnings)
- `test-install-smoke.sh` gains four new assertions (4d ×3, 7b ×1) that will exercise the install.env path on every CI E1/E2/E3 run
- Assertion 7b is the direct regression guard: `apictl logs -n 1` must exit 0 against the running prefix install
- No dotnet/docker changes; CI is the verification gate per host-toolchain-gaps memory

## Checklist

- [x] No secrets or credentials committed (install.env contains paths only, chmod 644)
- [x] Linter clean on changed files (shellcheck clean, bash -n clean)
- [x] Database migrations are reversible (not applicable)
- [x] API changes are backward-compatible (not applicable)
- [x] CLAUDE.md updated (not applicable — no commands/endpoints/workflow changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)