### PR TITLE
fix: apictl resolves the secrets file from the install wrapper

### DIFF
--- a/scripts/expertise-apictl
+++ b/scripts/expertise-apictl
@@ -333,6 +333,28 @@ _resolve_bin_dir() {
   printf '%s' "${HOME}/.local/share/expertise-api/bin"
 }
 
+_resolve_secrets_file() {
+  # _resolve_secrets_file PREFIX — precedence: env override -> the SECRETS_FILE
+  # recorded in the install's launch wrapper (the single source of truth for
+  # the RUNNING service; installs with a custom --prefix/--config-dir put
+  # secrets.env outside the XDG default) -> XDG default.
+  local prefix="$1" wrapper recorded
+  if [[ -n "${EXPERTISE_API_SECRETS_FILE:-}" ]]; then
+    printf '%s' "${EXPERTISE_API_SECRETS_FILE}"
+    return 0
+  fi
+  wrapper="${prefix}/launch-expertise-api.sh"
+  if [[ -f "${wrapper}" ]]; then
+    recorded=$(grep -m1 '^SECRETS_FILE=' "${wrapper}" \
+               | sed 's/^SECRETS_FILE=//; s/^"//; s/"$//' 2>/dev/null || true)
+    if [[ -n "${recorded}" ]]; then
+      printf '%s' "${recorded}"
+      return 0
+    fi
+  fi
+  printf '%s' "${SECRETS_FILE_DEFAULT}"
+}
+
 _run_api_verb() {
   # _run_api_verb VERB [ARGS...] — source secrets + mirror the launch
   # wrapper's env (same rationale as scripts/migrate.sh: the DI graph must
@@ -341,7 +363,7 @@ _run_api_verb() {
   local bin_dir prefix secrets_file
   bin_dir="$(_resolve_bin_dir)"
   prefix="$(dirname "${bin_dir}")"
-  secrets_file="${EXPERTISE_API_SECRETS_FILE:-${SECRETS_FILE_DEFAULT}}"
+  secrets_file="$(_resolve_secrets_file "${prefix}")"
 
   if [[ -f "${secrets_file}" ]]; then
     set -a

--- a/tests/backup/test-apictl-backup.sh
+++ b/tests/backup/test-apictl-backup.sh
@@ -141,6 +141,33 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 4b. secrets-file resolution honors the install wrapper's recorded path
+#     (custom-prefix installs put secrets.env outside the XDG default). The
+#     resolved path surfaces in the "ConnectionStrings... not set" error, so
+#     asserting on the message pins the resolution order without needing a DB.
+# ---------------------------------------------------------------------------
+if command -v jq >/dev/null 2>&1; then
+  prefix="${SANDBOX}/install-prefix"
+  mkdir -p "${prefix}/bin" "${XDG_CONFIG_HOME}/expertise-api"
+  printf 'EXPERTISE_API_PREFIX=%s\n' "${prefix}" > "${XDG_CONFIG_HOME}/expertise-api/install.env"
+  cat > "${prefix}/launch-expertise-api.sh" <<EOF
+#!/usr/bin/env bash
+SECRETS_FILE="${prefix}/custom-secrets.env"
+EOF
+  printf 'ConnectionStrings__DefaultConnection=""\n' > "${prefix}/custom-secrets.env"
+  out="$(PATH="${STUB_DIR}:${PATH}" "${APICTL}" backup 2>&1)"
+  rc=$?
+  assert   "wrapper-secrets backup exits nonzero" test "${rc}" -ne 0
+  assert_contains "error names the wrapper-recorded secrets path" "${out}" "${prefix}/custom-secrets.env"
+
+  # Env override wins over the wrapper-recorded path.
+  out="$(PATH="${STUB_DIR}:${PATH}" EXPERTISE_API_SECRETS_FILE="${SANDBOX}/override.env" "${APICTL}" backup 2>&1)"
+  assert_contains "env override wins" "${out}" "${SANDBOX}/override.env"
+else
+  printf 'SKIP: secrets-resolution tests — jq not on host PATH\n'
+fi
+
+# ---------------------------------------------------------------------------
 # 5. restore without an artifact → usage error.
 # ---------------------------------------------------------------------------
 out="$(PATH="${STUB_DIR}:${PATH}" "${APICTL}" restore 2>&1)"


### PR DESCRIPTION
## Summary

`expertise-apictl backup` failed with "ConnectionStrings__DefaultConnection is not set" against a healthy custom-prefix A2 install: `_run_api_verb` hardcoded the XDG default secrets path, but such installs record the real location only in `launch-expertise-api.sh`. Found taking the first real canonical backup (#340 follow-through).

Fix: new `_resolve_secrets_file` — precedence `EXPERTISE_API_SECRETS_FILE` env → wrapper-recorded `SECRETS_FILE` (single source of truth for the running service) → XDG default. Two new shell-test cases pin the resolution order (21 assertions total).

## Verification

shellcheck clean; `tests/backup/test-apictl-backup.sh` 21/21; real-host repro confirmed fixed (canonical backup produced against the custom-prefix install).
