### PR TITLE
test: make mock embeddings content-discriminating

### DIFF
--- a/tests/ExpertiseApi.Tests/Infrastructure/ApiFactory.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/ApiFactory.cs
@@ -68,16 +68,12 @@ public class ApiFactory : WebApplicationFactory<Program>
                     Arg.Any<CancellationToken>())
                 .Returns(callInfo =>
                 {
+                    // Content-derived embeddings (#353): index i maps to input i, identical
+                    // content yields identical vectors, distinct content stays near-orthogonal.
                     var inputs = callInfo.ArgAt<IEnumerable<string>>(0).ToList();
                     var result = new GeneratedEmbeddings<Embedding<float>>();
-                    foreach (var _ in inputs)
-                    {
-                        var vector = new float[384];
-                        new Random(42).NextBytes(new byte[4]); // deterministic seed
-                        for (var i = 0; i < 384; i++)
-                            vector[i] = (float)(new Random(42 + i).NextDouble() * 2 - 1);
-                        result.Add(new Embedding<float>(vector));
-                    }
+                    foreach (var input in inputs)
+                        result.Add(new Embedding<float>(TestHelpers.CreateContentEmbedding(input)));
                     return Task.FromResult<GeneratedEmbeddings<Embedding<float>>>(result);
                 });
 

--- a/tests/ExpertiseApi.Tests/Infrastructure/JwtApiFactory.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/JwtApiFactory.cs
@@ -112,15 +112,12 @@ public class JwtApiFactory : WebApplicationFactory<Program>
                     Arg.Any<CancellationToken>())
                 .Returns(callInfo =>
                 {
+                    // Content-derived embeddings (#353): index i maps to input i, identical
+                    // content yields identical vectors, distinct content stays near-orthogonal.
                     var inputs = callInfo.ArgAt<IEnumerable<string>>(0).ToList();
                     var result = new GeneratedEmbeddings<Embedding<float>>();
-                    foreach (var _ in inputs)
-                    {
-                        var vector = new float[384];
-                        for (var i = 0; i < 384; i++)
-                            vector[i] = (float)(new Random(42 + i).NextDouble() * 2 - 1);
-                        result.Add(new Embedding<float>(vector));
-                    }
+                    foreach (var input in inputs)
+                        result.Add(new Embedding<float>(TestHelpers.CreateContentEmbedding(input)));
                     return Task.FromResult<GeneratedEmbeddings<Embedding<float>>>(result);
                 });
 

--- a/tests/ExpertiseApi.Tests/Infrastructure/TestHelpers.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/TestHelpers.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using ExpertiseApi.Auth;
 using ExpertiseApi.Models;
+using ExpertiseApi.Services;
 using Pgvector;
 
 namespace ExpertiseApi.Tests.Infrastructure;
@@ -88,7 +89,10 @@ internal static class TestHelpers
             Severity = severity,
             Source = source,
             Tags = ["test"],
-            Embedding = CreateTestVector(),
+            // Content-derived so a seeded entry and a POSTed entry with the same
+            // title+body produce the SAME embedding (semantic dedup can then collide
+            // them), while distinct content stays near-orthogonal (#353).
+            Embedding = CreateContentVector(EmbeddingService.BuildInputText(title, body)),
             Tenant = tenant,
             AuthorPrincipal = authorPrincipal,
             ReviewState = reviewState,
@@ -96,6 +100,7 @@ internal static class TestHelpers
         };
     }
 
+    /// <summary>Content-independent fixed vector (query vectors / unit-test stubs that don't care).</summary>
     internal static Vector CreateTestVector(int dimensions = 384)
     {
         var values = new float[dimensions];
@@ -103,5 +108,40 @@ internal static class TestHelpers
         for (var i = 0; i < dimensions; i++)
             values[i] = (float)(rng.NextDouble() * 2 - 1);
         return new Vector(values);
+    }
+
+    /// <summary>
+    /// Deterministic, CONTENT-DERIVED embedding for tests (#353). Identical content yields
+    /// the identical vector (cosine distance 0 → a real duplicate); different content yields
+    /// a near-orthogonal vector (cosine distance ≈ 1.0, far above the 0.10 dedup threshold →
+    /// NOT a duplicate). Replaces the old content-independent mock that returned the same
+    /// vector for every input — which made semantic-dedup behaviour structurally unobservable
+    /// and forced two integration tests into per-test workarounds.
+    /// </summary>
+    internal static float[] CreateContentEmbedding(string content, int dimensions = 384)
+    {
+        var rng = new Random(StableSeed(content));
+        var values = new float[dimensions];
+        for (var i = 0; i < dimensions; i++)
+            values[i] = (float)(rng.NextDouble() * 2 - 1);
+        return values;
+    }
+
+    internal static Vector CreateContentVector(string content, int dimensions = 384)
+        => new(CreateContentEmbedding(content, dimensions));
+
+    // FNV-1a over UTF-16 code units. Stable across processes, unlike string.GetHashCode
+    // (randomized per run in .NET Core) — the seed MUST be reproducible so the same content
+    // embeds identically in the mock generator and in seeded fixtures. Collisions are
+    // irrelevant for test data.
+    private static int StableSeed(string s)
+    {
+        unchecked
+        {
+            var hash = (int)2166136261;
+            foreach (var c in s)
+                hash = (hash ^ c) * 16777619;
+            return hash;
+        }
     }
 }

--- a/tests/ExpertiseApi.Tests/Integration/ResponseHygieneIntegrationTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/ResponseHygieneIntegrationTests.cs
@@ -25,29 +25,20 @@ namespace ExpertiseApi.Tests.Integration;
 public class ResponseHygieneIntegrationTests : IAsyncLifetime
 {
     private readonly PostgresFixture _postgres;
-    private WebApplicationFactory<Program> _factory = null!;
-    private JwtApiFactory _baseFactory = null!;
+    private JwtApiFactory _factory = null!;
 
     public ResponseHygieneIntegrationTests(PostgresFixture postgres) => _postgres = postgres;
 
     public Task InitializeAsync()
     {
-        _baseFactory = new JwtApiFactory(_postgres.ConnectionString);
-        // Disable deduplication: the mock embedding generator in the test factory
-        // returns the same vector for every input, so dedup would collapse our two
-        // seed entries onto a single id and break the shared-nonce assertion.
-        _factory = _baseFactory.WithWebHostBuilder(builder =>
-        {
-            builder.UseSetting("Deduplication:Enabled", "false");
-        });
+        // Dedup stays ENABLED: content-derived embeddings (#353) mean the Guid-unique
+        // fixtures below no longer false-collide, so the shared-nonce assertion holds
+        // without the old Deduplication:Enabled=false workaround.
+        _factory = new JwtApiFactory(_postgres.ConnectionString);
         return Task.CompletedTask;
     }
 
-    public async Task DisposeAsync()
-    {
-        await _factory.DisposeAsync();
-        await _baseFactory.DisposeAsync();
-    }
+    public async Task DisposeAsync() => await _factory.DisposeAsync();
 
     private HttpClient AuthorizedClient(params string[] scopes)
     {

--- a/tests/ExpertiseApi.Tests/Integration/SyncOriginAttributionTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/SyncOriginAttributionTests.cs
@@ -35,12 +35,14 @@ public class SyncOriginAttributionTests : IClassFixture<PostgresFixture>
             [$"Sync:KnownInstances:{SpokeClientId}"] = SpokeInstanceId,
         });
 
-    // Domain is per-test: the shared JwtApiFactory embedding mock returns an identical
-    // vector for every input, so two tests writing the same domain would semantic-dedup
-    // against each other (dedup is domain-scoped by design).
-    private static object BatchItem(string domain, string title, string? originAuthor = null) => new
+    // A single shared domain across both tests: content-derived embeddings (#353) mean the
+    // distinct Guid titles below produce near-orthogonal vectors, so the two tests no longer
+    // semantic-collide — the old per-test-unique-domain workaround is gone.
+    private const string Domain = "origin-attribution";
+
+    private static object BatchItem(string title, string? originAuthor = null) => new
     {
-        domain,
+        domain = Domain,
         title,
         body = $"body of {title}",
         entryType = "Pattern",
@@ -65,7 +67,7 @@ public class SyncOriginAttributionTests : IClassFixture<PostgresFixture>
 
         var title = $"synced entry {Guid.NewGuid():N}";
         var response = await client.PostAsJsonAsync("/expertise/batch",
-            new[] { BatchItem("origin-attribution-registered", title, originAuthor: "alice@spoke-alpha") });
+            new[] { BatchItem(title, originAuthor: "alice@spoke-alpha") });
 
         var responseBody = await response.Content.ReadAsStringAsync();
         response.StatusCode.Should().Be(HttpStatusCode.OK, "batch response was: {0}", responseBody);
@@ -96,7 +98,7 @@ public class SyncOriginAttributionTests : IClassFixture<PostgresFixture>
 
         var title = $"ordinary entry {Guid.NewGuid():N}";
         var response = await client.PostAsJsonAsync("/expertise/batch",
-            new[] { BatchItem("origin-attribution-unregistered", title, originAuthor: "mallory@fake-origin") });
+            new[] { BatchItem(title, originAuthor: "mallory@fake-origin") });
 
         var responseBody = await response.Content.ReadAsStringAsync();
         response.StatusCode.Should().Be(HttpStatusCode.OK, "batch response was: {0}", responseBody);

--- a/tests/ExpertiseApi.Tests/Unit/EmbeddingServiceTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/EmbeddingServiceTests.cs
@@ -1,0 +1,44 @@
+using ExpertiseApi.Services;
+using ExpertiseApi.Tests.Infrastructure;
+using Microsoft.Extensions.AI;
+using NSubstitute;
+
+namespace ExpertiseApi.Tests.Unit;
+
+public class EmbeddingServiceTests
+{
+    [Fact]
+    public async Task GenerateBatchAsync_MapsEachOutputToItsInputPosition()
+    {
+        // A content-derived generator (same shape as the test factory mocks, #353) so each
+        // input maps to a DISTINGUISHABLE vector — the precondition that makes an ordering
+        // bug observable at all. With the old content-independent mock (identical vector for
+        // every input) a reorder/off-by-one in GenerateBatchAsync would have been invisible.
+        var generator = Substitute.For<IEmbeddingGenerator<string, Embedding<float>>>();
+        generator.GenerateAsync(
+                Arg.Any<IEnumerable<string>>(),
+                Arg.Any<EmbeddingGenerationOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var inputs = ci.ArgAt<IEnumerable<string>>(0).ToList();
+                var res = new GeneratedEmbeddings<Embedding<float>>();
+                foreach (var input in inputs)
+                    res.Add(new Embedding<float>(TestHelpers.CreateContentEmbedding(input)));
+                return Task.FromResult(res);
+            });
+
+        var service = new EmbeddingService(generator);
+        var texts = new[] { "alpha input", "bravo input", "charlie input" };
+
+        var vectors = await service.GenerateBatchAsync(texts);
+
+        vectors.Should().HaveCount(3);
+        for (var i = 0; i < texts.Length; i++)
+        {
+            vectors[i].ToArray().Should().Equal(
+                TestHelpers.CreateContentEmbedding(texts[i]),
+                $"output {i} must correspond to input {i} — a reorder would attach the wrong embedding to an entry");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #353 — the **Critical** test-infra flaw the coverage audit's code-review lens surfaced. The mock `IEmbeddingGenerator` in both `ApiFactory` and `JwtApiFactory` seeded its vector purely from the dimension index (`new Random(42 + i)`), **never from the input string** — so every title/body produced a byte-identical embedding. Semantic distance was always `0.0` for any two same-domain entries, which made semantic-dedup behaviour structurally unobservable and forced two integration test files into per-test workarounds.

## Fix

`TestHelpers.CreateContentEmbedding` now seeds from a **stable, process-independent FNV hash** of the content (not `string.GetHashCode`, which is randomized per run):

- identical content → identical vector (cosine distance 0 → a real duplicate)
- distinct content → near-orthogonal vector (distance ≈ 1.0, far above the 0.10 threshold → not a duplicate)

Both factory mocks and `TestHelpers.SeedEntry` use it, so a seeded entry and a POSTed entry with the same content now embed identically.

## Workarounds removed (the proof the fix works end-to-end)

- `ResponseHygieneIntegrationTests` no longer sets `Deduplication:Enabled=false`.
- `SyncOriginAttributionTests`' two tests now share **one** domain — the distinct Guid titles no longer false-collide, replacing the per-test-unique-domain hack.

## Added

`EmbeddingServiceTests.GenerateBatchAsync_MapsEachOutputToItsInputPosition` — an index/reorder guard that was literally unobservable while all vectors were identical.

## Mutation-verified

Reverting `CreateContentEmbedding` to content-independent makes a `SyncOrigin` test **fail** with a false semantic collision on the now-shared domain — proof the workaround removals genuinely depend on content-discrimination.

## Honest scope note

Hash-based vectors are all-or-nothing (identical vs orthogonal). They eliminate **false collisions** (the Critical flaw) but do not model *graded* semantic similarity — testing the 0.10 threshold itself still needs real embeddings and is deliberately out of scope.

## Verification

Full suite 363/363 (1 new, 0 removed); `dotnet format analyzers --verify-no-changes` clean; `scripts/validate-pr.sh` PASS.

Remaining tiers: #354 (CLI/background-service tests), #355 (CI coverage ratchet + enum guard), #356 (semantic-search + dead code).
