### PR TITLE
fix(deps): pin Microsoft.OpenApi to 2.9.0 (GHSA-v5pm-xwqc-g5wc)

### DIFF
--- a/src/ExpertiseApi/ExpertiseApi.csproj
+++ b/src/ExpertiseApi/ExpertiseApi.csproj
@@ -62,6 +62,16 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
     <!--
+      Transitive security pin. Microsoft.AspNetCore.OpenApi 10.0.8 pulls
+      Microsoft.OpenApi 2.0.0, which carries a HIGH-severity advisory
+      (GHSA-v5pm-xwqc-g5wc: circular schema references may terminate OpenAPI
+      parsing; vulnerable <= 2.7.4, first patched 2.7.5). Pin forward to the
+      latest patched 2.x — API-compatible within the 2.x major, so the parent
+      package resolves against it. Drop this once Microsoft.AspNetCore.OpenApi
+      references a patched Microsoft.OpenApi transitively.
+    -->
+    <PackageReference Include="Microsoft.OpenApi" Version="2.9.0" />
+    <!--
       Build-time OpenAPI document generator (Part D C8). PrivateAssets=all keeps the
       package out of the published output (it's an MSBuild task, not a runtime dependency).
       IncludeAssets covers the build / buildMultitargeting / buildTransitive surfaces


### PR DESCRIPTION
## Problem

`Microsoft.AspNetCore.OpenApi 10.0.8` pulls `Microsoft.OpenApi 2.0.0` transitively, which carries a **high-severity advisory** — [GHSA-v5pm-xwqc-g5wc](https://github.com/advisories/GHSA-v5pm-xwqc-g5wc): circular schema references may terminate OpenAPI parsing (vulnerable `<= 2.7.4`, first patched `2.7.5`). This newly-published advisory fails the `Build & Test` SCA gate (NU1903) **repo-wide**, independent of any code change — surfaced on #335 (a shell-only PR) and #336.

## Fix

Direct transitive pin to the latest patched 2.x (`2.9.0`) in `src/ExpertiseApi/ExpertiseApi.csproj`. A parent patch-bump won't reach 2.7.5, so a direct pin is the correct remediation; it's API-compatible within the 2.x major, so `Microsoft.AspNetCore.OpenApi 10.0.8` resolves against it. The pin propagates to the test project via `ProjectReference`.

## Validation (local .NET 10 SDK 10.0.301)

- `dotnet list package --vulnerable --include-transitive` → **both projects report no vulnerable packages**
- `dotnet build -c Release` → **succeeds, 0 errors** (parent package compatible)
- Generated OpenAPI doc (`dotnet-getdocument`) is **byte-identical** to the `dev` baseline built with 2.0.0 — the OpenAPI breaking-change gate stays green

Closes #336