### PR TITLE
fix: align EF Core to 10.0.9 and harden openapi-diff base build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -574,8 +574,13 @@ jobs:
         #   2. base build fails (SDK drift, transient infra) — we cannot
         #      diff, but failing the gate would block unrelated PRs on
         #      base-branch breakage. Surface as a Warning instead.
-        # set -uo pipefail (no -e) so we can capture rc explicitly.
+        # GitHub's default step shell is `bash -e {0}`, so a failing
+        # `dotnet build` below aborts the step before the rc capture, turning
+        # the intended "treat as non-breaking" fallback into a hard gate
+        # failure. `set +e` clears that errexit so we can inspect rc
+        # explicitly; `set -uo pipefail` keeps the rest of the safety net.
         run: |
+          set +e
           set -uo pipefail
           if [ ! -f src/ExpertiseApi/ExpertiseApi.csproj ]; then
             echo "::notice::base ref has no API project; skipping diff"

--- a/src/ExpertiseApi/ExpertiseApi.csproj
+++ b/src/ExpertiseApi/ExpertiseApi.csproj
@@ -74,7 +74,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.9" />
     <!--
       Service-host integration. Both packages are no-ops outside their host
       environment (SystemdHelpers.IsSystemdService / WindowsServiceHelpers.IsWindowsService),


### PR DESCRIPTION
## Summary

Two interdependent fixes that together restore a green build on `dev`:

1. **EF Core version alignment** — bump `Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore` `10.0.8` → `10.0.9`. The rest of the EF stack is already at `10.0.9` (`Microsoft.EntityFrameworkCore.Design 10.0.9`; `Npgsql.EntityFrameworkCore.PostgreSQL 10.0.2` → EF Core `10.0.9`), but this package lagged at `10.0.8` and transitively pinned EF Core / EFCore.Relational to `10.0.8`. The test project then resolved the lower assemblies and failed to consume `ExpertiseApi.dll` (compiled against `10.0.9`):

   ```
   CSC : error CS1705: Assembly 'ExpertiseApi' uses 'Microsoft.EntityFrameworkCore, Version=10.0.9.0'
   which has a higher version than referenced assembly 'Microsoft.EntityFrameworkCore' ... '10.0.8.0'
   ```

   This broke `Build & Test`, `OpenAPI breaking-change check`, and CodeQL's `Analyze C#` (all compile the solution).

2. **openapi-diff base-build hardening** — the `Build base ref spec` job documents its intent to downgrade a base-branch build failure to a Warning (so base breakage doesn't block otherwise-fine PRs) and sets `set -uo pipefail` "(no -e)" to capture the exit code. But GitHub's default step shell is `bash -e {0}`, and `set -uo pipefail` doesn't clear that inherited errexit — so a failing `dotnet build` aborted the step before the `rc=$?` capture, turning the graceful skip into a hard failure. Added `set +e` so the documented fallback actually runs.

### Why both in one PR

They're interdependent — neither produces a green PR alone. With only the csproj bump, this PR's OpenAPI gate still fails because it builds the `dev` base (which lacks the fix) and the latent `-e` bug makes that fatal. With only the CI fix, this PR's `Build & Test` and the OpenAPI job's "Build PR head spec" still fail on the EF skew in the head. Together, the head builds clean **and** the gate tolerates the still-broken base, so the PR goes fully green; once merged, `dev` builds again and the CI guard protects future PRs from base-branch breakage.

(Surfaced while investigating CI on #326, whose changes are scripts/docs only; this is the pre-existing root cause, fixed here.)

## Type of Change

- [ ] `feat` — new feature
- [x] `fix` — bug fix (dependency alignment)
- [ ] `docs` — documentation only
- [ ] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [x] `ci` — CI/CD changes (openapi-diff errexit guard)
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change (add `!` to PR title)

## Test Plan

- [ ] `dotnet test` locally — not run: no .NET SDK in the authoring environment. CI validates: the prior run already showed the **head** spec building with `0 Warning(s) 0 Error(s)` (proving the EF fix); the new run should show the OpenAPI gate green via the base-build guard.
- [x] New features and bug fixes include tests — N/A: dependency-version bump + CI errexit guard, no behavior change.
- [x] Helm render tests — N/A: chart unchanged.
- [x] Relevant endpoint(s) manually verified — N/A: no API change.

## Checklist

- [x] No secrets or credentials committed
- [x] Linter clean on changed files — single csproj `Version` attribute; `ci.yml` validated as well-formed YAML
- [x] Database migrations are reversible (if applicable) — N/A
- [x] API changes are backward-compatible (if applicable) — N/A, patch-version bump within the same minor
- [x] CLAUDE.md updated (if commands, endpoints, or workflow changed) — N/A: no documented command/endpoint/workflow behavior changes (the CI guard only fixes error handling already described in-file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)