### PR TITLE
ci: align codeql-action init version with analyze

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,7 +43,7 @@ jobs:
           restore-keys: nuget-${{ runner.os }}-
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: csharp
           build-mode: manual


### PR DESCRIPTION
## Problem

Dependabot #377 bumped `github/codeql-action/analyze` to **v4.36.3** but left `github/codeql-action/init` at **v4.36.2** in `.github/workflows/codeql.yml`. The `init` step writes a CodeQL config stamped `4.36.2`; the `4.36.3` `analyze` step rejects it:

```
##[error]Loaded a configuration file for version '4.36.2', but running version '4.36.3'
```

This fails the **Analyze C#** job on **every** PR against `dev` (a required check), independent of the PR's contents — currently blocking #383 and #384.

## Fix

Pin `init` to the same v4.36.3 commit (`54f647b7…`) already used by `analyze` here and by `upload-sarif` in `security.yml`. `init`/`analyze`/`upload-sarif` are subpaths of the same `github/codeql-action` repo, so one commit covers all three at a release.

Self-validating: this PR's own CodeQL run uses the fixed workflow from its branch, so a green **Analyze C#** here confirms the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)