### PR TITLE
test: cover reembed/rehash cli and gc/refresher background services

### DIFF
--- a/src/ExpertiseApi/Services/Health/MigrationState.cs
+++ b/src/ExpertiseApi/Services/Health/MigrationState.cs
@@ -173,7 +173,9 @@ internal sealed class MigrationStateRefresher : BackgroundService
         }
     }
 
-    private async Task RefreshOnceAsync(CancellationToken ct)
+    // internal (not private) so MigrationStateRefresherTests can drive one refresh
+    // deterministically without racing the PeriodicTimer loop (#354).
+    internal async Task RefreshOnceAsync(CancellationToken ct)
     {
         try
         {

--- a/src/ExpertiseApi/Services/Idempotency/IdempotencyGcService.cs
+++ b/src/ExpertiseApi/Services/Idempotency/IdempotencyGcService.cs
@@ -74,7 +74,9 @@ internal sealed class IdempotencyGcService : BackgroundService
         }
     }
 
-    private async Task SweepOnceAsync(CancellationToken ct)
+    // internal (not private) so IdempotencyGcServiceTests can drive a single sweep
+    // deterministically without racing the PeriodicTimer loop (#354).
+    internal async Task SweepOnceAsync(CancellationToken ct)
     {
         try
         {

--- a/tests/ExpertiseApi.Tests/Integration/CliMaintenanceCommandTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/CliMaintenanceCommandTests.cs
@@ -1,0 +1,165 @@
+using ExpertiseApi.Auth;
+using ExpertiseApi.Cli;
+using ExpertiseApi.Data;
+using ExpertiseApi.Models;
+using ExpertiseApi.Services;
+using ExpertiseApi.Tests.Infrastructure;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Pgvector;
+using Testcontainers.PostgreSql;
+
+namespace ExpertiseApi.Tests.Integration;
+
+/// <summary>
+/// Functional coverage for the <c>reembed</c> and <c>rehash</c> maintenance verbs (#354).
+/// Both run hand-rolled cursor-paged LINQ (<c>IgnoreQueryFilters().OrderBy(Id).Where(Id &gt;
+/// last)</c>) against real Postgres and back the restore/seed runbook, yet had ZERO
+/// functional tests — the exact "raw query against real Postgres, never executed by CI"
+/// risk class. Owns its container (MigrateCommandTests pattern).
+/// </summary>
+public class CliMaintenanceCommandTests : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("pgvector/pgvector:pg17")
+        .WithDatabase("cli_maint")
+        .WithUsername("test")
+        .WithPassword("test")
+        .Build();
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+        await using var db = NewContext();
+        await db.Database.MigrateAsync();
+    }
+
+    public async Task DisposeAsync() => await _container.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task Reembed_RegeneratesEveryEntry_AcrossTenantsAndBatchBoundary_AndStampsMetadata()
+    {
+        // 5 entries across two tenants seeded with a deliberately WRONG (all-zero) embedding
+        // so reembed must overwrite each. batch-size 2 over 5 rows exercises 3 pages of the
+        // keyset loop, including the final short page.
+        var seeded = new List<ExpertiseEntry>();
+        for (var i = 0; i < 5; i++)
+        {
+            await using var db = NewContext();
+            var entry = TestHelpers.SeedEntry(
+                domain: "reembed", title: $"entry {i}", body: $"body {i}",
+                tenant: i % 2 == 0 ? "team-a" : "team-b");
+            entry.Embedding = new Vector(new float[384]);
+            db.ExpertiseEntries.Add(entry);
+            await db.SaveChangesAsync();
+            seeded.Add(entry);
+        }
+
+        await using var app = BuildApp();
+        await ReembedCommand.RunAsync(app, ["reembed", "--batch-size", "2"]);
+
+        await using var verify = NewContext();
+        foreach (var s in seeded)
+        {
+            var reloaded = await verify.ExpertiseEntries.IgnoreQueryFilters().AsNoTracking()
+                .SingleAsync(x => x.Id == s.Id);
+            var expected = TestHelpers.CreateContentEmbedding(EmbeddingService.BuildInputText(s.Title, s.Body));
+            reloaded.Embedding!.ToArray().Should().Equal(expected,
+                "reembed must regenerate every entry across all tenants and every page");
+        }
+
+        var metadata = await verify.EmbeddingMetadata.SingleAsync();
+        metadata.ModelName.Should().Be("bge-micro-v2");
+        metadata.Dimensions.Should().Be(384);
+        metadata.LastReembedAt.Should().NotBe(default);
+    }
+
+    [Fact]
+    public async Task Rehash_BackfillsNullHashes_AndIsIdempotent()
+    {
+        var ids = new List<Guid>();
+        for (var i = 0; i < 3; i++)
+        {
+            await using var db = NewContext();
+            var entry = TestHelpers.SeedEntry(domain: "rehash", title: $"h {i}", body: $"b {i}");
+            entry.IntegrityHash = null; // simulate pre-rehash rows
+            db.ExpertiseEntries.Add(entry);
+            await db.SaveChangesAsync();
+            ids.Add(entry.Id);
+        }
+
+        await using (var app = BuildApp())
+            await RehashCommand.RunAsync(app, ["rehash", "--batch-size", "2"]);
+
+        await using (var verify = NewContext())
+        {
+            foreach (var id in ids)
+            {
+                var entry = await verify.ExpertiseEntries.IgnoreQueryFilters().AsNoTracking()
+                    .SingleAsync(x => x.Id == id);
+                entry.IntegrityHash.Should().Be(IntegrityHashService.Compute(entry),
+                    "rehash backfills the canonical hash");
+            }
+            (await verify.ExpertiseEntries.IgnoreQueryFilters().CountAsync(e => e.IntegrityHash == null))
+                .Should().Be(0);
+        }
+
+        // Idempotent: a second run must not change any already-populated hash.
+        var before = await SnapshotHashes(ids);
+        await using (var app = BuildApp())
+            await RehashCommand.RunAsync(app, ["rehash"]);
+        var after = await SnapshotHashes(ids);
+        after.Should().Equal(before, "rehash only touches IntegrityHash == null rows");
+    }
+
+    // ---- Helpers ----------------------------------------------------------
+
+    private async Task<List<string>> SnapshotHashes(IEnumerable<Guid> ids)
+    {
+        await using var db = NewContext();
+        var idList = ids.ToList();
+        return await db.ExpertiseEntries.IgnoreQueryFilters().AsNoTracking()
+            .Where(e => idList.Contains(e.Id))
+            .OrderBy(e => e.Id)
+            .Select(e => e.IntegrityHash!)
+            .ToListAsync();
+    }
+
+    private ExpertiseDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<ExpertiseDbContext>()
+            .UseNpgsql(_container.GetConnectionString(), o => o.UseVector())
+            .Options;
+        return new ExpertiseDbContext(options, new NoOpTenantContextAccessor());
+    }
+
+    private WebApplication BuildApp()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        builder.Services.AddSingleton<ITenantContextAccessor, NoOpTenantContextAccessor>();
+        builder.Services.AddDbContext<ExpertiseDbContext>(o =>
+            o.UseNpgsql(_container.GetConnectionString(), x => x.UseVector()));
+
+        var generator = Substitute.For<IEmbeddingGenerator<string, Embedding<float>>>();
+        generator.GenerateAsync(
+                Arg.Any<IEnumerable<string>>(),
+                Arg.Any<EmbeddingGenerationOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var inputs = ci.ArgAt<IEnumerable<string>>(0).ToList();
+                var res = new GeneratedEmbeddings<Embedding<float>>();
+                foreach (var input in inputs)
+                    res.Add(new Embedding<float>(TestHelpers.CreateContentEmbedding(input)));
+                return Task.FromResult(res);
+            });
+        builder.Services.AddSingleton(generator);
+        builder.Services.AddScoped<EmbeddingService>();
+
+        return builder.Build();
+    }
+}

--- a/tests/ExpertiseApi.Tests/Integration/IdempotencyGcServiceTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/IdempotencyGcServiceTests.cs
@@ -1,0 +1,83 @@
+using ExpertiseApi.Auth;
+using ExpertiseApi.Data;
+using ExpertiseApi.Services.Idempotency;
+using ExpertiseApi.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Npgsql;
+using NSubstitute;
+using Testcontainers.PostgreSql;
+
+namespace ExpertiseApi.Tests.Integration;
+
+/// <summary>
+/// Functional coverage for the idempotency GC sweep (#354). The periodic sweep DELETE
+/// runs against real Postgres but the loop had zero tests — only the store's reserve/replay
+/// path was covered indirectly. Drives <see cref="IdempotencyGcService.SweepOnceAsync"/>
+/// directly (internal seam) so the cutoff computation and the raw DELETE are both exercised
+/// deterministically, without racing the PeriodicTimer.
+/// </summary>
+public class IdempotencyGcServiceTests : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("pgvector/pgvector:pg17")
+        .WithDatabase("idem_gc")
+        .WithUsername("test")
+        .WithPassword("test")
+        .Build();
+
+    private NpgsqlDataSource _dataSource = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+        var options = new DbContextOptionsBuilder<ExpertiseDbContext>()
+            .UseNpgsql(_container.GetConnectionString(), o => o.UseVector())
+            .Options;
+        await using var db = new ExpertiseDbContext(options, new NoOpTenantContextAccessor());
+        await db.Database.MigrateAsync();
+
+        _dataSource = new NpgsqlDataSourceBuilder(_container.GetConnectionString()).Build();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _dataSource.DisposeAsync();
+        await _container.DisposeAsync().AsTask();
+    }
+
+    [Fact]
+    public async Task SweepOnce_DeletesRowsOlderThanTtl_AndKeepsFreshRows()
+    {
+        var store = new NpgsqlIdempotencyStore(_dataSource);
+
+        // Two reserved rows (created_at defaults to now()).
+        await store.TryReserveAsync("tenant-a", "expired-key", "hash1", TimeSpan.FromHours(24), CancellationToken.None);
+        await store.TryReserveAsync("tenant-a", "fresh-key", "hash2", TimeSpan.FromHours(24), CancellationToken.None);
+
+        // Age the first row past a 24h TTL by rewriting its created_at directly.
+        await using (var cmd = _dataSource.CreateCommand(
+            "UPDATE idempotency_records SET created_at = now() - interval '48 hours' WHERE key = 'expired-key';"))
+        {
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        var options = Substitute.For<IOptionsMonitor<IdempotencyOptions>>();
+        options.CurrentValue.Returns(new IdempotencyOptions { Ttl = TimeSpan.FromHours(24) });
+        var service = new IdempotencyGcService(store, options, NullLogger<IdempotencyGcService>.Instance);
+
+        await service.SweepOnceAsync(CancellationToken.None);
+
+        (await RowExists("expired-key")).Should().BeFalse("a row older than the TTL is swept");
+        (await RowExists("fresh-key")).Should().BeTrue("a row within the TTL survives");
+    }
+
+    private async Task<bool> RowExists(string key)
+    {
+        await using var cmd = _dataSource.CreateCommand(
+            "SELECT count(*) FROM idempotency_records WHERE key = @key;");
+        cmd.Parameters.AddWithValue("key", key);
+        var count = (long)(await cmd.ExecuteScalarAsync())!;
+        return count > 0;
+    }
+}

--- a/tests/ExpertiseApi.Tests/Integration/MigrationStateRefresherTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/MigrationStateRefresherTests.cs
@@ -1,0 +1,82 @@
+using ExpertiseApi.Auth;
+using ExpertiseApi.Data;
+using ExpertiseApi.Services.Health;
+using ExpertiseApi.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Testcontainers.PostgreSql;
+
+namespace ExpertiseApi.Tests.Integration;
+
+/// <summary>
+/// Functional coverage for the migration-state refresher (#354). The refresher polls
+/// <c>GetPendingMigrationsAsync</c> and publishes the readiness snapshot that
+/// <c>PendingMigrationHealthCheck</c> reads, but had zero tests. Drives
+/// <see cref="MigrationStateRefresher.RefreshOnceAsync"/> directly (internal seam) against
+/// a migrated and an un-migrated container so both snapshot branches are exercised.
+/// Owns two containers because migration is one-way.
+/// </summary>
+public class MigrationStateRefresherTests : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _migrated = new PostgreSqlBuilder("pgvector/pgvector:pg17")
+        .WithDatabase("migstate_ok").WithUsername("test").WithPassword("test").Build();
+
+    private readonly PostgreSqlContainer _pending = new PostgreSqlBuilder("pgvector/pgvector:pg17")
+        .WithDatabase("migstate_pending").WithUsername("test").WithPassword("test").Build();
+
+    public async Task InitializeAsync()
+    {
+        await Task.WhenAll(_migrated.StartAsync(), _pending.StartAsync());
+        // Migrate only the first; the second stays schema-less so every migration is pending.
+        var options = new DbContextOptionsBuilder<ExpertiseDbContext>()
+            .UseNpgsql(_migrated.GetConnectionString(), o => o.UseVector()).Options;
+        await using var db = new ExpertiseDbContext(options, new NoOpTenantContextAccessor());
+        await db.Database.MigrateAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _migrated.DisposeAsync().AsTask();
+        await _pending.DisposeAsync().AsTask();
+    }
+
+    [Fact]
+    public async Task RefreshOnce_OnUpToDateSchema_PublishesNoPending()
+    {
+        await using var provider = BuildProvider(_migrated.GetConnectionString());
+        var state = new MigrationState();
+        var refresher = new MigrationStateRefresher(
+            provider.GetRequiredService<IServiceScopeFactory>(), state,
+            NullLogger<MigrationStateRefresher>.Instance);
+
+        await refresher.RefreshOnceAsync(CancellationToken.None);
+
+        state.HasPendingMigrations.Should().BeFalse("the container is migrated to HEAD");
+        state.Pending.Should().BeEmpty();
+        state.LastCheckedUtc.Should().NotBeNull("a successful poll stamps the check time");
+    }
+
+    [Fact]
+    public async Task RefreshOnce_OnSchemaLessDatabase_PublishesPending()
+    {
+        await using var provider = BuildProvider(_pending.GetConnectionString());
+        var state = new MigrationState();
+        var refresher = new MigrationStateRefresher(
+            provider.GetRequiredService<IServiceScopeFactory>(), state,
+            NullLogger<MigrationStateRefresher>.Instance);
+
+        await refresher.RefreshOnceAsync(CancellationToken.None);
+
+        state.HasPendingMigrations.Should().BeTrue("no migrations have been applied");
+        state.Pending.Should().NotBeEmpty("every migration in the assembly is pending");
+    }
+
+    private static ServiceProvider BuildProvider(string connectionString)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ITenantContextAccessor, NoOpTenantContextAccessor>();
+        services.AddDbContext<ExpertiseDbContext>(o => o.UseNpgsql(connectionString, x => x.UseVector()));
+        return services.BuildServiceProvider();
+    }
+}


### PR DESCRIPTION
## Summary

Closes #354. Adds functional coverage for four surfaces that ran real queries against Postgres but had **zero** functional tests (grep confirmed only an unrelated architecture-test name reference) — the same "raw/LINQ query against real Postgres, never executed by CI" risk class as the original bug.

- **reembed** (`CliMaintenanceCommandTests`) — regenerates every entry's embedding across two tenants and a batch-size boundary (5 rows / batch 2 = 3 pages, incl. the final short page), then upserts `EmbeddingMetadata`. Backs the restore/seed runbook.
- **rehash** — backfills null `IntegrityHash` rows to the canonical hash and is idempotent on re-run (second pass changes nothing).
- **IdempotencyGcService** (`IdempotencyGcServiceTests`) — `SweepOnceAsync` deletes rows older than the TTL and keeps fresh ones. `created_at` is aged 48h via raw SQL so both the service's cutoff computation and the store's raw `DELETE` are exercised deterministically.
- **MigrationStateRefresher** (`MigrationStateRefresherTests`) — `RefreshOnceAsync` publishes no-pending on a migrated container and pending on a schema-less one (both snapshot branches; owns two containers since migration is one-way).

## Testability seams

Two `private → internal` changes (`SweepOnceAsync`, `RefreshOnceAsync`) so each runs once, deterministically, without racing its `PeriodicTimer` loop — the same seam approach used for tier 2's `ApplyTenantFilter`. No behavior change.

## Verification

Full suite 368/368 (5 new); `dotnet format analyzers --verify-no-changes` clean; `scripts/validate-pr.sh` PASS.

Remaining: #355 (CI coverage ratchet + enum guard), #356 (semantic-search + dead code).
