### PR TITLE
test: deepen post /expertise/batch coverage

### DIFF
--- a/tests/ExpertiseApi.Tests/Integration/BatchEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/BatchEndpointTests.cs
@@ -1,0 +1,213 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using ExpertiseApi.Auth;
+using ExpertiseApi.Data;
+using ExpertiseApi.Models;
+using ExpertiseApi.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ExpertiseApi.Tests.Integration;
+
+/// <summary>
+/// Depth coverage for <c>POST /expertise/batch</c> (#351). The endpoint shipped a
+/// runtime-fatal EF translation bug (<c>FindExactMatchesAsync</c>'s
+/// <c>ToLowerInvariant()</c>) that no test caught because the only two batch tests
+/// were single-item, all-<c>Created</c>, 200-OK cases. These drive the multi-item
+/// 207 shape, per-item verdicts, shared-tenant scope escalation, authz, and size
+/// boundaries.
+/// <para>
+/// Robust against the content-independent mock embedding generator (tracked for a
+/// proper fix in #353): the <c>Duplicate</c> branch uses an EXACT-match duplicate
+/// (same domain+title+body — independent of embedding similarity, and the exact
+/// path that re-exercises <c>FindExactMatchesAsync</c>), and every <c>Created</c>
+/// item uses a per-test-unique domain so the mock's identical vectors cannot
+/// collapse it into a false semantic duplicate.
+/// </para>
+/// </summary>
+[Collection("Postgres")]
+public class BatchEndpointTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private JwtApiFactory _factory = null!;
+
+    public BatchEndpointTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public async Task InitializeAsync()
+    {
+        _factory = new JwtApiFactory(_postgres.ConnectionString);
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+        await db.ExpertiseAuditLogs.IgnoreQueryFilters().ExecuteDeleteAsync();
+        await db.ExpertiseEntries.IgnoreQueryFilters().ExecuteDeleteAsync();
+    }
+
+    public async Task DisposeAsync() => await _factory.DisposeAsync();
+
+    private HttpClient ClientWithScopes(params string[] scopes)
+    {
+        var token = JwtTokenMinter.Mint(tenant: "test", scopes: scopes, groups: ["group-test"]);
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
+    }
+
+    private async Task<ExpertiseEntry> SeedApproved(string domain, string title, string body)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+        var entry = TestHelpers.SeedEntry(
+            domain: domain, title: title, body: body, tenant: "test", reviewState: ReviewState.Approved);
+        db.ExpertiseEntries.Add(entry);
+        await db.SaveChangesAsync();
+        return entry;
+    }
+
+    private static object Item(string domain, string title, string body, string? tenant = null) => new
+    {
+        domain,
+        title,
+        body,
+        entryType = "Pattern",
+        severity = "Info",
+        source = "test",
+        tenant,
+    };
+
+    private static string UniqueDomain() => $"batch-{Guid.NewGuid():N}";
+
+    /// <summary>Mirror of the server's <c>BatchEntryResult</c> — Status arrives as the enum name.</summary>
+    private sealed record BatchResult(int Index, string Status, Guid? Id, string? Error);
+
+    // ---- Multi-item verdicts ---------------------------------------------
+
+    [Fact]
+    public async Task Batch_MixedItems_Returns207_WithCorrectPerItemVerdicts()
+    {
+        var existing = await SeedApproved("dup-domain", "existing title", "existing body");
+        var client = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);
+        var freshDomain = UniqueDomain();
+
+        var response = await client.PostAsJsonAsync("/expertise/batch", new[]
+        {
+            Item("dup-domain", "existing title", "existing body"), // exact duplicate -> Duplicate(existing.Id)
+            Item(freshDomain, "brand new", "brand new body"),      // unique domain  -> Created
+            Item(freshDomain, "", "blank title body"),             // invalid        -> Rejected
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.MultiStatus);
+        var results = (await response.Content.ReadFromJsonAsync<List<BatchResult>>())!;
+        results.Should().HaveCount(3);
+
+        results[0].Status.Should().Be("Duplicate");
+        results[0].Id.Should().Be(existing.Id, "an exact title+body match collapses onto the existing entry");
+        results[1].Status.Should().Be("Created");
+        results[1].Id.Should().NotBeNull();
+        results[2].Status.Should().Be("Rejected");
+        results[2].Id.Should().BeNull();
+        results[2].Error.Should().NotBeNullOrWhiteSpace();
+
+        // The Created item actually persisted as a Draft in the caller's tenant.
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+        var created = await db.ExpertiseEntries.IgnoreQueryFilters().SingleAsync(e => e.Id == results[1].Id);
+        created.Tenant.Should().Be("test");
+        created.ReviewState.Should().Be(ReviewState.Draft);
+    }
+
+    [Fact]
+    public async Task Batch_AllValidDistinctItems_Returns200()
+    {
+        var client = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);
+
+        var response = await client.PostAsJsonAsync("/expertise/batch", new[]
+        {
+            Item(UniqueDomain(), "one", "body one"),
+            Item(UniqueDomain(), "two", "body two"),
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, "200 only when every item is Created");
+        var results = (await response.Content.ReadFromJsonAsync<List<BatchResult>>())!;
+        results.Should().OnlyContain(r => r.Status == "Created");
+    }
+
+    // ---- Shared-tenant override scope escalation -------------------------
+
+    [Fact]
+    public async Task Batch_SharedOverride_ByWriteDraftCaller_ItemRejected()
+    {
+        var client = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);
+
+        var response = await client.PostAsJsonAsync("/expertise/batch", new[]
+        {
+            Item(UniqueDomain(), "shared attempt", "body", tenant: "shared"),
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.MultiStatus);
+        var results = (await response.Content.ReadFromJsonAsync<List<BatchResult>>())!;
+        results[0].Status.Should().Be("Rejected");
+        results[0].Error.Should().Contain("approve", "shared creation requires expertise.write.approve");
+    }
+
+    [Fact]
+    public async Task Batch_SharedOverride_ByWriteApproveCaller_ItemCreatedAsShared()
+    {
+        var client = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteApproveScope);
+        var domain = UniqueDomain();
+
+        var response = await client.PostAsJsonAsync("/expertise/batch", new[]
+        {
+            Item(domain, "shared entry", "shared body", tenant: "shared"),
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var results = (await response.Content.ReadFromJsonAsync<List<BatchResult>>())!;
+        results[0].Status.Should().Be("Created");
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+        var created = await db.ExpertiseEntries.IgnoreQueryFilters().SingleAsync(e => e.Id == results[0].Id);
+        created.Tenant.Should().Be("shared");
+        created.ReviewState.Should().Be(ReviewState.Approved, "shared entries bypass the tenant-scoped draft queue");
+    }
+
+    // ---- Authorization ----------------------------------------------------
+
+    [Fact]
+    public async Task Batch_WithNoAuth_Returns401()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/expertise/batch", new[] { Item(UniqueDomain(), "t", "b") });
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Batch_WithReadOnlyScope_Returns403()
+    {
+        var client = ClientWithScopes(AuthConstants.ReadScope);
+        var response = await client.PostAsJsonAsync("/expertise/batch", new[] { Item(UniqueDomain(), "t", "b") });
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden, "WriteAccess requires expertise.write.draft");
+    }
+
+    // ---- Size boundaries --------------------------------------------------
+
+    [Fact]
+    public async Task Batch_ExceedingMaxSize_Returns400()
+    {
+        var client = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);
+        var domain = UniqueDomain();
+        var items = Enumerable.Range(0, 101).Select(i => Item(domain, $"t{i}", $"b{i}")).ToArray();
+
+        var response = await client.PostAsJsonAsync("/expertise/batch", items);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest, "MaxBatchSize is 100");
+    }
+
+    [Fact]
+    public async Task Batch_EmptyArray_Returns400()
+    {
+        var client = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);
+        var response = await client.PostAsJsonAsync("/expertise/batch", Array.Empty<object>());
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #351 (tier 1 of the post-audit coverage work). `POST /expertise/batch` shipped a runtime-fatal EF translation bug (`FindExactMatchesAsync` `ToLowerInvariant()`) that survived compile + analyzers + CodeQL because only single-item, all-`Created`, 200-OK batch tests existed. This adds 8 HTTP-level tests covering the previously-unexercised branch surface:

- **Multi-item 207** with mixed `Created`/`Duplicate`/`Rejected` and **per-item `BatchEntryResult` body assertions** (Status/Id/Error) — prior tests checked only the HTTP status code, so a mis-reported per-item verdict with correct DB writes passed silently.
- **Shared-tenant override scope escalation** — rejected per-item for a `write.draft` caller, created-as-shared for a `write.approve` caller (a distinct code path from single-create with zero prior coverage).
- **401** (no auth) and **403** (read-only scope) — `/batch` was never in `AuthEndpointTests`.
- **`MaxBatchSize`+1 → 400** and **empty array → 400**.

## Robustness against the identical-vector mock (#353)

The `Duplicate` branch uses an **exact** title+body match (independent of embedding similarity, and the exact path that re-exercises the once-buggy `FindExactMatchesAsync`); every `Created` item uses a per-test-unique domain so the content-independent mock embedding can't force a false semantic duplicate. These tests will stay correct after #353 replaces the mock with content-derived vectors.

## Mutation-verified

Reintroducing the original `ToLowerInvariant()` predicate makes `Batch_MixedItems_Returns207_WithCorrectPerItemVerdicts` **fail** — direct proof this suite would have caught the shipped bug (it didn't exist at the time).

## Verification

Full suite 351/351 (8 new); `dotnet format analyzers --verify-no-changes` clean; `scripts/validate-pr.sh` PASS. Test-only change — no production diff.

Follow-up tiers: #352 (ToQueryString translation suite — a seed probe is staged locally), #353 (content-discriminating mock), #354 (CLI/background-service tests), #355 (CI coverage ratchet + enum guard), #356 (semantic-search + dead code).
