### PR TITLE
test: add db-less query-translation suite and tags-filter coverage

### DIFF
--- a/src/ExpertiseApi/Data/ExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/ExpertiseRepository.cs
@@ -16,8 +16,14 @@ internal class ExpertiseRepository(
     /// <summary>
     /// Builds the tenant predicate per ADR-001: a row is visible if its <c>Tenant</c>
     /// matches the caller's, or if it is in the cross-tenant <c>shared</c> namespace.
+    /// <para>
+    /// <c>internal</c> (not private) so the query-translation test suite
+    /// (<c>RepositoryQueryTranslationTests</c>, #352) can build on the exact same
+    /// tenant-scoping seam the production reads use, rather than re-deriving it and
+    /// risking drift.
+    /// </para>
     /// </summary>
-    private static IQueryable<ExpertiseEntry> ApplyTenantFilter(
+    internal static IQueryable<ExpertiseEntry> ApplyTenantFilter(
         IQueryable<ExpertiseEntry> query, TenantContext ctx)
     {
         var tenant = RequireTenant(ctx);
@@ -26,9 +32,10 @@ internal class ExpertiseRepository(
 
     /// <summary>
     /// Reads default to <see cref="ReviewState.Approved"/>. Drafts and Rejected entries
-    /// are exposed only via the dedicated <c>/drafts</c> endpoint.
+    /// are exposed only via the dedicated <c>/drafts</c> endpoint. <c>internal</c> for the
+    /// same test-seam reason as <see cref="ApplyTenantFilter"/> (#352).
     /// </summary>
-    private static IQueryable<ExpertiseEntry> ApplyApprovedReviewFilter(
+    internal static IQueryable<ExpertiseEntry> ApplyApprovedReviewFilter(
         IQueryable<ExpertiseEntry> query) =>
             query.Where(e => e.ReviewState == ReviewState.Approved);
 
@@ -105,6 +112,26 @@ internal class ExpertiseRepository(
         bool includeDeprecated,
         CancellationToken ct)
     {
+        return await BuildListQuery(ctx, domain, tags, entryType, severity, includeDeprecated).ToListAsync(ct);
+    }
+
+    /// <summary>
+    /// Composes the conditional <c>GET /expertise</c> filter query. Extracted from
+    /// <see cref="ListAsync"/> as an <c>internal</c> seam so the query-translation test
+    /// suite (#352) can assert every filter-combination's SQL translatability via
+    /// <c>ToQueryString()</c> against the exact production expression tree — the
+    /// <c>tags.All(t =&gt; e.Tags.Contains(t))</c> array-containment predicate is the
+    /// highest-risk shape (same class as the <c>ToLowerInvariant</c> incident) and must
+    /// be tested against the real builder, not a reconstruction that could drift.
+    /// </summary>
+    internal IQueryable<ExpertiseEntry> BuildListQuery(
+        TenantContext ctx,
+        string? domain,
+        List<string>? tags,
+        EntryType? entryType,
+        Severity? severity,
+        bool includeDeprecated)
+    {
         var query = ApplyApprovedReviewFilter(ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx));
 
         if (!includeDeprecated)
@@ -122,7 +149,7 @@ internal class ExpertiseRepository(
         if (tags is { Count: > 0 })
             query = query.Where(e => tags.All(t => e.Tags.Contains(t)));
 
-        return await query.OrderByDescending(e => e.UpdatedAt).ToListAsync(ct);
+        return query.OrderByDescending(e => e.UpdatedAt);
     }
 
     public async Task<List<ExpertiseEntry>> ListDraftsAsync(TenantContext ctx, CancellationToken ct)

--- a/tests/ExpertiseApi.Tests/Integration/ExpertiseEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/ExpertiseEndpointTests.cs
@@ -95,6 +95,25 @@ public class ExpertiseEndpointTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task List_WithTagsFilter_ReturnsOnlyEntriesWithAllRequestedTags()
+    {
+        // Closes the audit's #1 gap: the ?tags= filter (tags.All array-containment over a
+        // text[] column) had no HTTP test — the exact untested shape-class that let the
+        // batch-dedup bug ship. Complements the DB-less translation guard
+        // (RepositoryQueryTranslationTests) with an end-to-end correctness assertion.
+        await SeedWithTags("has both", "postgres", "ef-core");
+        await SeedWithTags("missing one", "postgres");
+        await SeedWithTags("different set", "ef-core", "kubernetes");
+
+        var response = await _client.GetAsync("/expertise?tags=postgres,ef-core");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetArrayLength().Should().Be(1, "tags.All requires EVERY requested tag be present on the entry");
+        json[0].GetProperty("title").GetProperty("value").GetString().Should().Contain("has both");
+    }
+
+    [Fact]
     public async Task List_ExcludesDeprecatedByDefault()
     {
         var entry = await SeedEntryViaRepo("shared", "Active entry");
@@ -175,5 +194,16 @@ public class ExpertiseEndpointTests : IAsyncLifetime
         return await repo.CreateAsync(
             TestHelpers.SeedEntry(domain: domain, title: title, entryType: entryType, tenant: tenant),
             TestHelpers.CreateTenantContext(tenant));
+    }
+
+    // Seeds an Approved entry with an explicit tag set (SeedEntry hardcodes ["test"]).
+    private async Task SeedWithTags(string title, params string[] tags)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+        var entry = TestHelpers.SeedEntry(domain: "tag-filter", title: title);
+        entry.Tags = [.. tags];
+        db.ExpertiseEntries.Add(entry);
+        await db.SaveChangesAsync();
     }
 }

--- a/tests/ExpertiseApi.Tests/Unit/RepositoryQueryTranslationTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/RepositoryQueryTranslationTests.cs
@@ -1,0 +1,243 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Claims;
+using ExpertiseApi.Auth;
+using ExpertiseApi.Data;
+using ExpertiseApi.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Pgvector;
+using Pgvector.EntityFrameworkCore;
+
+namespace ExpertiseApi.Tests.Unit;
+
+/// <summary>
+/// DB-less EF Core query-translation guard (#352). <c>ToQueryString()</c> runs the full
+/// EF+Npgsql translation pipeline WITHOUT a database or open connection — the exact probe
+/// that would have caught the <c>FindExactMatchesAsync</c> <c>ToLowerInvariant()</c> bug
+/// (compiled clean, analyzer-clean, threw only at runtime against a real provider).
+/// <para>
+/// Every distinctive predicate shape in <see cref="ExpertiseRepository"/> gets a
+/// NotThrow assertion. Simple equality/comparison filters (tenant, id) always translate
+/// and are covered incidentally through the shared seams; the shapes with real
+/// translation risk are called out per test: array containment (<c>tags.All</c>),
+/// <c>LOWER()</c> (<c>ToLower</c>), pgvector <c>CosineDistance</c> ordering, the two Guid
+/// keyset-cursor forms (<c>&gt;</c> vs <c>CompareTo</c>), and <c>HasConversion&lt;string&gt;</c>
+/// enum comparisons.
+/// </para>
+/// <para>
+/// SAME-PR EXPECTATION: any new conditional filter or <c>EF.Functions.*</c> call added to
+/// <see cref="ExpertiseRepository"/> ships with a translation assertion here. This suite
+/// is fast (no Docker) — there is no excuse to skip it.
+/// </para>
+/// </summary>
+public class RepositoryQueryTranslationTests
+{
+    // No database is contacted: ToQueryString generates SQL from the model + provider
+    // without opening a connection ("the database does not need to exist"). The
+    // connection string only needs to be parseable.
+    private static ExpertiseDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<ExpertiseDbContext>()
+            .UseNpgsql("Host=localhost;Database=translate-only;Username=x;Password=x", o => o.UseVector())
+            .Options;
+        return new ExpertiseDbContext(options, new NoOpTenantContextAccessor());
+    }
+
+    private static ExpertiseRepository NewRepository(ExpertiseDbContext db) =>
+        new(db, new HttpContextAccessor(), NullLogger<ExpertiseRepository>.Instance);
+
+    private static TenantContext Ctx() =>
+        new("team-alpha", new ClaimsPrincipal(), Agent: null, new HashSet<string>());
+
+    private static void AssertTranslates(IQueryable query, string because)
+    {
+        var act = () => query.ToQueryString();
+        act.Should().NotThrow(because);
+    }
+
+    // ---- ListAsync — combinatorial conditional filters (highest-risk method) ----
+
+    [Fact]
+    public void ListQuery_EveryFilterCombination_Translates()
+    {
+        using var db = NewContext();
+        var repo = NewRepository(db);
+        var tags = new List<string> { "postgres", "ef-core" };
+
+        // 5 conditional dimensions -> 32 combinations, exercised against the REAL
+        // BuildListQuery seam (extracted from ListAsync) so this can never drift from
+        // production. The tags.All(t => e.Tags.Contains(t)) array-containment predicate
+        // over a text[] column is the same shape-class as the ToLowerInvariant bug.
+        for (var mask = 0; mask < 32; mask++)
+        {
+            var query = repo.BuildListQuery(
+                Ctx(),
+                domain: (mask & 1) != 0 ? "dotnet" : null,
+                tags: (mask & 2) != 0 ? tags : null,
+                entryType: (mask & 4) != 0 ? EntryType.Pattern : null,
+                severity: (mask & 8) != 0 ? Severity.Warning : null,
+                includeDeprecated: (mask & 16) != 0);
+
+            AssertTranslates(query, $"ListAsync filter mask {mask} must translate to SQL");
+        }
+    }
+
+    // ---- LOWER() predicates (the shipped-bug shape) -----------------------
+
+    [Fact]
+    [SuppressMessage("Performance", "CA1862:Use the StringComparison overload of String.Equals",
+        Justification = "This is a LINQ-to-SQL expression tree, not a runtime comparison — e.Title.ToLower() must translate to SQL LOWER() and a StringComparison overload does not translate. Mirrors the production suppression on FindExactMatchAsync.")]
+    public void FindExactMatch_LowerEquality_Translates()
+    {
+        using var db = NewContext();
+        var lowerTitle = "some title";
+        var query = ExpertiseRepository.ApplyTenantFilter(db.ExpertiseEntries, Ctx())
+            .Where(e => e.DeprecatedAt == null)
+            .Where(e => e.ReviewState != ReviewState.Rejected)
+            .Where(e => e.Domain == "dotnet")
+            .Where(e => e.Title.ToLower() == lowerTitle);
+
+        AssertTranslates(query, "e.Title.ToLower() must map to SQL LOWER() (ToLowerInvariant does not translate)");
+    }
+
+    [Fact]
+    public void FindExactMatches_ContainsLower_Translates()
+    {
+        using var db = NewContext();
+        var lowerTitles = new List<string> { "a", "b" };
+        var query = ExpertiseRepository.ApplyTenantFilter(db.ExpertiseEntries, Ctx())
+            .Where(e => e.DeprecatedAt == null)
+            .Where(e => e.ReviewState != ReviewState.Rejected)
+            .Where(e => e.Domain == "dotnet")
+            .Where(e => lowerTitles.Contains(e.Title.ToLower()));
+
+        AssertTranslates(query, "lowerTitles.Contains(e.Title.ToLower()) is the exact shape that shipped broken as ToLowerInvariant");
+    }
+
+    // ---- pgvector CosineDistance ordering ---------------------------------
+
+    [Fact]
+    public void SemanticSearch_CosineDistanceOrdering_Translates()
+    {
+        using var db = NewContext();
+        var vector = new Vector(new float[384]);
+        var query = ExpertiseRepository.ApplyApprovedReviewFilter(
+                ExpertiseRepository.ApplyTenantFilter(db.ExpertiseEntries, Ctx()))
+            .Where(e => e.Embedding != null)
+            .Where(e => e.DeprecatedAt == null)
+            .OrderBy(e => e.Embedding!.CosineDistance(vector))
+            .Take(10);
+
+        AssertTranslates(query, "pgvector CosineDistance ORDER BY must translate");
+    }
+
+    [Fact]
+    public void FindNearestInDomain_CosineDistanceOrdering_Translates()
+    {
+        using var db = NewContext();
+        var vector = new Vector(new float[384]);
+        var query = ExpertiseRepository.ApplyTenantFilter(db.ExpertiseEntries, Ctx())
+            .Where(e => e.DeprecatedAt == null)
+            .Where(e => e.ReviewState != ReviewState.Rejected)
+            .Where(e => e.Domain == "dotnet")
+            .Where(e => e.Embedding != null)
+            .OrderBy(e => e.Embedding!.CosineDistance(vector));
+
+        AssertTranslates(query, "dedup nearest-neighbour CosineDistance ORDER BY must translate");
+    }
+
+    // ---- Guid keyset cursors (two distinct comparison forms) --------------
+
+    [Fact]
+    public void SharedApprovedKeyset_GuidGreaterThan_Translates()
+    {
+        using var db = NewContext();
+        var afterId = Guid.NewGuid();
+        var afterUpdatedAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var query = db.ExpertiseEntries
+            .Where(e => e.Tenant == "shared")
+            .Where(e => e.ReviewState == ReviewState.Approved)
+            .Where(e => e.DeprecatedAt == null)
+            .Where(e => e.UpdatedAt > afterUpdatedAt
+                        || (e.UpdatedAt == afterUpdatedAt && e.Id > afterId))
+            .OrderBy(e => e.UpdatedAt).ThenBy(e => e.Id)
+            .Take(100);
+
+        AssertTranslates(query, "up-sync keyset uses the Guid > operator (uuid comparison)");
+    }
+
+    [Fact]
+    public void AuditQuery_AllFiltersAndCompareToCursor_Translate()
+    {
+        using var db = NewContext();
+        var cursorTs = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var cursorId = Guid.NewGuid();
+        var query = db.ExpertiseAuditLogs.AsQueryable()
+            .Where(a => a.EntryId == Guid.NewGuid())
+            .Where(a => a.Principal == "p")
+            .Where(a => a.Action == AuditAction.Created)
+            .Where(a => a.ActorClass == ActorClass.Service)
+            .Where(a => a.Timestamp >= cursorTs)
+            .Where(a => a.Timestamp <= cursorTs)
+            .Where(a => a.Timestamp < cursorTs
+                        || (a.Timestamp == cursorTs && a.Id.CompareTo(cursorId) < 0))
+            .OrderByDescending(a => a.Timestamp).ThenByDescending(a => a.Id)
+            .Take(50);
+
+        AssertTranslates(query, "audit keyset uses Guid.CompareTo — a distinct translation from the > operator");
+    }
+
+    // ---- Enum disjunction + draft queue -----------------------------------
+
+    [Fact]
+    public void ListDrafts_ReviewStateDisjunction_Translates()
+    {
+        using var db = NewContext();
+        var query = db.ExpertiseEntries
+            .Where(e => e.Tenant == "team-alpha")
+            .Where(e => e.ReviewState == ReviewState.Draft || e.ReviewState == ReviewState.Rejected)
+            .Where(e => e.DeprecatedAt == null)
+            .OrderByDescending(e => e.UpdatedAt);
+
+        AssertTranslates(query, "HasConversion<string> enum disjunction must translate");
+    }
+
+    // ---- Approved-read seam (GetById / SemanticSearch prefix) -------------
+
+    [Fact]
+    public void ApprovedTenantSeam_Translates()
+    {
+        using var db = NewContext();
+        var query = ExpertiseRepository.ApplyApprovedReviewFilter(
+                ExpertiseRepository.ApplyTenantFilter(db.ExpertiseEntries, Ctx()))
+            .Where(e => e.Id == Guid.NewGuid());
+
+        AssertTranslates(query, "the shared tenant+approved read seam must translate");
+    }
+
+    // ---- Raw FromSqlInterpolated (keyword search) -------------------------
+
+    [Fact]
+    public void KeywordSearch_FromSqlInterpolated_Parameterizes()
+    {
+        using var db = NewContext();
+        var q = "postgres pgvector";
+        var tenant = "team-alpha";
+        var approvedState = nameof(ReviewState.Approved);
+
+        // ToQueryString on FromSql renders the raw SQL with its parameters — this pins the
+        // interpolation/parameterization (it does not validate the tsquery against a live
+        // server; SearchEndpointTests covers execution correctness).
+        var query = db.ExpertiseEntries.FromSqlInterpolated($"""
+            SELECT *, xmin FROM "ExpertiseEntries"
+            WHERE "SearchVector" @@ plainto_tsquery('english', {q})
+              AND ("Tenant" = {tenant} OR "Tenant" = 'shared')
+              AND "ReviewState" = {approvedState}
+              AND "DeprecatedAt" IS NULL
+            ORDER BY ts_rank("SearchVector", plainto_tsquery('english', {q})) DESC
+            """);
+
+        AssertTranslates(query, "keyword-search raw SQL must parameterize without throwing");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #352 (tier 2 of the post-audit coverage work). Adds a **DB-less EF query-translation guard** — the cheapest, most direct defense against the class of bug behind the whole exercise (compiles clean, analyzer-clean, throws only at runtime against a real provider).

`RepositoryQueryTranslationTests` uses `IQueryable.ToQueryString()`, which runs the full EF+Npgsql translation pipeline **without a database or open connection**. 10 tests (444ms, no Docker) cover every distinctive predicate shape in `ExpertiseRepository`:

- `tags.All(t => e.Tags.Contains(t))` — text[] array containment (highest risk)
- `e.Title.ToLower()` → `LOWER()` (the shipped-bug shape)
- pgvector `CosineDistance` ORDER BY (semantic search + dedup nearest)
- both Guid keyset cursors — `Guid >` (up-sync) vs `Guid.CompareTo` (audit), which translate differently
- `HasConversion<string>` enum comparisons and disjunctions
- raw `FromSqlInterpolated` parameterization

### Zero-drift for the highest-risk method

`ListAsync`'s conditional filter-building is extracted into an **internal `BuildListQuery` seam** so the 32 filter-combination test runs against the *exact production expression tree*, not a reconstruction. `ApplyTenantFilter`/`ApplyApprovedReviewFilter` made `internal` to share the real tenant/review seams (the #352 intent). Behavior-preserving refactor — `ListAsync` semantics unchanged, all prior tests green.

### Also closes the audit's #1-ranked gap

`List_WithTagsFilter_ReturnsOnlyEntriesWithAllRequestedTags` — the `?tags=` filter (`tags.All` over a `text[]` column) had **zero HTTP-level test**, the exact untested shape-class that let the batch-dedup bug ship. The translation suite is the DB-less guard; this is the end-to-end correctness backstop.

## Mutation-verified

Injecting an untranslatable predicate into `BuildListQuery` (`e.Tags.Select(x => x.ToLowerInvariant())`) makes `ListQuery_EveryFilterCombination` fail with the exact `could not be translated` error — proof the real-seam test catches the bug class DB-lessly.

## Verification

Full suite 362/362 (11 new); `dotnet format analyzers --verify-no-changes` clean; `scripts/validate-pr.sh` PASS. Documented same-PR expectation: any new conditional filter or `EF.Functions.*` call ships with a translation assertion.

Next tiers: #353 (content-discriminating mock — unblocks stronger dedup/semantic assertions), #354 (CLI/background-service tests), #355 (CI coverage ratchet + enum guard), #356 (semantic-search + dead code).
