### PR TITLE
fix: wrapper exports runtime root for apphost launches

### DIFF
--- a/docs/operations/backup-restore-runbook.md
+++ b/docs/operations/backup-restore-runbook.md
@@ -16,6 +16,31 @@ head -c 5 dump.file        # "PGDMP" => custom/tar archive: use pg_restore
 pg_restore --list dump.file  # confirms/rejects archive format cleanly
 ```
 
+### A.0b Lessons from the first real seed (2026-07-05)
+
+Three preconditions the original procedure under-specified, all hit in practice:
+
+1. **Stop the API service first** (`expertise-apictl stop`) — `DROP DATABASE` fails
+   with "being accessed by other users" while the service holds pooled connections,
+   and a partial retry then restores into the still-migrated database (object
+   collisions, the exact hazard A.1 warns about).
+2. **Pre-create the vector extension as a superuser** when the app role is not one
+   (native installs; container images make the app user a bootstrap superuser, which
+   masks this): `psql -U <superuser> -d <db> -c 'CREATE EXTENSION vector;'` before
+   `pg_restore`, which then reports one ignorable "must be owner of extension" error.
+   Hosted-only extensions in the dump (e.g. `pg_stat_statements`) also fail
+   ignorably — expected.
+3. **If you change `Tenant` during remediation (A.4), re-run `rehash` after
+   NULLing the hashes** — `IntegrityHash` canonicalizes over `{tenant, title, body,
+   entryType, severity}`, so a tenant move invalidates every hash silently:
+   `UPDATE "ExpertiseEntries" SET "IntegrityHash"=NULL;` then `rehash`.
+
+After a successful seed, take an ADR-012 artifact immediately (`expertise-apictl
+backup`) — that becomes the canonical source going forward, and future seeds use
+`expertise-apictl restore` (schema-skew-proof) instead of this Part A procedure.
+Make sure the installed service binary is current first: a pre-ADR-012 binary
+silently ignores the `backup` verb and boots the web host instead.
+
 ### A.1 Restore into a truly EMPTY database — before ever running migrations
 
 Order matters: **restore first, migrate second.** Restoring into a database where EF migrations already ran produces object-already-exists collisions that `--clean --if-exists` only partially resolves.

--- a/scripts/expertise-apictl
+++ b/scripts/expertise-apictl
@@ -539,9 +539,13 @@ cmd_backup() {
   local out_dir="${output_override:-${BACKUP_OUTPUT_DIR}}"
   mkdir -p "${out_dir}"
 
-  local workdir ts artifact
-  workdir="$(mktemp -d)"
-  trap 'rm -rf "${workdir}"' EXIT
+  # workdir is deliberately NOT local: the EXIT trap fires after the function's
+  # locals are gone, and under `set -u` an out-of-scope expansion aborts the
+  # trap with "unbound variable" (leaving the plaintext tempdir behind).
+  local ts artifact
+  _apictl_workdir="$(mktemp -d)"
+  local workdir="${_apictl_workdir}"
+  trap 'rm -rf "${_apictl_workdir:-}"' EXIT
   ts="$(date -u +%Y%m%dT%H%M%SZ)"
   artifact="${out_dir}/expertise-backup-${instance_id}-${ts}.tar"
 
@@ -585,9 +589,10 @@ cmd_restore() {
 
   _backup_preflight
 
-  local workdir
-  workdir="$(mktemp -d)"
-  trap 'rm -rf "${workdir}"' EXIT
+  # See cmd_backup for why the trap variable must not be local.
+  _apictl_workdir="$(mktemp -d)"
+  local workdir="${_apictl_workdir}"
+  trap 'rm -rf "${_apictl_workdir:-}"' EXIT
 
   # Member allowlist before extraction (ADR-011 tar-hardening posture): the
   # outer tar must contain exactly the three expected members, no paths.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -836,15 +836,23 @@ export Metrics__Enabled="\${Metrics__Enabled:-false}"
 export Onnx__ModelPath="${MODEL_DIR}/model.onnx"
 export Onnx__VocabPath="${MODEL_DIR}/vocab.txt"
 
+# DOTNET_ROOT must be exported for BOTH exec branches: an fdd APPHOST
+# resolves the runtime exactly like the muxer path does, and on hosts where
+# dotnet lives outside the default /usr/local/share/dotnet location (e.g.
+# ~/.dotnet from dotnet-install.sh) the apphost fails with
+# "app-launch-failed / missing_runtime" without it. Previously only the
+# DLL branch exported it, so an fdd publish that emitted an apphost crash-
+# looped at service start on such hosts.
+if [[ -n "${dotnet_root}" ]]; then
+  export DOTNET_ROOT="\${DOTNET_ROOT:-${dotnet_root}}"
+fi
+
 if [[ -x "\${BIN_DIR}/ExpertiseApi" ]]; then
   exec "\${BIN_DIR}/ExpertiseApi"
 elif [[ -n "\${DOTNET_BIN}" && -x "\${DOTNET_BIN}" ]]; then
   # Absolute path baked at install time: the service manager's PATH
   # (launchd path_helper, systemd user units) does not include
   # non-standard dotnet roots, so bare \`dotnet\` is not resolvable here.
-  if [[ -n "${dotnet_root}" ]]; then
-    export DOTNET_ROOT="\${DOTNET_ROOT:-${dotnet_root}}"
-  fi
   exec "\${DOTNET_BIN}" "\${BIN_DIR}/ExpertiseApi.dll"
 else
   # Last resort: PATH lookup (pre-existing behavior).


### PR DESCRIPTION
## Summary

Three real-world fixes from executing the seed runbook and taking the first canonical ADR-012 backup on a live A2 install:

1. **`install.sh` wrapper: `DOTNET_ROOT` now exported for both exec branches.** An fdd publish that emits an apphost took the apphost branch without `DOTNET_ROOT`; on hosts where the runtime lives outside `/usr/local/share/dotnet` (`~/.dotnet` via dotnet-install.sh) the service crash-looped with `app-launch-failed / missing_runtime` (launchd exit 131). Reproduced and confirmed fixed on a real LaunchAgent install.
2. **apictl backup/restore: EXIT-trap tempdir cleanup fixed.** The trap referenced a `local` that is out of scope when the trap fires; under `set -u` it aborted with `workdir: unbound variable` and left the plaintext tempdir behind. Trap variable is now function-global with a `:-` guard.
3. **Runbook Part A addendum** with the preconditions the first real seed exposed: stop the service before `DROP DATABASE`; pre-create the `vector` extension as superuser on non-superuser app roles (container bootstrap users mask this); NULL + `rehash` after any tenant remediation (IntegrityHash canonicalizes over tenant); upgrade the installed binary before relying on new CLI verbs (a stale binary silently ignores `backup` and boots the web host).

## Verification

shellcheck clean (install.sh + apictl); `tests/backup/test-apictl-backup.sh` 21/21; end-to-end on the real install: service healthy on upgraded binary, `apictl backup` produced a signed artifact (`ssh-keygen -Y verify`: Good signature; 607 entries, dbSchemaVersion=AddSyncColumns) with clean tempdir teardown.
