### PR TITLE
chore: gitignore claude agent-memory subagent scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ src/ExpertiseApi/Models/tokenizer*.json
 ## Claude Code worktrees
 .claude/worktrees/
 
+## Claude Code per-agent runtime memory (subagent scratch; not part of the repo)
+.claude/agent-memory/
+
 ## Part D C8: build-time OpenAPI document emission (Microsoft.Extensions.ApiDescription.Server)
 ## Output of _GenerateOpenApiDocuments MSBuild target; published as a GitHub Release asset via release.yml.
 src/ExpertiseApi/artifacts/


### PR DESCRIPTION
Per-agent runtime memory written by subagents (`.claude/agent-memory/`) is local scratch, not repo content. It was untracked and got swept into a staging area by a `git add -A` during unrelated work. This ignores just that path so it can't be accidentally committed.

Surgical by design: the intentionally-tracked `.claude/agents/` and `.claude/skills/` paths are untouched — only `.claude/agent-memory/` is added, next to the existing `.claude/worktrees/` ignore.

No behavior change; one line in `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)