### PR TITLE
ci(codeql): exclude cs/useless-cast-to-self (generated-code noise)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -25,3 +25,16 @@ paths-ignore:
   - '**/bin/**'
   - '**/generated/**'
   - '**/*.generated.cs'
+
+# Rule-level exclusions. `paths-ignore` above cannot reach source-generator
+# output for C# under CodeQL's manual build mode — the extractor processes
+# `obj/Release/.../generated/*.g.cs` during compilation, before the database-path
+# filter applies — so generated-code alerts still surface. cs/useless-cast-to-self
+# fires 64x purely on System.Text.Json source-generated `*.g.cs` (e.g.
+# SyncJsonContext, aggregator #348); it is a redundant-cast style rule with
+# negligible value on hand-written code. Excluding the rule clears this
+# generated-code noise durably, rather than via repeated per-alert REST-API
+# dismissals that recur with every new source-generated type.
+query-filters:
+  - exclude:
+      id: cs/useless-cast-to-self


### PR DESCRIPTION
Clears the 64 open `cs/useless-cast-to-self` code-scanning alerts, **all** of which are in System.Text.Json source-generated `SyncJsonContext.*.g.cs` (from the aggregator, #348).

## Why config, not dismissal
`paths-ignore` (already lists `**/obj/**`, `**/generated/**`) does not filter these: under CodeQL's **manual build mode** for C#, the extractor processes `obj/Release/.../generated/*.g.cs` during compilation, *before* the database-path filter applies. Per-alert REST dismissal (the prior pattern) would recur with every new source-generated type. A rule-level `query-filters` exclude is durable.

`cs/useless-cast-to-self` is a low-value redundant-cast style rule; hand-written cases are negligible and already covered by the `AnalysisMode=All` Roslyn analyzers in the build. The 64 existing alerts auto-close on the next scan that no longer emits them.

## Verification
YAML parses; `validate-pr.sh` PASS. CI-config only.