### PR TITLE
perf: tune A2 native service for local workstation footprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,28 @@ as a native OS service:
 - **Windows**: Windows Service via `sc.exe` with Virtual Account
   `NT SERVICE\expertise-api`, failure recovery 5s/5s/30s
 
+#### Lightweight local defaults
+
+The native-service install is tuned for a single-user workstation rather
+than a multi-tenant pod. These defaults are injected by the install scripts
+into the **service runtime environment only** (the generated
+`launch-expertise-api.sh` wrapper on macOS/Linux, the service registry key on
+Windows) — they are **never** baked into the csproj, `appsettings.json`, or
+the Docker image, so the container / Helm / `dotnet run` paths keep the
+production defaults unchanged.
+
+| Setting | Local default | Production default | Why |
+| ------- | ------------- | ------------------ | --- |
+| `DOTNET_gcServer` | `0` (Workstation GC) | `1` (Server GC) | Server GC allocates one managed heap + background GC thread *per logical core* and reserves memory aggressively. Workstation GC uses a single heap — a substantial idle-RSS and thread-count cut for a low-traffic service on a many-core laptop, with no downside at single-user request rates. |
+| `DOTNET_gcConcurrent` | `1` | `1` | Background GC stays on to keep collection pauses short. |
+| `Metrics__Enabled` | `false` | `true` | A solo workstation has no Prometheus scraper, so `/metrics` and per-request histogram bookkeeping are dead weight. |
+| PgBouncer | not used | sidecar (transaction pooling) | A single workstation connects **directly** to PostgreSQL on `5432`; the connection-pooling sidecar (and the `No Reset On Close=true` connection-string flag it requires) is a multi-client concern. The secrets stub written by the installer points straight at Postgres. |
+
+Every value is overridable. On macOS/Linux, set the same variable in
+`secrets.env` (the wrapper uses `:-` defaults, so an explicit value wins) —
+e.g. `DOTNET_gcServer=1` or `Metrics__Enabled=true`. On Windows, edit the
+`Environment` `REG_MULTI_SZ` value on the service key and restart the service.
+
 #### Survives reboot?
 
 | OS | Mode | Survives reboot? | Notes |

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -201,6 +201,16 @@ function Install-WindowsService {
         'ASPNETCORE_ENVIRONMENT=Production'
         'DOTNET_NOLOGO=true'
         'DOTNET_PRINT_TELEMETRY_MESSAGE=false'
+        # Lightweight local-workstation runtime tuning (native service ONLY —
+        # set on the service key, never in the csproj/Docker image so the
+        # container/k8s path keeps Server GC + metrics on). Workstation GC uses
+        # a single heap instead of one-per-core, cutting idle working set for a
+        # single-user, low-traffic service; metrics default off (no local
+        # scraper). Override by editing this REG_MULTI_SZ value (e.g. set
+        # DOTNET_gcServer=1 or Metrics__Enabled=true) and restarting the service.
+        'DOTNET_gcServer=0'
+        'DOTNET_gcConcurrent=1'
+        'Metrics__Enabled=false'
         "Onnx__ModelPath=$(Join-Path $ModelDir 'model.onnx')"
         "Onnx__VocabPath=$(Join-Path $ModelDir 'vocab.txt')"
     )

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -703,6 +703,12 @@ ensure_config_stubs() {
 # Set the connection string after install. Example for native Postgres:
 #   ConnectionStrings__DefaultConnection="Host=127.0.0.1;Port=5432;Database=expertise;Username=expertise;Password=CHANGE_ME"
 #
+# This points DIRECTLY at PostgreSQL on 5432 — a single-workstation install
+# does NOT need the PgBouncer sidecar (that is a k8s/Compose concern for pooling
+# many concurrent clients). The appsettings.json default of Port=6432 +
+# "No Reset On Close=true" is PgBouncer-specific; neither is needed here. Only
+# add "No Reset On Close=true" if you deliberately front Postgres with PgBouncer.
+#
 # The double quotes are REQUIRED: bash sources this file via \`set -a; . file\`
 # from the launch wrapper (and scripts/migrate.sh), and an unquoted value
 # containing \`;\` would be split as separate commands. systemd's own
@@ -781,6 +787,29 @@ export ASPNETCORE_URLS="http://${BIND_ADDR}"
 export ASPNETCORE_ENVIRONMENT="\${ASPNETCORE_ENVIRONMENT:-Production}"
 export DOTNET_NOLOGO=true
 export DOTNET_PRINT_TELEMETRY_MESSAGE=false
+
+# --- Lightweight local-workstation runtime tuning (A2 native install ONLY) ---
+# These are set here in the wrapper, NOT in the csproj/appsettings, so they
+# never reach the Docker image, Helm chart, or \`dotnet run\` — the container /
+# k8s path keeps the production defaults (Server GC, metrics on).
+#
+# Server GC (the Microsoft.NET.Sdk.Web default) allocates one managed heap and
+# background GC thread PER logical core and reserves memory aggressively — the
+# right trade for a multi-tenant pod under concurrent load, but pure idle-RSS
+# and thread overhead for a single-user, low-traffic local service. Workstation
+# GC uses a single heap and cuts idle working set substantially on a many-core
+# workstation. Concurrent (background) GC stays on to keep pauses short.
+#
+# Prometheus metrics default off locally: a solo workstation has no scraper, so
+# \`/metrics\` + per-request histogram bookkeeping is dead weight.
+#
+# Every value uses \`:-\` defaults so an operator can override any of them by
+# setting the same variable in secrets.env (sourced above) — e.g. set
+# DOTNET_gcServer=1 or Metrics__Enabled=true to restore production behaviour.
+export DOTNET_gcServer="\${DOTNET_gcServer:-0}"
+export DOTNET_gcConcurrent="\${DOTNET_gcConcurrent:-1}"
+export Metrics__Enabled="\${Metrics__Enabled:-false}"
+
 export Onnx__ModelPath="${MODEL_DIR}/model.onnx"
 export Onnx__VocabPath="${MODEL_DIR}/vocab.txt"
 


### PR DESCRIPTION
## Summary

Makes the Archetype A2 native OS service install lighter for a single-user workstation by injecting Workstation-GC and metrics-off defaults into the **service runtime environment only** (the generated `launch-expertise-api.sh` wrapper on macOS/Linux, the Windows service registry key). Nothing in the csproj, `appsettings.json`, or Docker image changes, so the container / Helm / `dotnet run` path keeps the production defaults (Server GC, metrics on).

The A2 install runs a single .NET process but inherited the production-shaped runtime. The two real footprint costs for a low-traffic, single-user service:

- **Server GC** (the `Microsoft.NET.Sdk.Web` default) allocates one managed heap + background GC thread *per logical core* and reserves memory aggressively — pure idle-RSS/thread overhead on a many-core laptop.
- **Prometheus metrics on** — `/metrics` + per-request histogram bookkeeping with no local scraper.

Local defaults set by the installer (all overridable):

| Setting | Local | Production | Why |
| --- | --- | --- | --- |
| `DOTNET_gcServer` | `0` (Workstation GC) | `1` (Server GC) | single heap → large idle working-set + thread-count cut |
| `DOTNET_gcConcurrent` | `1` | `1` | keep background GC for short pauses |
| `Metrics__Enabled` | `false` | `true` | solo workstation has no scraper |

Overrides: the bash wrapper uses `:-` defaults so a value in `secrets.env` wins; on Windows edit the `Environment` `REG_MULTI_SZ` value on the service key. Also clarifies in the secrets stub that a single-workstation install talks directly to Postgres on `5432` and needs neither PgBouncer nor `No Reset On Close=true`, and documents the defaults in the README A2 section.

Deliberately **not** included: an ONNX inference-thread cap (`BertOnnxOptions` exposes no session/thread knob and the default ONNX Runtime build ignores thread env vars — the only path touches all deployments), and any csproj-level GC/globalization change (would regress the k8s image).

## Type of Change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [ ] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes
- [x] `perf` — local-only runtime tuning (no behavior change to the shared app)
- [ ] Breaking change (add `!` to PR title)

## Test Plan

- [x] `bash -n scripts/install.sh` passes
- [x] Wrapper heredoc verified to render GC/metrics vars as runtime-deferred `${VAR:-default}` (install-time vars still expand; operator override via `secrets.env` wins, default `0`/`false` otherwise)
- [x] No existing test asserts wrapper env content (the install-smoke and upgrade-roundtrip tests check wrapper existence/inode only); GC env does not affect `migrate.sh` correctness, so no mirroring needed
- [ ] `dotnet test` — unaffected: no application code changed
- [ ] Helm render tests — N/A: chart unchanged

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files (`bash -n` clean; only scripts + README touched)
- [x] Database migrations are reversible (if applicable) — N/A
- [x] API changes are backward-compatible (if applicable) — N/A, no API change; Docker/Helm/k8s path unchanged
- [ ] CLAUDE.md updated (if commands, endpoints, or workflow changed) — not needed; no command/endpoint/workflow change, README A2 section documents the defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011uagQ2PcuZsDGc7WfRRAmR)_