### PR TITLE
refactor(cli): clear two CodeQL alerts in backup/restore code

### DIFF
--- a/src/ExpertiseApi/Cli/RestoreCommand.cs
+++ b/src/ExpertiseApi/Cli/RestoreCommand.cs
@@ -282,12 +282,17 @@ internal static class RestoreCommand
 
             // Record the vintage of the imported vectors so the runbook's post-restore
             // check (and a future automated check, issue #345) has ground truth.
-            if (importEmbeddings && manifest.EmbeddingModel is not null && liveModel is null)
+            // importEmbeddings (set above) is true only when manifest.EmbeddingModel
+            // is non-null, so the null-forgiving access is safe; the extra
+            // `manifest.EmbeddingModel is not null` here was redundant (CodeQL
+            // cs/constant-condition — always true given importEmbeddings).
+            if (importEmbeddings && liveModel is null)
             {
+                var embeddingModel = manifest.EmbeddingModel!;
                 db.EmbeddingMetadata.Add(new EmbeddingMetadata
                 {
-                    ModelName = manifest.EmbeddingModel.Name,
-                    Dimensions = manifest.EmbeddingModel.Dims,
+                    ModelName = embeddingModel.Name,
+                    Dimensions = embeddingModel.Dims,
                     LastReembedAt = manifest.ExportedAt,
                 });
                 await db.SaveChangesAsync();

--- a/tests/ExpertiseApi.Tests/Integration/BackupRestoreCommandTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/BackupRestoreCommandTests.cs
@@ -299,7 +299,9 @@ public class BackupRestoreCommandTests : IAsyncLifetime
 
     private static string FreshDir()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "backup-tests", Guid.NewGuid().ToString("N"));
+        // Path.Join (not Path.Combine) — Join never drops earlier segments if a
+        // later one looks rooted (CodeQL cs/path-combine on the 3-arg Combine).
+        var dir = Path.Join(Path.GetTempPath(), "backup-tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dir);
         return dir;
     }


### PR DESCRIPTION
Clears the two CodeQL alerts flagged on the v1.3.0 promotion PR (#369), both in the backup/restore code from #347:

- **`RestoreCommand.cs:285`** (cs/constant-condition) — removed the redundant `manifest.EmbeddingModel is not null` sub-condition (always true given `importEmbeddings`, which is set from that same null/dims pattern at line 120). The guarded body uses a null-forgiving access, justified by `importEmbeddings`. **Behavior unchanged.**
- **`BackupRestoreCommandTests.cs:302`** (cs/path-combine) — `Path.Combine` → `Path.Join` in the temp-dir helper. `Path.Join` never drops earlier segments when a later one looks rooted; the flagged 3-arg `Combine` was a false-positive class (the `Guid('N')` segment is never rooted), and `Join` is the idiomatic clear.

## Verification
- `dotnet build` src + tests: **0 warnings** (the null-forgiving change is analyzer-clean under `AnalysisMode=All`).
- `dotnet format analyzers --verify-no-changes`: **clean**.
- Behavior-preserving; Build & Test (incl. the backup/restore integration suite) runs on this PR.

Feeds the v1.3.0 release (#369) once merged to `dev`.