### PR TITLE
docs: add backup/restore and aggregator up-sync adrs and runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,24 @@ pending EF Core migrations and is idempotent (no-op when up to date).
   The flag is accepted by `scripts/migrate.sh` directly for standalone use,
   and by `scripts/install.sh` / `scripts/install.ps1` which pass it through.
 
+#### Backup & restore
+
+Operator procedures live in the
+[Backup & Restore Runbook](docs/operations/backup-restore-runbook.md):
+
+- **Part A — seed from an existing pg_dump** (older hosted instance →
+  fresh local install): restore-before-migrate ordering, pre-migrate
+  verification queries, the `Tenant='legacy'` remediation trap, and the
+  `rehash`/`reembed` follow-ups.
+- **Part B — ongoing provenance-verified backups** ([ADR-012](adrs/012-backup-artifact-format.md)):
+  `backup`/`restore` CLI verbs producing an age-encrypted, cosign-signed
+  NDJSON artifact with per-record Merkle hashing, orchestrated by
+  `expertise-apictl backup-init | backup | restore` (#340).
+
+Backup artifacts contain Drafts, Rejected entries, and the audit log —
+treat them as sensitive (the tooling chmods them 600) even though the
+payload is encrypted.
+
 #### Upgrade safety
 
 `scripts/install.sh` is safe to re-run for upgrades. Each invocation:
@@ -855,6 +873,8 @@ Adding the label is an explicit human decision recorded on the PR. Anyone with `
 | Scanning stack (CodeQL, Trivy, Hadolint, OSV-Scanner) | [ADR-004](adrs/004-security-scanning-stack.md) |
 | Idempotency-Key handling and replay semantics (Part D C3) | [ADR-010](adrs/010-idempotency-key-handling.md) |
 | Cosign-signed published tarball over SDK-on-host for Archetype A2 install | [ADR-011](adrs/011-deployment-artifact-format.md) |
+| Application-level signed + encrypted backup artifact (format, trust policy) | [ADR-012](adrs/012-backup-artifact-format.md) |
+| Aggregator up-sync: draft-only scope as the knowledge-supply-chain control | [ADR-013](adrs/013-aggregator-upsync.md) |
 
 ## License
 

--- a/adrs/012-backup-artifact-format.md
+++ b/adrs/012-backup-artifact-format.md
@@ -1,0 +1,119 @@
+# Application-level signed and encrypted backup artifact over pg_dump
+
+- Status: accepted
+- Date: 2026-07-05
+- Companion: [ADR-011](011-deployment-artifact-format.md) (signing precedent), `docs/operations/backup-restore-runbook.md`, [ADR-013](013-aggregator-upsync.md) (reuses the Merkle construction)
+- Tracking issue: [#340](https://github.com/psmfd/agent-expertise-api/issues/340)
+- Surfaced by: 2026-07-05 backup/restore + aggregator design session (3-agent fan-out: `expertise-api-owner`, `dotnet-expert`, `security-review-expert`); immediate driver is seeding a local A2 instance from an older hosted pg_dump and needing durable, portable backups thereafter.
+
+## Context and Problem Statement
+
+The only backup mechanism today is a raw `pg_dump`. A logical dump is coupled to the PostgreSQL/pgvector/EF-migration vintage of the moment it was taken, provides no per-record provenance, and its restore path was only validated as a one-time seeding runbook (see `docs/operations/backup-restore-runbook.md` Part A). The API needs a repeatable, provenance-verified backup and restore path that:
+
+- survives PostgreSQL major-version, pgvector, and EF-migration skew between backup time and restore time;
+- gives entry-granular tamper evidence, not just whole-file integrity;
+- is trustworthy at disaster-recovery time with **no network access** and no CI identity;
+- protects entry content at rest (backups leave the database's access-control envelope).
+
+How should backup artifacts be formatted, signed, and encrypted, and what does restore trust?
+
+## Considered Options
+
+### Format
+
+- **A. pg_dump (status quo).** Zero new code. Couples the artifact to DB engine vintage; no per-record hashing; restore of a partial/tampered dump is undetectable until data is served.
+- **B. Application-level NDJSON export via new CLI verbs.** `backup`/`restore` verbs following the established `Cli/` pattern. Engine-agnostic (JSON survives any future PG/pgvector/EF change); per-record hashing is natural; restore re-enters through EF so column defaults, generated columns, and migrations behave identically to normal writes.
+- **C. EF bulk export via a third-party library.** EFCore.BulkExtensions is revenue-gated dual-license (since 2023) — rejected on licensing grounds alone.
+
+### Compression
+
+- **gzip via .NET `GZipStream`** — zero new NuGet or host dependencies; compression happens inside the CLI verb so the verb alone produces a complete (unsigned, unencrypted) artifact for dev use.
+- **zstd** — better ratio/speed, but requires either a NuGet native-binding package or a host binary; a third external tool alongside cosign and age for marginal gain at this data volume.
+
+### Signing
+
+- **cosign local-keypair mode (`cosign sign-blob --key`)** — one signing tool across releases (ADR-011) and backups; works fully offline.
+- **cosign keyless OIDC (release-pipeline mode)** — requires network + an OIDC identity at signing/verification time (unavailable at DR time for a solo operator) and publishes to the public Rekor transparency log (a metadata leak for private-tenant backups).
+- **`ssh-keygen -Y sign/verify`** — acceptable lighter-weight alternative (no new tool if cosign were not already a host dependency), but cosign is already installed for A2 release verification.
+
+### Encryption
+
+- **age (encrypt payload, sign manifest in cleartext)** — modern, single-purpose file encryption; recipients model supports multiple keys; layered *under* the signature so verification is possible without the decryption key.
+- **No encryption (signing only)** — acceptable only while backups never leave operator-controlled disks; rejected by user decision 2026-07-05: entries may contain sensitive prose, encrypt from day one.
+- **GPG** — larger tool surface and worse UX than age for this single use case.
+
+## Decision Outcome
+
+**Chosen: application-level NDJSON (B), gzip, cosign local-keypair signing, age encryption of the payload only.**
+
+Artifact layout — outer tar `expertise-backup-<instanceId>-<timestamp>.tar` containing:
+
+```text
+payload.tar.gz.age     # age-encrypted, gzipped tar of entries.jsonl + audit.jsonl
+manifest.json          # cleartext — see schema below
+manifest.json.sig      # detached cosign sign-blob --key signature over manifest.json only
+```
+
+Manifest schema (v1):
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "instanceId": "…",             // operator-supplied or machine name
+  "exportedAt": "…",             // UTC ISO-8601
+  "entryCount": 0,
+  "auditCount": 0,
+  "entriesMerkleRoot": "…",      // RFC 6962 over per-entry BackupRecordHash leaves
+  "auditMerkleRoot": "…",        // RFC 6962 over per-audit-row leaves
+  "dbSchemaVersion": "…",        // last applied EF migration id at export time
+  "embeddingModel": { "name": "bge-micro-v2", "dims": 384 },
+  "payloadSha256": "…"           // SHA-256 of payload.tar.gz.age as stored
+}
+```
+
+Because the manifest and signature are cleartext, an operator verifies the signature and the payload SHA **before** decrypting anything; the Merkle roots verify per-record integrity after decryption.
+
+### Sub-decisions
+
+**Record hashing: new `BackupRecordHash`, not a widened `IntegrityHashService.Compute`.** `Compute` hashes exactly `{tenant, title, body, entryType, severity}` and is load-bearing for the dedup-equality contract (`DeduplicationService`). The backup leaf hash must cover the full record: those 5 fields plus `Domain`, sorted `Tags`, `Source`/`SourceVersion`, `Visibility`, `AuthorPrincipal`/`AuthorAgent`, `ReviewState`/`ReviewedBy`/`ReviewedAt`/`RejectionReason`, and `CreatedAt`/`UpdatedAt`/`DeprecatedAt`. It lives as a static sibling of `IntegrityHashService`, reusing the same `Utf8JsonWriter` canonical-JSON idiom. Leaves combine into an RFC 6962 Merkle tree (0x00 leaf / 0x01 node prefixes) so inclusion proofs are available later for down-sync reconciliation (ADR-013 deferral list).
+
+**Embeddings ship inside the artifact but outside the trust boundary.** Embedding vectors are exported for restore speed, but are NOT covered by leaf hashes — they are derived data, regenerable via `reembed`. Restore compares the manifest's `embeddingModel` against the live `EmbeddingMetadata` row and **fails loudly on mismatch**, directing the operator to `reembed` (same explicit-compat-check posture as ADR-011's `requiredRuntime.minVersion`).
+
+**Restore trust policy.**
+
+| Scenario | Policy |
+| --- | --- |
+| DR restore of own backup | Fail closed on bad or missing signature |
+| Single record fails its leaf hash | Quarantine that record as `Draft` + audit row; continue |
+| Foreign backup (someone else's instance) | ALL entries forced to `Draft` regardless of signature validity |
+| Local dev | `--i-accept-unsigned-backup` escape hatch (mirrors `--i-accept-unverified-source`, ADR-011) |
+
+**Scope: everything reviewable, nothing ephemeral.** All `ReviewState`s (including Drafts — they are exactly the data the feature protects) and the full audit log are exported. Idempotency rows are excluded (24h-TTL ephemera; restoring them is meaningless). `SearchVector` (server-generated) and the `xmin` concurrency token are excluded from the DTO; `Id`/`CreatedAt`/`UpdatedAt` are preserved on import (explicit values win over `gen_random_uuid()`/`now()` column defaults — integration-tested invariant).
+
+**v1 restore is `--mode replace` (empty target only).** Merge-mode restore has real conflict semantics (Id collisions, hash divergence, audit interleaving) and gets its own ADR — tracked in [#343](https://github.com/psmfd/agent-expertise-api/issues/343).
+
+**CLI-only; no HTTP endpoints.** A backup is a full-fidelity cross-tenant extract — strictly more privileged than `GET /audit/{id}/raw`. It must not be reachable through any bearer token. Restore additionally requires `GetPendingMigrationsAsync()` to be empty, else it aborts (the `MigrateCommand` idiom).
+
+**Key management and operator UX.** cosign keypair and age identity live in `~/.config/expertise-api/backup/` (directory 700, files 600). `scripts/expertise-apictl backup-init` bootstraps the whole surface: installs missing tools (apt on Debian, brew on macOS — mirroring `install.sh --install-deps`), generates keys if absent (never overwriting silently), and writes/validates `backup.env` (key paths, age recipients, output directory). Every `apictl backup`/`apictl restore` run re-validates preconditions with actionable errors pointing at `backup-init`. age recipients are configurable so a second (offline/escrow) key can decrypt.
+
+## Consequences
+
+- **Good** — artifact survives PG major, pgvector, and EF-migration skew by construction; restore re-enters through EF and the normal migration gate.
+- **Good** — entry-granular tamper evidence; a single modified record is quarantined, not silently served.
+- **Good** — verification requires no network, no CI identity, no Rekor: `cosign verify-blob --key` + SHA + Merkle recomputation are all local.
+- **Good** — encrypted at rest from day one; signature verifiable without the decryption key.
+- **Good** — one signing tool (cosign) across releases and backups; gzip adds zero dependencies.
+- **Bad** — a second cosign *mode* (local keypair) now exists alongside the release pipeline's keyless mode; documentation must be explicit that the backup public key, not the Fulcio identity, is the backup trust root.
+- **Bad** — key loss = backup loss (age) or unverifiable backups (cosign). Mitigated by the multi-recipient age configuration and the runbook's key-escrow note; accepted for a solo-operator scale.
+- **Bad** — restore is replace-only in v1; operators with a populated target must wait for merge mode (#343) or wipe.
+- **Bad** — backup artifacts contain Draft and Rejected content plus the audit log; the artifact itself is sensitive and the tooling chmods it 600, but off-disk handling is the operator's responsibility (runbook note).
+- **Revisit if** — backup volume outgrows single-file NDJSON (streaming/chunked format), or a hub-side automated backup service materializes (would need non-interactive key handling).
+
+## Implementation notes (non-normative)
+
+- Export wraps keyset paging (`Id`-ordered, `IgnoreQueryFilters()`) in one `RepeatableRead` transaction for a consistent multi-page snapshot; import commits per batch.
+- Import order: entries first, then audit rows (`ON DELETE RESTRICT` FK).
+- Export DTOs get a source-generated `JsonSerializerContext` (repo-first; keeps `AnalysisMode=All` clean and the CLI trim-friendly).
+- `Embedding` exports as `float[]` via `entry.Embedding?.ToArray()`.
+- The .NET verbs own NDJSON+gzip+Merkle+manifest; `apictl` owns age/cosign orchestration — so the binary alone produces a valid artifact under `--i-accept-unsigned-backup` for dev loops.
+- tar extraction on restore follows ADR-011's hardening note (prefer `bsdtar`; GNU tar fallback flags).

--- a/adrs/012-backup-artifact-format.md
+++ b/adrs/012-backup-artifact-format.md
@@ -27,7 +27,8 @@ How should backup artifacts be formatted, signed, and encrypted, and what does r
 
 ### Compression
 
-- **gzip via .NET `GZipStream`** — zero new NuGet or host dependencies; compression happens inside the CLI verb so the verb alone produces a complete (unsigned, unencrypted) artifact for dev use.
+- **gzip via `tar -czf` in the orchestration wrapper** — zero new NuGet or host dependencies (gzip ships everywhere cosign and age do); the wrapper streams tar → gzip → age in one pipeline, and the CLI verb emits plain NDJSON so the dev loop (`--i-accept-unsigned-backup`) needs no tooling at all.
+- **gzip via .NET `GZipStream` inside the CLI verb** — also dependency-free, but double-buffers the payload through managed memory and splits compression across two layers once the wrapper tars the files anyway.
 - **zstd** — better ratio/speed, but requires either a NuGet native-binding package or a host binary; a third external tool alongside cosign and age for marginal gain at this data volume.
 
 ### Signing
@@ -44,7 +45,7 @@ How should backup artifacts be formatted, signed, and encrypted, and what does r
 
 ## Decision Outcome
 
-**Chosen: application-level NDJSON (B), gzip, cosign local-keypair signing, age encryption of the payload only.**
+**Chosen: application-level NDJSON (B), gzip via the wrapper's `tar -czf`, cosign local-keypair signing, age encryption of the payload only.**
 
 Artifact layout — outer tar `expertise-backup-<instanceId>-<timestamp>.tar` containing:
 
@@ -75,7 +76,7 @@ Because the manifest and signature are cleartext, an operator verifies the signa
 
 ### Sub-decisions
 
-**Record hashing: new `BackupRecordHash`, not a widened `IntegrityHashService.Compute`.** `Compute` hashes exactly `{tenant, title, body, entryType, severity}` and is load-bearing for the dedup-equality contract (`DeduplicationService`). The backup leaf hash must cover the full record: those 5 fields plus `Domain`, sorted `Tags`, `Source`/`SourceVersion`, `Visibility`, `AuthorPrincipal`/`AuthorAgent`, `ReviewState`/`ReviewedBy`/`ReviewedAt`/`RejectionReason`, and `CreatedAt`/`UpdatedAt`/`DeprecatedAt`. It lives as a static sibling of `IntegrityHashService`, reusing the same `Utf8JsonWriter` canonical-JSON idiom. Leaves combine into an RFC 6962 Merkle tree (0x00 leaf / 0x01 node prefixes) so inclusion proofs are available later for down-sync reconciliation (ADR-013 deferral list).
+**Record hashing: new `BackupRecordHash`, not a widened `IntegrityHashService.Compute`.** `Compute` hashes exactly `{tenant, title, body, entryType, severity}` and is load-bearing for the dedup-equality contract (`DeduplicationService`). The backup leaf hash must cover the full record: those 5 fields plus `Id` (binds the hash to the record's identity, so hashes cannot be swapped between records with identical content), `Domain`, sorted `Tags`, `Source`/`SourceVersion`, `Visibility`, `AuthorPrincipal`/`AuthorAgent`, `ReviewState`/`ReviewedBy`/`ReviewedAt`/`RejectionReason`, and `CreatedAt`/`UpdatedAt`/`DeprecatedAt`. It lives as a static sibling of `IntegrityHashService`, reusing the same `Utf8JsonWriter` canonical-JSON idiom. Leaves combine into an RFC 6962 Merkle tree (0x00 leaf / 0x01 node prefixes) so inclusion proofs are available later for down-sync reconciliation (ADR-013 deferral list).
 
 **Embeddings ship inside the artifact but outside the trust boundary.** Embedding vectors are exported for restore speed, but are NOT covered by leaf hashes — they are derived data, regenerable via `reembed`. Restore compares the manifest's `embeddingModel` against the live `EmbeddingMetadata` row and **fails loudly on mismatch**, directing the operator to `reembed` (same explicit-compat-check posture as ADR-011's `requiredRuntime.minVersion`).
 
@@ -115,5 +116,5 @@ Because the manifest and signature are cleartext, an operator verifies the signa
 - Import order: entries first, then audit rows (`ON DELETE RESTRICT` FK).
 - Export DTOs get a source-generated `JsonSerializerContext` (repo-first; keeps `AnalysisMode=All` clean and the CLI trim-friendly).
 - `Embedding` exports as `float[]` via `entry.Embedding?.ToArray()`.
-- The .NET verbs own NDJSON+gzip+Merkle+manifest; `apictl` owns age/cosign orchestration — so the binary alone produces a valid artifact under `--i-accept-unsigned-backup` for dev loops.
+- The .NET verbs own NDJSON+Merkle+manifest; `apictl` owns tar/gzip/age/cosign orchestration — so the binary alone produces a valid (plain, unsigned) payload under `--i-accept-unsigned-backup` for dev loops.
 - tar extraction on restore follows ADR-011's hardening note (prefer `bsdtar`; GNU tar fallback flags).

--- a/adrs/013-aggregator-upsync.md
+++ b/adrs/013-aggregator-upsync.md
@@ -1,0 +1,65 @@
+# Hub-and-spoke aggregator: up-sync v1 via existing batch endpoint and draft-only scope
+
+- Status: accepted
+- Date: 2026-07-05
+- Companion: [ADR-001](001-tenancy-model.md) (tenancy, unmodified), [ADR-003](003-scope-split.md) (scope semantics as the enforcement mechanism), [ADR-005](005-multi-issuer-jwt-policy-scheme.md) (auth plumbing reused), [ADR-008](008-response-hygiene-and-actor-class.md) (service actor class), [ADR-010](010-idempotency-key-handling.md) (batch exclusion), [ADR-012](012-backup-artifact-format.md) (Merkle construction reused later)
+- Tracking issue: [#341](https://github.com/psmfd/agent-expertise-api/issues/341)
+- Surfaced by: 2026-07-05 backup/restore + aggregator design session (3-agent fan-out); user decisions locked the same day: OIDC `client_credentials` on a shared IdP, up-sync only for v1.
+
+## Context and Problem Statement
+
+Several independent A2 instances ("spokes", typically NAT'd solo-developer boxes) accumulate expertise entries. Teams want approved, shareable knowledge aggregated on one central instance (the "hub") where a curator controls what becomes visible to other teams. How do spokes ship entries to the hub without new write surface, without a new auth mode, and without letting any spoke poison the hub's shared knowledge base (OWASP ASI04/ASI06 — knowledge-supply-chain poisoning, the exact threat class in `docs/security/integration-threat-model.md`)?
+
+## Considered Options
+
+- **A. New dedicated sync endpoint + new service-token auth mode.** Maximum flexibility; maximum new attack surface: a second write path to review, a non-OIDC credential class outside the existing startup guards, and a new ADR-003 bypass risk.
+- **B. Reuse `POST /expertise/batch` + OIDC `client_credentials` on a shared IdP, spoke credential scoped `expertise.write.draft` only.** Zero new write endpoints; zero new auth code (ADR-005 multi-issuer plumbing and the `TenantSource` mapping already handle service principals); the Draft gate is enforced by scope semantics that already exist and are already tested.
+- **C. Pull model (hub polls spokes).** Requires every spoke to be reachable from the hub — false for NAT'd A2 boxes; also inverts the credential direction so the hub holds a credential for every spoke (worse blast radius).
+
+## Decision Outcome
+
+**Chosen: Option B.** Hub-and-spoke; **each spoke is a tenant on the hub** (ADR-001 unmodified). All connections are spoke-initiated. v1 is **up-sync only**; down-sync is deferred with an explicit scope list ([#342](https://github.com/psmfd/agent-expertise-api/issues/342)).
+
+The non-negotiable control: the spoke's hub credential carries **`expertise.write.draft` and nothing else — never `.approve`**. ADR-003's scope semantics then force every synced entry to land as `Draft` in the spoke's own hub-side tenant, invisible to every other tenant until the hub curator independently approves it. No sync code enforces this; the existing authorization layer does. A compromised or malicious spoke can spam its own tenant's draft queue — it cannot place content in front of other teams.
+
+### Sub-decisions
+
+**Spoke side: `ExpertiseSyncWorker` (`BackgroundService`).** Modeled on `IdempotencyGcService`/`MigrationStateRefresher` (PeriodicTimer, `IServiceScopeFactory` scope per tick, two-tier narrowed exception handling, `internal static` interval override for tests). It pages newly Approved + `shared`-tenant local entries after a persisted cursor and POSTs them to the hub's existing `POST /expertise/batch` in ≤100-item chunks (the endpoint's `MaxBatchSize`). Data access goes through a new `IExpertiseRepository` method (cursor-paged `(UpdatedAt, Id)` keyset) — the DbContext-encapsulation architecture test forbids constructor-injecting `ExpertiseDbContext` outside `Data/`/`Cli/`, and the worker is not CLI.
+
+**Sync cursor: new `SyncStates` table.** Singleton-row pattern copied from `EmbeddingMetadata` (POCO + `DbSet` + get-or-create at the call site): `LastSyncedUpdatedAt`, `LastSyncedId`, `LastSuccessAt`. The cursor advances only after the hub acknowledges a batch (200/207 with per-item `Created`/`Duplicate` results); `Failed` items are retried next tick.
+
+**Auth: OIDC `client_credentials` on the shared IdP; hub-side tenancy is config-only.** The hub derives the spoke's tenant from the token via the existing `TenantSource.CompoundRole` (roles encoded `{tenant}:{scope}`) or `GroupToTenantMapping` machinery — whichever the shared IdP supports for service clients. The payload's tenant field is never trusted (ADR-003 "never from request body"). No new auth code on either side; provisioning a spoke = IdP client + role/group config + hub `Auth:Oidc` config.
+
+**Actor class: `Service`, for free.** `client_credentials` tokens where `sub == azp` already resolve to `ActorClass = Service` (ADR-008), so synced writes are distinguishable in the hub audit log with no sync-specific code.
+
+**Origin attribution: two nullable informational columns.** `OriginInstanceId` — set **server-side on the hub** from the authenticated client identity (azp/client_id → configured instance mapping), never from the payload (same principle as tenant). `OriginAuthorPrincipal` — accepted from the request body as informational reviewer context. Both are excluded from `IntegrityHashService.Compute`'s canonical fields (like `Source`/`SourceVersion`) and from dedup equality. Adding an optional request field is an additive OpenAPI change (breaking-change gate unaffected).
+
+**Retry safety: at-least-once via dedup, not header idempotency.** `POST /expertise/batch` is explicitly outside Idempotency-Key scope (ADR-010: "revisiting batch requires amending this ADR") — confirmed in code: the route chains no `.RequireIdempotency()`. Sync retries therefore rely on the tenant-scoped `DeduplicationService` (exact + semantic) to absorb replays: a re-POSTed entry returns `Duplicate`, which the worker treats as success. This is recorded here deliberately; if strict idempotency is later required, that is an ADR-010 amendment, not a sync-side workaround.
+
+**Resilience: named HttpClient + `Microsoft.Extensions.Http.Resilience`** (first HttpClient in the codebase), plus a minimal `client_credentials` token client caching tokens until expiry−60s. Sync failure must never affect API availability: the worker degrades to logging + Prometheus counters (`pushed`/`duplicate`/`failed`/cycle metrics) and retries on the next tick.
+
+### Explicitly out of scope for v1
+
+- **Down-sync (hub → spoke)** — deferred with its scope enumerated in [#342](https://github.com/psmfd/agent-expertise-api/issues/342): keyset cursor on `GET /expertise`, ADR-008 hygiene-envelope stripping in the client, monotonic `sourceUpdatedAt` anti-rollback, tombstone propagation + signed-Merkle-root reconciliation (reusing ADR-012's construction), and a draft re-gate on the receiving spoke.
+- **Cross-spoke dedup at the hub** — two spokes submitting the same tip land in two tenants and do not collapse; `DeduplicationService` is deliberately tenant-scoped (ADR-001, prevents cross-tenant leakage via 409 bodies). Curator-facing hints tracked in [#344](https://github.com/psmfd/agent-expertise-api/issues/344).
+- **mTLS PKI between instances, per-entry cryptographic signatures on sync, hub re-signing, hash-chained audit log, SLSA-level provenance** — rejected as disproportionate at this scale by all three design agents; revisit only if the hub becomes an untrusted third party.
+- **EFCore.BulkExtensions** for hub-side upsert volume — rejected (revenue-gated dual license since 2023); plain EF load-then-save, raw `ON CONFLICT` SQL if volume ever demands.
+
+## Consequences
+
+- **Good** — zero new write endpoints and zero new auth code; the supply-chain control is an existing, tested authorization behavior (ADR-003), not new sync logic.
+- **Good** — spokes work from behind NAT; the hub holds no spoke credentials.
+- **Good** — synced writes are audit-distinguishable (`ActorClass = Service`) and origin-attributed (`OriginInstanceId` server-set) with minimal schema change.
+- **Good** — at-least-once delivery with dedup absorption means the worker needs no distributed-transaction machinery.
+- **Bad** — requires a shared IdP between hub and spokes; two organizations without one cannot federate in v1 (accepted per user decision — revisit only with a concrete second-party need).
+- **Bad** — semantic dedup as the replay absorber is heuristic: a replay after the original was *edited* on the hub may create a near-duplicate draft for the curator to reject. Accepted; curator review is the backstop by design.
+- **Bad** — the hub's draft queue is spammable by a compromised spoke (rate-limited by the existing `expertise-write` policy, 10/min per principal; blast radius is the spoke's own tenant).
+- **Bad** — `Visibility` vs tenant-`shared` vocabulary remains subtle: "Approved + shared" for sync purposes means `Tenant == "shared" && ReviewState == Approved` on the spoke. The implementation and docs must be precise or the worker syncs the wrong slice.
+- **Revisit if** — a second write-heavy consumer of `/batch` appears (idempotency amendment pressure), down-sync is scheduled (#342), or hub trust assumptions change (per-entry signatures moot).
+
+## Implementation notes (non-normative)
+
+- Spoke config: `Sync` section (`Enabled`, `HubUrl`, `TokenEndpoint`, `ClientId`, secret via env, `Interval`, `BatchSize`), manual startup guard in the repo's convention (no `ValidateOnStart`): `Enabled` ⇒ all connection fields present, else fail at boot.
+- Hub config: `Sync:KnownInstances` map (client_id → instance id) feeding `OriginInstanceId`.
+- Config surfaces: `appsettings.json` (`_comment` convention), compose `.env.example`, Helm `values.yaml` + `values.schema.json` + secret via existing `secretRef` pattern, `install.sh` secrets-stub heredoc + `SECRETS_SCHEMA_VERSION` bump.
+- Tests: unit (cursor advance, chunking, token cache); integration (new repository method's tenant/review filtering; batch endpoint origin handling; worker end-to-end against an in-proc stub hub via `WebApplicationFactory`).

--- a/docs/operations/backup-restore-runbook.md
+++ b/docs/operations/backup-restore-runbook.md
@@ -1,0 +1,114 @@
+# Backup & Restore Runbook
+
+Operator procedures for (A) seeding an instance from an existing `pg_dump` backup taken by an **older** deployed version of this API, and (B) ongoing provenance-verified backups via the `backup`/`restore` CLI (ADR-012).
+
+Part A was validated by the 2026-07-05 schema-skew research (3-agent fan-out over the repo's migration history, EF Core migration semantics, and PostgreSQL restore mechanics). Key result: this repo's migration history contains no renames, squashes, or post-merge edits, so a dump from any earlier hosted version restores as a clean history *prefix* — exactly the case `migrate` is designed to close. The hazards are all outside `migrate`'s visibility, and this runbook exists to catch them.
+
+---
+
+## Part A — One-time seed from an existing pg_dump
+
+### A.0 Identify the dump format
+
+```bash
+head -c 5 dump.file        # "PGDMP" => custom/tar archive: use pg_restore
+                           # SQL text ("--" comments) => plain format: use psql
+pg_restore --list dump.file  # confirms/rejects archive format cleanly
+```
+
+### A.1 Restore into a truly EMPTY database — before ever running migrations
+
+Order matters: **restore first, migrate second.** Restoring into a database where EF migrations already ran produces object-already-exists collisions that `--clean --if-exists` only partially resolves.
+
+```bash
+# Fresh container/volume — do NOT run `dotnet ef database update` or `migrate` first
+docker compose -f deploy/local/docker-compose.yml up -d postgres pgbouncer
+
+# Truly empty target, cloned from template0 (template1 can carry local additions)
+createdb -h localhost -U postgres --template=template0 expertise
+
+# Archive formats — use PG17-native binaries regardless of the dump's source version:
+pg_restore --no-owner --no-privileges --dbname=expertise --verbose dump.file
+
+# Plain SQL format (no restore-time --no-owner equivalent exists):
+psql -v ON_ERROR_STOP=1 -d expertise -f dump.sql
+# Expect role errors if the dump carries ALTER OWNER/GRANT for roles that don't
+# exist locally — pre-create the roles or strip those statements.
+```
+
+The HNSW index DDL in the dump requires pgvector ≥ 0.5.0 on the target — an older extension fails **at restore time** (unsupported access method), not at migrate time.
+
+### A.2 Verify the restore BEFORE migrating
+
+```sql
+SELECT extname, extversion FROM pg_extension WHERE extname = 'vector';
+SELECT count(*) FROM "ExpertiseEntries";
+SELECT count(*) FROM "ExpertiseAuditLogs";
+SELECT "MigrationId" FROM "__EFMigrationsHistory" ORDER BY 1;  -- expect a prefix of the current migration list
+SELECT indexname FROM pg_indexes WHERE tablename = 'ExpertiseEntries';
+```
+
+Compare the row counts against what you know about the source instance — `migrate` reasons only about `__EFMigrationsHistory` and has zero visibility into a truncated or partial dump.
+
+### A.3 Apply pending migrations
+
+```bash
+dotnet run --project src/ExpertiseApi -- migrate
+```
+
+Capture the logged pending-migration list — it is the only structured record of how far behind the dump was. Exit 0 with an empty pending list on re-run confirms convergence.
+
+### A.4 Tenant remediation — the one silent trap
+
+If the dump predates the `AddTenantAuditFields` migration (2026-04-28), the migration backfills **every restored entry into tenant `legacy`**. Every read path filters `Tenant IN (caller_tenant, 'shared')`, so callers whose token maps to any other tenant see **zero rows** even though restore and migrate both succeeded.
+
+```sql
+SELECT "Tenant", count(*) FROM "ExpertiseEntries" GROUP BY "Tenant";
+-- If 'legacy' rows exist and the real owning tenant is known:
+UPDATE "ExpertiseEntries" SET "Tenant" = '<real-tenant>' WHERE "Tenant" = 'legacy';
+```
+
+This one-shot `UPDATE` bypasses the app and is **not audited** — an accepted, deliberate exception for data remediation. Record when you ran it (and against which backup) in your operations notes.
+
+### A.5 Integrity hashes — run unconditionally
+
+```bash
+dotnet run --project src/ExpertiseApi -- rehash
+```
+
+Idempotent; only touches rows where `IntegrityHash IS NULL`. Costs nothing on a current dump, closes the gap on an old one.
+
+### A.6 Embedding vintage — manual judgment (no automatic check exists)
+
+`reembed` does **not** compare the stored model vintage against the deployed model (tracked: [#345](https://github.com/psmfd/agent-expertise-api/issues/345)); decide yourself:
+
+```sql
+SELECT "ModelName", "Dimensions", "LastReembedAt" FROM "EmbeddingMetadata";
+```
+
+If that row is absent, or disagrees with the deployed model files (`./scripts/download-models.sh` fetches bge-micro-v2, 384-dim), regenerate:
+
+```bash
+dotnet run --project src/ExpertiseApi -- reembed
+```
+
+When in doubt, reembed — it is safe to re-run.
+
+### A.7 Smoke test
+
+Run the CLAUDE.md quick-start sequence: `GET /health` → authenticated `POST /expertise` (with `Idempotency-Key`) → keyword search → semantic search. Semantic search round-trips pgvector + the tsvector path together, which is the cheapest end-to-end check of everything above.
+
+### RPO note
+
+A clean `migrate` exit proves the **schema** converged — not that no data was lost. Anything written to the source between the backup timestamp and now is simply absent.
+
+---
+
+## Part B — Ongoing provenance-verified backups (ADR-012)
+
+> Ships with the `backup`/`restore` CLI feature ([#340](https://github.com/psmfd/agent-expertise-api/issues/340)). This section is finalized in that PR; the shape below is normative per [ADR-012](../../adrs/012-backup-artifact-format.md).
+
+- **One-time setup:** `scripts/expertise-apictl backup-init` — installs cosign/age if missing (apt/brew), generates the cosign keypair and age identity into `~/.config/expertise-api/backup/` (700/600), writes `backup.env`. Re-running validates and reports; it never overwrites keys silently.
+- **Take a backup:** `scripts/expertise-apictl backup` — preflight → NDJSON export → gzip → age-encrypt → manifest + `cosign sign-blob --key` → single `.tar` artifact, chmod 600.
+- **Restore:** `scripts/expertise-apictl restore <artifact>` — signature verify (fail-closed) → payload SHA check → decrypt → `restore` verb with pending-migrations and empty-target preconditions; per-record hash mismatches quarantine as Draft; foreign backups land entirely as Draft.
+- **Key discipline:** losing the age identity means losing the backups; losing the cosign key means future backups need a new trust root. Configure a second age recipient (offline/escrow copy) in `backup.env`. Backup artifacts contain Drafts, Rejected entries, and the audit log — treat the artifact itself as sensitive even though it is encrypted.


### PR DESCRIPTION
## Summary

Docs-first PR (1 of 3) for the backup/restore + aggregator work stream approved 2026-07-05. Lands the two governing ADRs and the operator runbook ahead of implementation, per adr-required.

- **ADR-012 — backup artifact format, signing, encryption**: application-level NDJSON over pg_dump; gzip (GZipStream, zero new deps); cosign **local-keypair** signing over a cleartext manifest (documented deviation from ADR-011's keyless mode — offline DR, no Rekor leak); age encryption of the payload under the signature; RFC 6962 Merkle roots from a new `BackupRecordHash` (the `IntegrityHashService.Compute` dedup contract is untouched); replace-only v1 restore, fail-closed trust policy, quarantine-as-Draft, foreign backups land all-Draft.
- **ADR-013 — aggregator up-sync v1**: hub-and-spoke, spoke = tenant on hub (ADR-001 unmodified); existing `POST /expertise/batch`; OIDC client_credentials on a shared IdP with config-only hub tenancy (ADR-005 reuse); **draft-only spoke scope as the knowledge-supply-chain control** (ADR-003 semantics, OWASP ASI04/ASI06); server-set `OriginInstanceId`; at-least-once retry via tenant-scoped dedup with the ADR-010 batch exclusion recorded explicitly.
- **Runbook** (`docs/operations/backup-restore-runbook.md`): Part A = validated seed-from-old-pg_dump procedure (restore-before-migrate ordering, pre-migrate verification, the `Tenant='legacy'` visibility trap + remediation, unconditional `rehash`, manual embedding-vintage check per #345); Part B = normative shape of the #340 tooling.
- README: A2 "Backup & restore" subsection + ADR-012/013 rows in the Security table.

## Issues

Tracking: #340 (Feature 1, PR 2 of 3), #341 (Feature 2, PR 3 of 3). Deferred scope filed: #342 (down-sync), #343 (merge-mode restore), #344 (cross-spoke dedup hints), #345 (reembed vintage detection).

## Doc-impact classification (documentation-in-plan)

| Surface | Classification | Disposition |
| --- | --- | --- |
| ADR-012 / ADR-013 | in-scope | this PR |
| `docs/operations/backup-restore-runbook.md` | in-scope | this PR (Part B finalized in #340's PR) |
| README A2 section + Security table | in-scope | this PR |
| CLAUDE.md (Build & Run, Data Model, Auth) | deferred to feature PRs | #340 / #341 |
| `.agents/skills/expertise-api/references/DESIGN.md` | deferred to feature PRs | #340 / #341 |
| `docs/security/integration-threat-model.md` | deferred to feature PRs | #340 / #341 |
| Helm values / compose env / install.sh stubs | deferred to feature PR | #341 |
| ADR-010 amendment (batch idempotency) | not-a-thing for v1 | dedup-based retry safety recorded in ADR-013 instead |

## Verification

Docs-only change (no test suite surface). `scripts/validate-pr.sh` PASS (title, branch, base). Links checked against filed issue numbers.
