### PR TITLE
test: semantic-search endpoint coverage and dead-code removal

### DIFF
--- a/src/ExpertiseApi/Data/ExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/ExpertiseRepository.cs
@@ -94,15 +94,6 @@ internal class ExpertiseRepository(
             .FirstOrDefaultAsync(ct);
     }
 
-    public async Task<ExpertiseEntry?> GetByIdIncludingDraftsAsync(Guid id, TenantContext ctx, CancellationToken ct)
-    {
-        // Approve/reject paths must be able to load Draft entries; the default
-        // ApplyApprovedReviewFilter would exclude them.
-        return await ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx)
-            .Where(e => e.Id == id)
-            .FirstOrDefaultAsync(ct);
-    }
-
     public async Task<List<ExpertiseEntry>> ListAsync(
         TenantContext ctx,
         string? domain,

--- a/src/ExpertiseApi/Data/IExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/IExpertiseRepository.cs
@@ -19,13 +19,6 @@ internal interface IExpertiseRepository
 {
     Task<ExpertiseEntry?> GetByIdAsync(Guid id, TenantContext ctx, CancellationToken ct = default);
 
-    /// <summary>
-    /// Reads an entry without filtering on <c>ReviewState</c>. Used by approve/reject paths
-    /// that must load <see cref="ReviewState.Draft"/> entries the default <see cref="GetByIdAsync"/>
-    /// would exclude. Tenant filter is still applied — cross-tenant returns null.
-    /// </summary>
-    Task<ExpertiseEntry?> GetByIdIncludingDraftsAsync(Guid id, TenantContext ctx, CancellationToken ct = default);
-
     Task<List<ExpertiseEntry>> ListAsync(
         TenantContext ctx,
         string? domain = null,

--- a/tests/ExpertiseApi.Tests/Integration/SemanticSearchEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/SemanticSearchEndpointTests.cs
@@ -1,0 +1,112 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ExpertiseApi.Auth;
+using ExpertiseApi.Data;
+using ExpertiseApi.Models;
+using ExpertiseApi.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ExpertiseApi.Tests.Integration;
+
+/// <summary>
+/// Coverage for <c>GET /expertise/search/semantic</c> (#356). Before this the endpoint's
+/// only test (in <c>TenantIsolationTests</c>) asserted tenant filtering alone — `limit`
+/// clamping, `includeDeprecated`, empty-`q` validation, and the <c>semantic-search</c>
+/// token-bucket rate limit were all unverified. A per-test <see cref="JwtApiFactory"/>
+/// isolates rate-limit state.
+/// </summary>
+[Collection("Postgres")]
+public class SemanticSearchEndpointTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private JwtApiFactory _factory = null!;
+
+    public SemanticSearchEndpointTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public async Task InitializeAsync()
+    {
+        _factory = new JwtApiFactory(_postgres.ConnectionString);
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+        await db.ExpertiseAuditLogs.IgnoreQueryFilters().ExecuteDeleteAsync();
+        await db.ExpertiseEntries.IgnoreQueryFilters().ExecuteDeleteAsync();
+    }
+
+    public async Task DisposeAsync() => await _factory.DisposeAsync();
+
+    private HttpClient ReadClient()
+    {
+        var token = JwtTokenMinter.Mint(tenant: "test", scopes: [AuthConstants.ReadScope], groups: ["group-test"]);
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
+    }
+
+    private async Task SeedApproved(int count, string domain, bool deprecated = false)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+        for (var i = 0; i < count; i++)
+        {
+            var entry = TestHelpers.SeedEntry(
+                domain: domain, title: $"{domain} entry {i} {Guid.NewGuid():N}", body: "semantic body",
+                tenant: "shared", reviewState: ReviewState.Approved);
+            if (deprecated)
+                entry.DeprecatedAt = DateTime.UtcNow;
+            db.ExpertiseEntries.Add(entry);
+        }
+        await db.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task Semantic_MissingQuery_Returns400()
+    {
+        var response = await ReadClient().GetAsync("/expertise/search/semantic?q=");
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Semantic_LimitAboveMax_IsClampedTo100()
+    {
+        await SeedApproved(105, "clamp-domain");
+
+        var response = await ReadClient().GetAsync("/expertise/search/semantic?q=anything&limit=1000");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var results = await response.Content.ReadFromJsonAsync<JsonElement>();
+        results.GetArrayLength().Should().Be(100, "limit is clamped to a maximum of 100 (105 entries exist)");
+    }
+
+    [Fact]
+    public async Task Semantic_ExcludesDeprecatedByDefault_IncludesWhenRequested()
+    {
+        await SeedApproved(1, "dep-domain");
+        await SeedApproved(1, "dep-domain", deprecated: true);
+        var client = ReadClient();
+
+        var byDefault = await client.GetAsync("/expertise/search/semantic?q=body&limit=10");
+        (await byDefault.Content.ReadFromJsonAsync<JsonElement>()).GetArrayLength()
+            .Should().Be(1, "deprecated entries are excluded by default");
+
+        var included = await client.GetAsync("/expertise/search/semantic?q=body&limit=10&includeDeprecated=true");
+        (await included.Content.ReadFromJsonAsync<JsonElement>()).GetArrayLength()
+            .Should().Be(2, "includeDeprecated=true lifts the DeprecatedAt filter");
+    }
+
+    [Fact]
+    public async Task Semantic_ExceedingTokenBucket_Returns429()
+    {
+        var client = ReadClient();
+
+        // Token bucket: limit 10, no queue — the 11th request in the window is rejected.
+        HttpResponseMessage? final = null;
+        for (var i = 0; i < 11; i++)
+            final = await client.GetAsync("/expertise/search/semantic?q=x");
+
+        final!.StatusCode.Should().Be(HttpStatusCode.TooManyRequests,
+            "the semantic-search token bucket admits 10 requests then 429s (each call runs ONNX inference)");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #356 (tier 6). Two items from the audit's lower tier.

**Semantic-search coverage** (`SemanticSearchEndpointTests`) — before this the endpoint's only test asserted tenant filtering. Now covered:
- missing `q` → 400
- `limit=1000` clamped to 100 (105 seeded entries → exactly 100 results)
- `includeDeprecated` lifts the `DeprecatedAt` filter (1 result default → 2 with the flag)
- the `semantic-search` token bucket 429s the 11th request (a per-test `JwtApiFactory` isolates rate-limit state)

**Dead-code removal** — `IExpertiseRepository.GetByIdIncludingDraftsAsync` had zero callers (confirmed by grep; approve/reject re-implement the same tenant+id lookup inline). **Deleted** rather than wired in, per the recommended option — a documented-but-unused API is drift.

## Verification

Full suite 372/372 (4 new, 0 broken by the removal); `dotnet format analyzers --verify-no-changes` clean; `scripts/validate-pr.sh` PASS.

Last tier remaining: #355 (CI coverage ratchet + frozen enum-name guard).
