### PR TITLE
ci: sync codeql-action subactions and fix dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,7 +46,7 @@ updates:
     groups:
       codeql-action:
         patterns:
-          - "github/codeql-action"
+          - "github/codeql-action*"
 
   - package-ecosystem: docker
     directory: /

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,6 +57,6 @@ jobs:
         run: dotnet build ExpertiseApi.slnx --configuration Release --no-restore --disable-build-servers
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           category: '/language:csharp'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Upload Trivy SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           sarif_file: trivy-results.sarif
           category: trivy-fs
@@ -68,7 +68,7 @@ jobs:
 
       - name: Upload Hadolint SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           sarif_file: hadolint-results.sarif
           category: hadolint


### PR DESCRIPTION
## Problem (recurring)

Dependabot bumps `github/codeql-action/init`, `/analyze`, and `/upload-sarif` in **separate** PRs that auto-merge independently, so the sub-actions drift out of lockstep. The `analyze` step then rejects the `init` step's config:

```
##[error]Loaded a configuration file for version 'X', but running version 'Y'
```

This fails the **Analyze C#** required check on **every** PR against `dev`. It has now recurred twice in a row:
- #377 bumped `analyze` → 4.36.3 (broke against `init` 4.36.2)
- #385 aligned `init` → 4.36.3 (fixed)
- #378 then bumped `init` → 4.37.0 (broke again against `analyze` 4.36.3)

## Root cause

The existing dependabot `codeql-action` group pattern is `"github/codeql-action"` — **no wildcard**, so it never matches the real dependency names (`github/codeql-action/init`, `/analyze`, `/upload-sarif`). The sub-actions were never actually grouped, so they bump one at a time.

## Fix (two layers)

1. **Immediate:** align `analyze` (codeql.yml) and `upload-sarif` ×2 (security.yml) to **v4.37.0**, matching `init`. All four refs now share commit `99df26d4…`.
2. **Systemic:** change the group pattern to `"github/codeql-action*"` so all sub-actions bump together in one PR from now on — stopping the recurrence.

Self-validating: this PR's own `Analyze C#` runs the aligned workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)