### PR TITLE
chore(deps): hold microsoft openapi at the 2x major and ignore 3x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,15 @@ updates:
       # AwesomeAssertions (Apache 2.0 community fork). Any future Dependabot PR
       # that tries to re-add FluentAssertions must be rejected.
       - dependency-name: "FluentAssertions"
+      # Microsoft.OpenApi is a direct security pin held at the 2.x major (see
+      # src/ExpertiseApi/ExpertiseApi.csproj). The 3.x major made
+      # IOpenApiMediaType.Example read-only, which the Microsoft.AspNetCore.OpenApi
+      # 10.0.x source generator still assigns to (CS0200 build failure). Ignore
+      # only the major bump so 2.x minor/patch security updates keep flowing.
+      # Drop this once Microsoft.AspNetCore.OpenApi's generator supports 3.x (#390).
+      - dependency-name: "Microsoft.OpenApi"
+        update-types:
+          - "version-update:semver-major"
     groups:
       ef-core:
         patterns:

--- a/src/ExpertiseApi/ExpertiseApi.csproj
+++ b/src/ExpertiseApi/ExpertiseApi.csproj
@@ -70,8 +70,17 @@
       latest patched 2.x — API-compatible within the 2.x major, so the parent
       package resolves against it. Drop this once Microsoft.AspNetCore.OpenApi
       references a patched Microsoft.OpenApi transitively.
+
+      Held at the 2.x major deliberately. Microsoft.OpenApi 3.x made
+      IOpenApiMediaType.Example read-only, but the Microsoft.AspNetCore.OpenApi
+      10.0.9 XML-comment source generator still assigns to it, so a 3.x bump
+      fails to compile (CS0200). Microsoft.AspNetCore.OpenApi 10.0.9 depends on
+      Microsoft.OpenApi (>= 2.0.0) and does not require 3.x, so there is no
+      forward path until its generator supports the 3.x example model. The 3.x
+      major is Dependabot-ignored (.github/dependabot.yml) until then; 2.x
+      minor/patch security bumps still flow. Tracked in #390.
     -->
-    <PackageReference Include="Microsoft.OpenApi" Version="2.9.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.10.0" />
     <!--
       Build-time OpenAPI document generator (Part D C8). PrivateAssets=all keeps the
       package out of the published output (it's an MSBuild task, not a runtime dependency).


### PR DESCRIPTION
## Summary

Resolves the recurring red Dependabot PR #380 (`Microsoft.OpenApi` 2.9.0 → 3.8.0) and, in the same pass, advances the direct security pin to the latest patched 2.x.

`Microsoft.OpenApi` is a **direct security pin** (see `src/ExpertiseApi/ExpertiseApi.csproj`), held forward within the 2.x major so the app resolves off the patched line rather than the vulnerable 2.0.0 that `Microsoft.AspNetCore.OpenApi` pulls transitively.

## Why 3.x cannot land (yet)

`Microsoft.OpenApi` **3.x** made `IOpenApiMediaType.Example` read-only, but the `Microsoft.AspNetCore.OpenApi` **10.0.9** XML-comment source generator still *assigns* to it, so a 3.x bump fails to compile:

```
OpenApiXmlCommentSupport.generated.cs(399,41):
  error CS0200: Property or indexer 'IOpenApiMediaType.Example' cannot be assigned to -- it is read only
```

`Microsoft.AspNetCore.OpenApi` 10.0.9 (our current version, the latest stable) depends on `Microsoft.OpenApi (>= 2.0.0)` and does **not** require 3.x — so there is no lockstep forward path today. Full diagnosis in #390.

## Changes

1. **`ExpertiseApi.csproj`** — pin `Microsoft.OpenApi` **2.9.0 → 2.10.0** (current patched 2.x head, 2026-07-06). Comment extended to record why the 2.x major is held.
2. **`.github/dependabot.yml`** — `ignore` `Microsoft.OpenApi` `version-update:semver-major` only. The recurring un-buildable 3.x PR stops; **2.x minor/patch security bumps still flow.**

## Verification

- `dotnet build -c Release` → **0 warnings, 0 errors**; OpenAPI document generates cleanly.
- CI runs Build & Test + the OpenAPI breaking-change gate.

## Follow-up

- Closes the #380 churn (that PR is closed in favour of this one).
- #390 stays open as the standing "revisit 3.x once `Microsoft.AspNetCore.OpenApi`'s generator supports the 3.x example model" tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
