### PR TITLE
ci: add coverage regression ratchet and frozen enum-name guard

### DIFF
--- a/.coverage-baseline
+++ b/.coverage-baseline
@@ -1,0 +1,5 @@
+# Coverage regression floors (#355). Measured 84.6% line / 70.9% branch; floors set
+# ~2-3pts below so normal variation never trips CI but a removed test file does.
+# Raise these when coverage improves; never lower without a recorded reason.
+line=82.0
+branch=68.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,16 @@ jobs:
             --configuration Release \
             --no-build \
             --verbosity normal \
+            --settings coverlet.runsettings \
+            --collect:"XPlat Code Coverage" \
             --logger "trx;LogFileName=test-results.trx" \
             --results-directory test-results
+
+      # Coverage regression ratchet (#355). Fails only if line/branch coverage drops
+      # below the committed floor in .coverage-baseline — catches a removed test file,
+      # not a green build with a silent gap.
+      - name: Coverage regression ratchet
+        run: bash scripts/check-coverage.sh "" test-results
 
       - name: Upload test results on failure
         if: failure()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,7 +340,7 @@ Scope shorthand (`read`, `draft`, `approve`, `admin`) expands to full scope stri
 
 | Workflow | Trigger | What it does |
 | -------- | ------- | ------------ |
-| `ci.yml` | PRs to main/dev, push to dev | Jobs: build & test (SCA vulnerable-package check, openapi.json artifact check, `dotnet format analyzers` gate), pi extension typecheck + tests, Helm lint + render tests, release-manifest generator, semver-comparator unit tests, install/uninstall script-guard unit tests, apictl restart-race (macOS + Debian 13), apictl stop→start lifecycle (macOS), install-smoke `--from-source` (Linux + macOS), install-smoke `--system` LaunchDaemon (macOS, `SMOKE_SYSTEM_SCOPE=1`, #145), OpenAPI breaking-change gate (PR-only, see below) |
+| `ci.yml` | PRs to main/dev, push to dev | Jobs: build & test (SCA vulnerable-package check, openapi.json artifact check, `dotnet format analyzers` gate, **coverage regression ratchet** via `scripts/check-coverage.sh` against `.coverage-baseline` — see below), pi extension typecheck + tests, Helm lint + render tests, release-manifest generator, semver-comparator unit tests, install/uninstall script-guard unit tests, apictl restart-race (macOS + Debian 13), apictl stop→start lifecycle (macOS), install-smoke `--from-source` (Linux + macOS), install-smoke `--system` LaunchDaemon (macOS, `SMOKE_SYSTEM_SCOPE=1`, #145), OpenAPI breaking-change gate (PR-only, see below) |
 | `install-smoke-from-release.yml` | Push to dev / PRs, path-filtered to the release-consumer chain | `install.sh --from-release` end-to-end against the latest cosign-signed release (Linux + macOS) — E3 of the readiness track; gates the D4 default-flip per ADR-011 |
 | `release.yml` | Push to main | semantic-release version bump + tag, Docker build linux/amd64+arm64 to GHCR, cosign-signed A2 tarball + manifest as release assets, Helm chart OCI push, deploy dispatch to the infra repo (only when a new version is released) |
 | `lint-pr-title.yml` | PR to dev | Validates PR title follows Conventional Commits format |
@@ -354,6 +354,10 @@ GHCR image: `ghcr.io/psmfd/agent-expertise-api` (multi-arch: amd64 + arm64).
 ### OpenAPI breaking-change gate
 
 The build emits the OpenAPI document to `src/ExpertiseApi/artifacts/openapi/ExpertiseApi.json` (build-time emission; `release.yml` attaches it as a release asset). On every PR, the `openapi-diff` job in `ci.yml` builds the spec from both the PR head and the base SHA and runs `oasdiff breaking` between them. Breaking API changes **fail the check** unless the PR carries the `breaking-change-approved` label (which `openapi-label-cleanup.yml` strips on merge). If an endpoint change is intentionally breaking, apply that label rather than reworking the diff.
+
+### Coverage regression ratchet
+
+The `Test` step collects coverage (`--collect:"XPlat Code Coverage"` with `coverlet.runsettings`, which excludes `Migrations/`), and `scripts/check-coverage.sh` fails the build if line or branch coverage drops below the floor in `.coverage-baseline` (currently `line=82.0`, `branch=68.0` against a measured ≈84.6% / ≈70.9%). It is a **regression ratchet, not a target**: the floors sit a few points below the measured value so normal variation never trips CI, but removing a test file does. Raise the floors when coverage improves; never lower them without a recorded reason. Mutation testing (Stryker.NET) was deliberately **not** adopted — it strengthens existing tests rather than covering unexecuted paths, and its per-mutant cost is disproportionate against the Testcontainers-backed suite (revisit only as a scheduled, file-scoped run).
 
 ### Pre-flight PR validator
 

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Coverage collection settings for the XPlat Code Coverage collector (#355).
+  Excludes generated / non-product code so the ratchet in
+  scripts/check-coverage.sh measures product code only:
+    * EF Core migrations (generated; asserting on them is meaningless)
+    * the source-generated JsonSerializerContext partials
+  The Cli namespace is intentionally NOT excluded: reembed/rehash/backup/restore
+  have real tests (#354, #340) and a coverage drop there is a real regression.
+-->
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <ExcludeByFile>**/Migrations/*.cs</ExcludeByFile>
+          <Exclude>[*]ExpertiseApi.Migrations.*</Exclude>
+          <ExcludeByAttribute>GeneratedCodeAttribute</ExcludeByAttribute>
+          <SkipAutoProps>true</SkipAutoProps>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -38,8 +38,11 @@ fi
 
 # The root <coverage line-rate="..." branch-rate="..."> attributes are the first
 # occurrences in the document; nested package/class elements repeat them.
+# grep -m1 stops after the first matching line and exits 0 — do NOT pipe grep to
+# `head`, which closes the pipe early and gives grep a SIGPIPE that fails the
+# pipeline under `set -o pipefail` (GNU grep on CI is stricter than BSD grep).
 extract() {
-  grep -o "$1=\"[0-9.]*\"" "$xml" | head -1 | sed "s/$1=\"//; s/\"//"
+  grep -o -m1 "$1=\"[0-9.]*\"" "$xml" | sed "s/$1=\"//; s/\"//"
 }
 line_raw="$(extract line-rate)"
 branch_raw="$(extract branch-rate)"

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# check-coverage.sh — coverage regression ratchet (#355).
+#
+# Reads the root line-rate / branch-rate from a Cobertura report and fails if
+# either has dropped below the committed floor in .coverage-baseline. This is a
+# REGRESSION ratchet, not an aspirational target: the floors sit a few points
+# below the measured value so normal variation never trips CI, but deleting a
+# test file (or a chunk of tests) does. Bump the floors UP when coverage
+# improves — never down without a recorded reason.
+#
+# Usage:
+#   scripts/check-coverage.sh [COBERTURA_XML] [SEARCH_DIR]
+#     COBERTURA_XML  explicit path to coverage.cobertura.xml
+#     SEARCH_DIR     directory to search when the path is omitted (default: test-results)
+#
+# Exit codes: 0 pass, 1 regression below floor, 2 precondition failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BASELINE_FILE="${REPO_ROOT}/.coverage-baseline"
+
+ok()   { printf 'OK    [%s] %s\n' "$1" "$2"; }
+info() { printf 'INFO  %s\n' "$*"; }
+err()  { printf 'ERROR [%s] %s\n' "$1" "$2" >&2; }
+fatal(){ err "$1" "$2"; exit 2; }
+
+xml="${1:-}"
+search_dir="${2:-test-results}"
+
+if [[ -z "$xml" ]]; then
+  xml="$(find "$search_dir" -name coverage.cobertura.xml 2>/dev/null | head -1 || true)"
+fi
+[[ -n "$xml" && -f "$xml" ]] || fatal "coverage-file" "no coverage.cobertura.xml found (looked in '${search_dir}')"
+[[ -f "$BASELINE_FILE" ]] || fatal "baseline" "missing ${BASELINE_FILE}"
+
+# The root <coverage line-rate="..." branch-rate="..."> attributes are the first
+# occurrences in the document; nested package/class elements repeat them.
+extract() {
+  grep -o "$1=\"[0-9.]*\"" "$xml" | head -1 | sed "s/$1=\"//; s/\"//"
+}
+line_raw="$(extract line-rate)"
+branch_raw="$(extract branch-rate)"
+[[ -n "$line_raw" && -n "$branch_raw" ]] || fatal "parse" "could not read line-rate/branch-rate from ${xml}"
+
+# Cobertura rates are 0..1; convert to a percentage with two decimals.
+line_pct="$(awk "BEGIN { printf \"%.2f\", ${line_raw} * 100 }")"
+branch_pct="$(awk "BEGIN { printf \"%.2f\", ${branch_raw} * 100 }")"
+
+line_floor="$(grep -E '^line=' "$BASELINE_FILE" | cut -d= -f2)"
+branch_floor="$(grep -E '^branch=' "$BASELINE_FILE" | cut -d= -f2)"
+[[ -n "$line_floor" && -n "$branch_floor" ]] || fatal "baseline" "baseline must define line= and branch="
+
+info "coverage: line ${line_pct}% (floor ${line_floor}%), branch ${branch_pct}% (floor ${branch_floor}%)"
+
+rc=0
+if awk "BEGIN { exit !(${line_pct} < ${line_floor}) }"; then
+  err "line-coverage" "line coverage ${line_pct}% is below the floor ${line_floor}% — a test was likely removed"
+  rc=1
+else
+  ok "line-coverage" "${line_pct}% >= ${line_floor}%"
+fi
+if awk "BEGIN { exit !(${branch_pct} < ${branch_floor}) }"; then
+  err "branch-coverage" "branch coverage ${branch_pct}% is below the floor ${branch_floor}%"
+  rc=1
+else
+  ok "branch-coverage" "${branch_pct}% >= ${branch_floor}%"
+fi
+
+printf '==================================\n'
+if [[ "$rc" -eq 0 ]]; then
+  printf 'PASS — coverage at or above floor\n'
+else
+  printf 'FAIL — coverage regressed below floor (raise a test, or justify lowering .coverage-baseline)\n'
+fi
+exit "$rc"

--- a/tests/ExpertiseApi.Tests/Unit/EnumContractTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/EnumContractTests.cs
@@ -1,0 +1,45 @@
+using ExpertiseApi.Models;
+
+namespace ExpertiseApi.Tests.Unit;
+
+/// <summary>
+/// Frozen enum-name guard (#355). <see cref="ReviewState"/>, <see cref="Visibility"/>,
+/// <see cref="EntryType"/>, <see cref="Severity"/>, <see cref="AuditAction"/> and
+/// <see cref="ActorClass"/> are ALL stored as strings (EF <c>HasConversion&lt;string&gt;()</c>)
+/// AND serialized as strings (<c>JsonStringEnumConverter</c>), so a member NAME is both the
+/// persisted DB value and the wire contract. Renaming or removing a member silently breaks
+/// stored-row parsing and the JSON contract — the `oasdiff` gate shows the schema change but
+/// a reviewer can approve it without registering the dual DB/wire drift.
+/// <para>
+/// These tests fail loudly on any name change so it becomes a DELIBERATE, migration-aware
+/// edit: update the frozen set here AND account for existing persisted rows. Adding a member
+/// is safe but still forces a conscious update of the list below.
+/// </para>
+/// </summary>
+public class EnumContractTests
+{
+    [Fact]
+    public void ReviewState_MemberNamesAreFrozen() =>
+        Enum.GetNames<ReviewState>().Should().BeEquivalentTo("Draft", "Approved", "Rejected");
+
+    [Fact]
+    public void Visibility_MemberNamesAreFrozen() =>
+        Enum.GetNames<Visibility>().Should().BeEquivalentTo("Private", "Shared");
+
+    [Fact]
+    public void EntryType_MemberNamesAreFrozen() =>
+        Enum.GetNames<EntryType>().Should().BeEquivalentTo("IssueFix", "Caveat", "Requirement", "Pattern");
+
+    [Fact]
+    public void Severity_MemberNamesAreFrozen() =>
+        Enum.GetNames<Severity>().Should().BeEquivalentTo("Info", "Warning", "Critical");
+
+    [Fact]
+    public void AuditAction_MemberNamesAreFrozen() =>
+        Enum.GetNames<AuditAction>().Should().BeEquivalentTo(
+            "Created", "Updated", "Approved", "Rejected", "Deleted", "RestoreQuarantined");
+
+    [Fact]
+    public void ActorClass_MemberNamesAreFrozen() =>
+        Enum.GetNames<ActorClass>().Should().BeEquivalentTo("Human", "Agent", "Service");
+}


### PR DESCRIPTION
## Summary

Closes #355 — the final tier of the post-audit coverage work.

### Coverage regression ratchet

The `Test` step now collects coverage (`--collect:"XPlat Code Coverage"` + `coverlet.runsettings`, which excludes `Migrations/`), and `scripts/check-coverage.sh` fails the build if **line or branch coverage drops below the floor** in `.coverage-baseline` (`line=82.0`, `branch=68.0` against a measured **≈84.6% line / ≈70.9% branch**).

It is a **regression ratchet, not a target** (the audit's recommendation over a fixed threshold): the floors sit a few points below the measured value so normal variation never trips CI, but removing a test file does. Raise the floors when coverage improves; never lower without a recorded reason. **Stryker.NET was deliberately not adopted** — it strengthens existing tests rather than covering unexecuted paths, and its per-mutant cost is disproportionate against the Testcontainers suite (rationale recorded in CLAUDE.md).

### Frozen enum-name guard

`EnumContractTests` freezes the member-name set of every enum that is **both** stored as a string (EF `HasConversion<string>()`) and serialized as a string (`JsonStringEnumConverter`): `ReviewState`, `Visibility`, `EntryType`, `Severity`, `AuditAction`, `ActorClass`. A rename silently breaks both the persisted DB value and the wire contract — `oasdiff` shows the schema change but a reviewer can wave it through. The frozen assertion forces any change to be a deliberate, migration-aware edit.

## Verification

Full suite 378/378; `scripts/check-coverage.sh` shellcheck-clean and validated locally (PASS at 84.54% / 70.95%); `dotnet format analyzers --verify-no-changes` clean; `scripts/validate-pr.sh` PASS. The two yamllint warnings on `ci.yml` are pre-existing lines outside this diff. CLAUDE.md CI/CD section updated (doc-sync).

**This completes all six coverage tiers** (#351–#356) from the audit.
