### PR TITLE
fix(uninstall): close prefix-parent toctou in --system mode with ancestor walk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,27 @@ jobs:
       - name: Run semver comparator unit tests
         run: bash tests/install/test-semver-compare.sh
 
+  install-script-guards:
+    name: install/uninstall script guard tests (#242)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    # Bash-only unit suites for the install/uninstall safety machinery:
+    # the --system ancestor-walk TOCTOU guard (#242) and the migrate
+    # wall-time bound (#152, added by PR #302 but left unwired in CI).
+    # Linux runner deliberately: the black-box layer of the ancestor test
+    # needs --system, which macOS rejects at preflight until #145.
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run prefix-ancestor TOCTOU guard tests
+        run: bash tests/uninstall/test-prefix-ancestors.sh
+
+      - name: Run migrate-timeout tests
+        run: bash tests/install/test-migrate-timeout.sh
+
   apictl-restart-race-macos:
     name: apictl restart race regression (macOS)
     runs-on: macos-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,7 +322,7 @@ Scope shorthand (`read`, `draft`, `approve`, `admin`) expands to full scope stri
 
 | Workflow | Trigger | What it does |
 | -------- | ------- | ------------ |
-| `ci.yml` | PRs to main/dev, push to dev | Ten jobs: build & test (SCA vulnerable-package check, openapi.json artifact check, `dotnet format analyzers` gate), pi extension typecheck + tests, Helm lint + render tests, release-manifest generator, apictl restart-race (macOS + Debian 13), apictl stop→start lifecycle (macOS), install-smoke `--from-source` (Linux + macOS), OpenAPI breaking-change gate (PR-only, see below) |
+| `ci.yml` | PRs to main/dev, push to dev | Jobs: build & test (SCA vulnerable-package check, openapi.json artifact check, `dotnet format analyzers` gate), pi extension typecheck + tests, Helm lint + render tests, release-manifest generator, semver-comparator unit tests, install/uninstall script-guard unit tests, apictl restart-race (macOS + Debian 13), apictl stop→start lifecycle (macOS), install-smoke `--from-source` (Linux + macOS), OpenAPI breaking-change gate (PR-only, see below) |
 | `install-smoke-from-release.yml` | Push to dev / PRs, path-filtered to the release-consumer chain | `install.sh --from-release` end-to-end against the latest cosign-signed release (Linux + macOS) — E3 of the readiness track; gates the D4 default-flip per ADR-011 |
 | `release.yml` | Push to main | semantic-release version bump + tag, Docker build linux/amd64+arm64 to GHCR, cosign-signed A2 tarball + manifest as release assets, Helm chart OCI push, deploy dispatch to the infra repo (only when a new version is released) |
 | `lint-pr-title.yml` | PR to dev | Validates PR title follows Conventional Commits format |

--- a/README.md
+++ b/README.md
@@ -711,12 +711,18 @@ The uninstaller defends against destructive `--prefix` mistakes:
     `/usr/{bin,sbin,lib,libexec,share,include}`, `/var/lib`, `/snap`,
     ...) and blocks every descendant unconditionally —
     `--allow-system-prefix` does *not* relax this.
-- Under `--system` mode the prefix directory itself may not be a
-  symlink (TOCTOU defense for multi-user hosts). **Caveat:** the
-  uninstaller does not currently verify that *ancestors* of the prefix
-  are owned by root — if you operate a multi-user host, ensure
-  `/opt/<your-parent>/` is root-owned and not group-writable. Tracking
-  in [#242](https://github.com/psmfd/agent-expertise-api/issues/242).
+- Under `--system` mode the uninstaller enforces a multi-user-safety
+  contract on the whole path (TOCTOU defense, #242): the prefix
+  directory itself may not be a symlink, and **every ancestor** of the
+  prefix (from `/` down to its parent) must be owned by root, must not
+  be a symlink, and must not be group- or world-writable unless the
+  sticky bit is set (`/tmp`-style `1777` is acceptable; `0775` is not).
+  A violation aborts before any deletion is planned. Rationale: POSIX
+  pathname resolution follows symlinks in intermediate components, so a
+  non-root-owned or other-writable ancestor can be swapped for a symlink
+  between validation and `rm -rf`, redirecting the deletion to an
+  attacker-chosen path. Operators on multi-user hosts should install
+  under a root-owned chain such as `/opt/expertise-api`.
 - `--dry-run` forces a non-destructive run even with `--yes` and is the
   primary safety hook used by `tests/uninstall/test-prefix-guard.sh`.
   The plan reflects host state at dry-run invocation time; if the

--- a/scripts/lib/prefix-validation.sh
+++ b/scripts/lib/prefix-validation.sh
@@ -2,7 +2,7 @@
 #
 # scripts/lib/prefix-validation.sh — shared --prefix safety guard.
 #
-# Sourced by scripts/install.sh and scripts/uninstall.sh. Exposes two
+# Sourced by scripts/install.sh and scripts/uninstall.sh. Exposes three
 # functions:
 #
 #   normalize_prefix PATH        — lexical normalization; rejects '..',
@@ -11,6 +11,21 @@
 #   validate_prefix  PATH        — runs two-tier blocklist + component
 #                                   check. Errors out via `err` (which
 #                                   the sourcing script must define).
+#   validate_prefix_ancestors PATH
+#                                — TOCTOU-safe ancestor walk for
+#                                   --system mode: stat every directory
+#                                   component from / down to the leaf
+#                                   parent and refuse if any ancestor
+#                                   (a) is not owned by root (uid 0),
+#                                   (b) is group-writable without the
+#                                       sticky bit, or
+#                                   (c) is world-writable without the
+#                                       sticky bit, or
+#                                   (d) is itself a symlink (symlinked
+#                                       ancestors are the primary TOCTOU
+#                                       redirection vector).
+#                                   Reusable by macOS LaunchDaemon path
+#                                   (#145).
 #
 # Required caller-defined symbols:
 #
@@ -21,7 +36,11 @@
 # Design locked 2026-05-22 via shell-expert + security-review pre-review;
 # extracted from scripts/uninstall.sh (PR #243) into a shared library on
 # 2026-05-22 to close the install/uninstall asymmetry surfaced by the
-# PR B (#223) pre-PR security review.
+# PR B (#223) pre-PR review.
+# Ancestor-walk added 2026-06-11 (issue #242) to close the prefix-parent
+# TOCTOU gap: a non-root-owned or writable ancestor directory can be
+# swapped for a symlink between validation and rm -rf, redirecting the
+# deletion to an attacker-chosen path.
 #
 
 normalize_prefix() {
@@ -105,4 +124,168 @@ validate_prefix() {
       err "--prefix '$p' must contain 'expertise-api' as a path component (or pass --allow-system-prefix to skip this check)"
     fi
   fi
+}
+
+# validate_prefix_ancestors PATH
+#
+# Walk every ancestor directory of PATH (from / down to the parent of PATH)
+# and refuse if any component:
+#   (a) is not owned by root (uid 0) — a non-root-owned ancestor can be
+#       replaced by a symlink at any time by its owner, redirecting a
+#       subsequent rm -rf to an attacker-chosen path.
+#   (b) is group-writable without the sticky bit — group members can
+#       rename/replace the directory entry.
+#   (c) is world-writable without the sticky bit — any user can do the
+#       same.
+#   (d) is itself a symlink — a symlinked intermediate component IS the
+#       TOCTOU redirection vector; POSIX pathname resolution follows
+#       symlinks in intermediate components, so only symlinks INSIDE a
+#       recursively-deleted tree are removed without following.
+#
+# Stat invocations use lstat semantics (no symlink following):
+#   Linux : stat -c '%u %a'    → "uid octal-perms"  e.g. "0 755"  "0 1777"
+#   macOS : stat -f '%u %Mp%Lp' → same format        e.g. "0 755"  "0 1777"
+#   Both default to lstat (macOS BSD stat never follows; GNU stat -c does
+#   not follow either — only stat -L does on Linux). The [ -L ] symlink
+#   check runs first so a symlink-typed entry is caught before stat.
+#
+# Only called for INSTALL_SCOPE=system. User-mode operators own $HOME and
+# control the entire ancestor chain — the cost is unnecessary there.
+#
+# Caller must define err() to exit non-zero with the supplied message.
+validate_prefix_ancestors() {
+  local prefix="$1"
+
+  # Determine the OS once so the inner loop stays cheap.
+  local _os
+  _os="$(uname -s)"
+
+  # Build the list of ancestors: strip the prefix itself (we only check
+  # ancestors, not the leaf — validate_prefix already checks the leaf for
+  # symlinks). Walk from / down to the immediate parent of the prefix.
+  # We accumulate components by stripping one level at a time from prefix.
+  local component
+  component="${prefix%/*}"   # strip last component (leaf of prefix path)
+  # component is now the parent directory. We will walk upward to / and
+  # collect paths, then check them in order (top-down).
+
+  # Collect ancestors into a newline-separated string (bash 3.2: no arrays
+  # at file scope in sourced libs; we use a local variable list instead).
+  local ancestor_list=""
+  local p="$component"
+  while [ -n "$p" ] && [ "$p" != "/" ]; do
+    ancestor_list="${p}${ancestor_list:+
+${ancestor_list}}"
+    p="${p%/*}"
+    # When p has no more slashes (top-level component stripped), the next
+    # dirname is "/".
+    if [ -z "$p" ]; then
+      p="/"
+    fi
+  done
+  # Always include root itself (we want to start the walk at /).
+  ancestor_list="/${ancestor_list:+
+${ancestor_list}}"
+
+  # Walk each ancestor (in order from / down to the leaf parent).
+  local checked_path
+  # Process line-by-line using a here-string loop (bash 3.2 safe; no
+  # readarray/mapfile). We read from a subshell-safe here-doc.
+  while IFS= read -r checked_path; do
+    [ -n "$checked_path" ] || continue
+
+    # (d) Symlink check — lstat via [ -L ]. Catches symlinked ancestors
+    # before we even call stat. A symlinked ancestor is the exact attack
+    # vector: it can be atomically replaced to redirect rm -rf.
+    if [ -L "$checked_path" ]; then
+      err "--system ancestor is a symlink: $checked_path — an attacker can redirect rm -rf by swapping this symlink; pass the fully-resolved path"
+    fi
+
+    # Get uid and octal permissions via lstat.
+    # Linux: stat -c '%u %a' uses lstat (no -L = no follow on GNU stat).
+    # macOS: stat -f '%u %Mp%Lp' uses lstat by default (BSD stat never
+    #        follows without explicit -L). %Mp = high octal digit (sticky/
+    #        setuid/setgid), %Lp = low 9-bit octal (rwxrwxrwx). Combined
+    #        output matches Linux '%a' format: e.g. "0 755" or "0 1777".
+    local stat_out uid perms
+    case "$_os" in
+      Linux*)
+        stat_out="$(stat -c '%u %a' "$checked_path" 2>/dev/null)" || \
+          err "cannot stat ancestor: $checked_path"
+        ;;
+      Darwin*)
+        stat_out="$(stat -f '%u %Mp%Lp' "$checked_path" 2>/dev/null)" || \
+          err "cannot stat ancestor: $checked_path"
+        ;;
+      *)
+        err "validate_prefix_ancestors: unsupported OS $(uname -s)"
+        ;;
+    esac
+
+    uid="${stat_out%% *}"
+    perms="${stat_out##* }"
+
+    # (a) Ownership: must be root (uid 0).
+    if [ "$uid" != "0" ]; then
+      err "--system ancestor not owned by root (uid=$uid): $checked_path — a non-root owner can replace the directory with a symlink"
+    fi
+
+    # Parse sticky bit and group/world write bits from octal permissions.
+    # Format is 3 or 4 octal digits: [sticky][user][group][other]
+    # e.g. "755" or "1777". The sticky-bit digit is 1 when present.
+    # We need to check group (digit -2) and other (digit -1) write bits,
+    # plus the sticky digit to determine whether write permission is safe.
+
+    # Strip any high digits beyond the 4-digit octal representation.
+    # GNU stat may emit more digits for special modes; take the rightmost 4.
+    local trimmed_perms
+    if [ "${#perms}" -gt 4 ]; then
+      trimmed_perms="${perms: -4}"     # last 4 chars (bash 3.2: space before -)
+    else
+      trimmed_perms="$perms"
+    fi
+
+    # Extract the four positional digits (pad with leading 0 if only 3).
+    local sticky_digit group_digit other_digit
+    if [ "${#trimmed_perms}" -eq 4 ]; then
+      sticky_digit="${trimmed_perms%???}"   # first char of 4
+      group_digit="${trimmed_perms:2:1}"   # third char (0-indexed)
+      other_digit="${trimmed_perms:3:1}"   # fourth char
+    else
+      # 3-digit: no explicit sticky digit → sticky=0
+      sticky_digit="0"
+      group_digit="${trimmed_perms:1:1}"   # second char
+      other_digit="${trimmed_perms:2:1}"   # third char
+    fi
+
+    # Sticky bit is set when sticky_digit is odd (1, 3, 5, 7).
+    # Values: 1=sticky, 2=sgid, 3=sticky+sgid, 4=suid, 5=suid+sticky, etc.
+    local sticky_set=0
+    case "$sticky_digit" in
+      1|3|5|7) sticky_set=1 ;;
+    esac
+
+    # Group-write bit is set when group_digit has bit 1 (values 2,3,6,7).
+    # (b) Group-writable without sticky.
+    case "$group_digit" in
+      2|3|6|7)
+        if [ "$sticky_set" -eq 0 ]; then
+          err "--system ancestor is group-writable without sticky bit: $checked_path (perms=$perms) — group members can replace the directory entry"
+        fi
+        ;;
+    esac
+
+    # World-write bit is set when other_digit has bit 1 (values 2,3,6,7).
+    # (c) World-writable without sticky.
+    case "$other_digit" in
+      2|3|6|7)
+        if [ "$sticky_set" -eq 0 ]; then
+          err "--system ancestor is world-writable without sticky bit: $checked_path (perms=$perms) — any user can replace the directory entry"
+        fi
+        ;;
+    esac
+
+  done <<EOF
+${ancestor_list}
+EOF
 }

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -127,16 +127,19 @@ fi
 # process rather than exec so we can inspect the exit code.
 run_migrate() {
   local rc
+  # `|| rc=$?` keeps a non-zero child exit from tripping `set -e` before we
+  # can inspect it — without the guard, exit 124 aborted the script here and
+  # the timeout diagnostic below was never printed (caught by CI on #242's
+  # wiring of this test suite).
+  rc=0
   if [[ -n "${TIMEOUT_BIN}" && "${MIGRATE_TIMEOUT}" -gt 0 ]]; then
     log "migrate timeout: ${MIGRATE_TIMEOUT}s (via ${TIMEOUT_BIN})"
-    "${TIMEOUT_BIN}" "${MIGRATE_TIMEOUT}" "$@"
-    rc=$?
+    "${TIMEOUT_BIN}" "${MIGRATE_TIMEOUT}" "$@" || rc=$?
     if [[ "${rc}" -eq 124 ]]; then
       err "migration exceeded ${MIGRATE_TIMEOUT}s; live binaries NOT swapped; service NOT touched — check for advisory-lock contention or a runaway ALTER TABLE"
     fi
   else
-    "$@"
-    rc=$?
+    "$@" || rc=$?
   fi
   return "${rc}"
 }

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -128,6 +128,25 @@ BIN_DIR="${PREFIX}/bin"
 MODEL_DIR="${PREFIX}/models"
 
 # ----------------------------------------------------------------------------
+# Ancestor-walk TOCTOU guard (--system only, issue #242)
+#
+# validate_prefix already rejects a symlinked PREFIX itself. This guard
+# extends coverage to every ANCESTOR of PREFIX: a non-root-owned or
+# group/world-writable-without-sticky ancestor can be swapped for a
+# symlink between validation and rm -rf, redirecting the deletion to an
+# attacker-chosen path. POSIX pathname resolution follows symlinks in
+# intermediate components; only symlinks INSIDE a recursively-deleted
+# tree are removed without following.
+#
+# User-mode operators own $HOME and control their entire ancestor chain —
+# the check is unnecessary there and would fire on any user install under
+# a home directory not owned by root.
+# ----------------------------------------------------------------------------
+if [[ "${INSTALL_SCOPE}" == "system" ]]; then
+  validate_prefix_ancestors "${PREFIX}"
+fi
+
+# ----------------------------------------------------------------------------
 # Action helper
 #
 # Direct argv invocation (no `eval`). Callers attach `|| true` and

--- a/tests/install/test-migrate-timeout.sh
+++ b/tests/install/test-migrate-timeout.sh
@@ -110,12 +110,14 @@ if [[ -z "${TIMEOUT_BIN}" ]]; then
 else
   make_slow_stub 20
 
+  # `|| rc=$?` (not `|| true` then `rc=$?` — that reads the exit code of
+  # `true` and is always 0).
+  rc=0
   out=$("${MIGRATE}" \
     --bin-dir "${BIN_DIR}" \
     --secrets-file "${SECRETS}" \
     --migrate-timeout 2 \
-    2>&1) || true
-  rc=$?
+    2>&1) || rc=$?
 
   assert "slow-stub-times-out: exits non-zero" [ "${rc}" -ne 0 ]
   assert_contains "slow-stub-times-out: timeout message present" "${out}" "migration exceeded"

--- a/tests/uninstall/test-prefix-ancestors.sh
+++ b/tests/uninstall/test-prefix-ancestors.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+#
+# tests/uninstall/test-prefix-ancestors.sh
+#
+# Unit + black-box tests for validate_prefix_ancestors in
+# scripts/lib/prefix-validation.sh (issue #242 — prefix-parent TOCTOU
+# guard for --system uninstalls).
+#
+# Layer 1 (unit): sources the lib in a subshell where `uname` and `stat`
+# are shadowed by shell functions, so root-owned / group-writable /
+# sticky ancestor permutations are simulated deterministically on any
+# host without sudo. Both the Linux (stat -c '%u %a') and macOS
+# (stat -f '%u %Mp%Lp') branches are exercised this way. The symlink
+# check ([ -L ]) runs against the real filesystem, so the symlink case
+# builds a real symlinked ancestor under a scratch dir.
+#
+# Layer 2 (black-box): runs scripts/uninstall.sh --system --dry-run
+# against a HOME-local scratch prefix whose ancestor chain is not
+# root-owned, and asserts the ancestor guard fires before any
+# "DRY-RUN: rm" plan line is emitted.
+#
+# Run from repo root:
+#   bash tests/uninstall/test-prefix-ancestors.sh
+#
+# Exit 0 = PASS, 1 = at least one assertion failed.
+#
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+LIB="${ROOT}/scripts/lib/prefix-validation.sh"
+SCRIPT="${ROOT}/scripts/uninstall.sh"
+[[ -f "${LIB}" ]] || { echo "FAIL: ${LIB} not found" >&2; exit 1; }
+[[ -x "${SCRIPT}" ]] || { echo "FAIL: ${SCRIPT} not executable" >&2; exit 1; }
+
+PASS=0
+FAIL=0
+
+# ---------------------------------------------------------------------------
+# Layer 1 — unit cases with shadowed uname/stat
+#
+# run_case NAME FAKE_OS WANT_RC WANT_SNIPPET PREFIX TABLE
+#
+# TABLE is newline-separated "path uid perms" rows consumed by the fake
+# stat; perms uses the OS-native shape ("755"/"1777" for Linux %a,
+# "0755"/"1777" for macOS %Mp%Lp). WANT_RC 0 expects success; non-zero
+# expects the guard to refuse with WANT_SNIPPET somewhere in the output.
+# ---------------------------------------------------------------------------
+run_case() {
+  local name="$1" fake_os="$2" want_rc="$3" want_snip="$4" prefix="$5" table="$6"
+  local out rc
+  out=$(
+    FAKE_OS="${fake_os}" FAKE_STAT_TABLE="${table}" bash -c '
+      set -u
+      err() { printf "ERROR [ancestor-guard] %s\n" "$1" >&2; exit 1; }
+      uname() { echo "${FAKE_OS}"; }
+      stat() {
+        # Lib calls: stat -c FMT PATH (Linux) | stat -f FMT PATH (macOS).
+        # PATH is always $3.
+        local _path="$3" _line _p _u _m
+        while IFS= read -r _line; do
+          [ -n "${_line}" ] || continue
+          _p="${_line%% *}"; _line="${_line#* }"
+          _u="${_line%% *}"; _m="${_line#* }"
+          if [ "${_p}" = "${_path}" ]; then
+            printf "%s %s\n" "${_u}" "${_m}"
+            return 0
+          fi
+        done <<TBL
+${FAKE_STAT_TABLE}
+TBL
+        return 1
+      }
+      . "$1"
+      validate_prefix_ancestors "$2"
+      echo UNIT-OK
+    ' _ "${LIB}" "${prefix}" 2>&1
+  )
+  rc=$?
+  if [ "${want_rc}" = "0" ]; then
+    if [ "${rc}" -eq 0 ] && printf '%s' "${out}" | grep -q "UNIT-OK"; then
+      PASS=$((PASS + 1)); printf 'PASS: %s\n' "${name}"
+    else
+      FAIL=$((FAIL + 1)); printf 'FAIL: %s (rc=%d)\n%s\n' "${name}" "${rc}" "${out}" >&2
+    fi
+  else
+    if [ "${rc}" -ne 0 ] && printf '%s' "${out}" | grep -qF "${want_snip}"; then
+      PASS=$((PASS + 1)); printf 'PASS: %s\n' "${name}"
+    else
+      FAIL=$((FAIL + 1)); printf 'FAIL: %s (rc=%d, wanted snippet "%s")\n%s\n' "${name}" "${rc}" "${want_snip}" "${out}" >&2
+    fi
+  fi
+}
+
+# Ancestors of /xtest/parent/expertise-api are: / , /xtest , /xtest/parent.
+# /xtest does not exist on any host, so the real-fs [ -L ] check is inert
+# for every unit case and the faked stat fully controls the outcome.
+
+# --- Linux branch -----------------------------------------------------------
+run_case "linux: all ancestors root 755 pass" Linux 0 "" \
+  "/xtest/parent/expertise-api" \
+"/ 0 755
+/xtest 0 755
+/xtest/parent 0 755"
+
+run_case "linux: non-root ancestor refused" Linux 1 "not owned by root" \
+  "/xtest/parent/expertise-api" \
+"/ 0 755
+/xtest 0 755
+/xtest/parent 1000 755"
+
+run_case "linux: group-writable ancestor without sticky refused" Linux 1 "group-writable without sticky" \
+  "/xtest/parent/expertise-api" \
+"/ 0 755
+/xtest 0 775
+/xtest/parent 0 755"
+
+run_case "linux: group-writable ancestor WITH sticky passes" Linux 0 "" \
+  "/xtest/parent/expertise-api" \
+"/ 0 755
+/xtest 0 1775
+/xtest/parent 0 755"
+
+# 757 not 777: a 777 dir trips the group-write check first (also correct);
+# 757 isolates the world-write branch.
+run_case "linux: world-writable ancestor without sticky refused" Linux 1 "world-writable without sticky" \
+  "/xtest/parent/expertise-api" \
+"/ 0 755
+/xtest 0 757
+/xtest/parent 0 755"
+
+run_case "linux: 777 ancestor refused (group-write check fires first)" Linux 1 "group-writable without sticky" \
+  "/xtest/parent/expertise-api" \
+"/ 0 755
+/xtest 0 777
+/xtest/parent 0 755"
+
+run_case "linux: world-writable ancestor WITH sticky (tmp-like 1777) passes" Linux 0 "" \
+  "/xtest/parent/expertise-api" \
+"/ 0 755
+/xtest 0 1777
+/xtest/parent 0 755"
+
+run_case "linux: setgid-only digit (2) is not sticky — group-write 2775 refused" Linux 1 "group-writable without sticky" \
+  "/xtest/parent/expertise-api" \
+"/ 0 755
+/xtest 0 2775
+/xtest/parent 0 755"
+
+run_case "linux: sticky+setgid digit (3) counts as sticky — 3775 passes" Linux 0 "" \
+  "/xtest/parent/expertise-api" \
+"/ 0 755
+/xtest 0 3775
+/xtest/parent 0 755"
+
+run_case "linux: unstatable ancestor refused" Linux 1 "cannot stat ancestor" \
+  "/xtest/parent/expertise-api" \
+"/ 0 755
+/xtest/parent 0 755"
+
+# --- macOS branch (stat -f '%u %Mp%Lp' always yields a 4-digit octal) -------
+run_case "macos: all ancestors root 0755 pass" Darwin 0 "" \
+  "/xtest/parent/expertise-api" \
+"/ 0 0755
+/xtest 0 0755
+/xtest/parent 0 0755"
+
+run_case "macos: non-root ancestor refused" Darwin 1 "not owned by root" \
+  "/xtest/parent/expertise-api" \
+"/ 0 0755
+/xtest 501 0755
+/xtest/parent 0 0755"
+
+run_case "macos: group-writable without sticky refused" Darwin 1 "group-writable without sticky" \
+  "/xtest/parent/expertise-api" \
+"/ 0 0755
+/xtest 0 0775
+/xtest/parent 0 0755"
+
+run_case "macos: world-writable with sticky (1777) passes" Darwin 0 "" \
+  "/xtest/parent/expertise-api" \
+"/ 0 0755
+/xtest 0 1777
+/xtest/parent 0 0755"
+
+# --- Symlinked ancestor (real filesystem [ -L ]) -----------------------------
+# Build SCRATCH/real (dir) and SCRATCH/link -> real, then validate a prefix
+# under .../link/. Every real ancestor on the way down gets a permissive
+# fake-stat row; the [ -L ] check must fire on a symlinked component before
+# stat is even consulted for it. On macOS the scratch path may itself sit
+# below a system symlink (/tmp -> private/tmp), in which case the guard
+# correctly fires there first — either way the refusal names a symlink.
+SCRATCH="${TMPDIR:-/tmp}/expertise-api-test-ancestors.$$"
+mkdir -p "${SCRATCH}/real"
+ln -s "${SCRATCH}/real" "${SCRATCH}/link"
+trap 'rm -rf "${SCRATCH}"' EXIT
+
+_sym_prefix="${SCRATCH}/link/expertise-api"
+_sym_table="/ 0 755"
+_p="${_sym_prefix%/*}"
+while [ -n "${_p}" ] && [ "${_p}" != "/" ]; do
+  _sym_table="${_sym_table}
+${_p} 0 755"
+  _p="${_p%/*}"
+  [ -z "${_p}" ] && _p="/"
+done
+
+run_case "symlinked ancestor refused (real lstat)" "$(uname -s)" 1 "is a symlink" \
+  "${_sym_prefix}" "${_sym_table}"
+
+# ---------------------------------------------------------------------------
+# Layer 2 — black-box: uninstall.sh --system --dry-run refuses a prefix
+# whose ancestor chain is not root-owned, before emitting any plan line.
+#
+# A HOME-local scratch prefix guarantees at least one non-root-owned
+# ancestor (the user's own directories) on every host, including CI
+# runners. On macOS the chain may instead trip the symlink check at a
+# system symlink — both are ancestor-guard refusals, so the assertion
+# accepts any "--system ancestor" error.
+# ---------------------------------------------------------------------------
+if [ "$(uname -s)" = "Darwin" ]; then
+  # uninstall.sh hard-errors on --system on macOS (parity with install.sh,
+  # #291/#145), so the ancestor guard is unreachable black-box here. The
+  # Linux CI job exercises this layer; the unit layer above already covers
+  # both OS stat branches.
+  printf 'SKIP: black-box --system layer (macOS rejects --system before the ancestor guard; covered on Linux CI)\n'
+else
+  BB_SCRATCH="${HOME}/.expertise-api-test-ancestors.$$"
+  mkdir -p "${BB_SCRATCH}/expertise-api/bin"
+  trap 'rm -rf "${SCRATCH}" "${BB_SCRATCH}"' EXIT
+
+  bb_out=$(bash "${SCRIPT}" --system --allow-system-prefix --dry-run --yes \
+    --prefix "${BB_SCRATCH}/expertise-api" 2>&1)
+  bb_rc=$?
+  if [ "${bb_rc}" -ne 0 ] \
+     && printf '%s' "${bb_out}" | grep -q -- "--system ancestor" \
+     && ! printf '%s' "${bb_out}" | grep -q "DRY-RUN: rm"; then
+    PASS=$((PASS + 1))
+    printf 'PASS: black-box --system --dry-run refuses non-root ancestor chain\n'
+  else
+    FAIL=$((FAIL + 1))
+    printf 'FAIL: black-box --system --dry-run (rc=%d)\n%s\n' "${bb_rc}" "${bb_out}" >&2
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo "=================================="
+if [ "${FAIL}" -eq 0 ]; then
+  printf 'PASS — %d passed, 0 failed\n' "${PASS}"
+  exit 0
+else
+  printf 'FAIL — %d passed, %d failed\n' "${PASS}" "${FAIL}" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

`validate_prefix` (from PR #222/#243) rejects a symlinked PREFIX itself, but every ANCESTOR of PREFIX was unchecked: under `--system`, a non-root-owned or group/world-writable ancestor (e.g. `/opt/badparent` for `--prefix /opt/badparent/expertise-api`) can be swapped for a symlink between validation and `rm -rf`, redirecting the deletion to an attacker-chosen path — POSIX 4.13 pathname resolution follows symlinks in intermediate components. This PR adds `validate_prefix_ancestors` to the shared `scripts/lib/prefix-validation.sh`: a top-down walk from `/` to the prefix parent that refuses (a) non-root ownership, (b) group-writability without sticky, (c) world-writability without sticky, (d) a symlinked component. Wired into `uninstall.sh` for `--system` only (user-mode operators own their $HOME chain), and designed for reuse by the #145 macOS LaunchDaemon path, which shares the multi-user threat model.

Closes #242

## Type of Change

- [x] `fix` — bug fix

## Test Plan

- New `tests/uninstall/test-prefix-ancestors.sh`: 15 unit cases PASS locally under /bin/bash 3.2. The unit layer shadows `uname`/`stat` with shell functions so root-owned/group-writable/sticky permutations are simulated deterministically without sudo, covering BOTH the Linux (`stat -c '%u %a'`) and macOS (`stat -f '%u %Mp%Lp'`) branches, sticky-bit digit semantics (1/3/5/7 vs setgid-only 2), and a real-filesystem symlinked-ancestor case. A black-box layer runs `uninstall.sh --system --dry-run` against a non-root-owned chain and asserts refusal before any plan line; it SKIPs on macOS (which rejects `--system` at preflight until #145) and runs on the Linux CI job.
- BSD stat format verified empirically on a real macOS host: `%Mp%Lp` always emits 4-digit octal (`0755`, `1777`); the parser handles both 3- and 4-digit forms.
- `shellcheck` clean on all changed scripts; `bash -n` (bash 3.2) clean; `actionlint` clean on ci.yml.
- New `install-script-guards` CI job runs the ancestor suite **and** `tests/install/test-migrate-timeout.sh` (added by #302 but left unwired in CI — 7 passed, 1 skipped locally).

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files
- [x] Database migrations are reversible (if applicable) — N/A
- [x] API changes are backward-compatible (if applicable) — N/A
- [x] CLAUDE.md updated (ci.yml job inventory row refreshed; README --system multi-user contract replaces the old caveat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)