### PR TITLE
test: cover adr-014 static-issuer compound-role auth end to end

### DIFF
--- a/tests/ExpertiseApi.Tests/Infrastructure/JwtTokenMinter.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/JwtTokenMinter.cs
@@ -15,10 +15,49 @@ public static class JwtTokenMinter
     public const string TestAudience = "test-audience";
     public const string TestSchemeName = "TestIssuer";
 
+    // ADR-014 static-LAN issuer: CompoundRole tenancy with scopes carried in a
+    // `roles` array claim (TenantSource=CompoundRole, ScopeClaims=["roles"],
+    // RoleSeparator=":"). Distinct issuer URL so the policy scheme routes by `iss`;
+    // shares SigningKey so JwtApiFactory can inject one OIDC config per scheme.
+    public const string CompoundRoleIssuer = "https://static-issuer.local/";
+    public const string CompoundRoleSchemeName = "StaticLan";
+
     public static readonly RsaSecurityKey SigningKey = new(RSA.Create(2048))
     {
         KeyId = "test-key-1"
     };
+
+    /// <summary>
+    /// Mints a static-LAN CompoundRole token exactly as <c>scripts/mint_token.py</c> emits:
+    /// each scope becomes a <c>roles</c> array entry of the form <c>{tenant}:{scope}</c>.
+    /// <paramref name="scopes"/> are fully-qualified scope strings (e.g.
+    /// <see cref="AuthConstants.WriteDraftScope"/>), matching the confirmed ADR-014 contract.
+    /// </summary>
+    public static string MintCompoundRole(
+        string tenant,
+        IEnumerable<string> scopes,
+        string? sub = null,
+        TimeSpan? expiresIn = null)
+    {
+        var handler = new JsonWebTokenHandler();
+
+        var claims = new Dictionary<string, object>
+        {
+            ["sub"] = sub ?? "static-lan-client",
+            ["roles"] = scopes.Select(s => $"{tenant}:{s}").ToArray()
+        };
+
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = CompoundRoleIssuer,
+            Audience = TestAudience,
+            Claims = claims,
+            Expires = DateTime.UtcNow.Add(expiresIn ?? TimeSpan.FromHours(1)),
+            SigningCredentials = new SigningCredentials(SigningKey, SecurityAlgorithms.RsaSha256)
+        };
+
+        return handler.CreateToken(descriptor);
+    }
 
     public static string Mint(
         string tenant,

--- a/tests/ExpertiseApi.Tests/Integration/StaticIssuerCompoundRoleTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/StaticIssuerCompoundRoleTests.cs
@@ -1,0 +1,149 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ExpertiseApi.Auth;
+using ExpertiseApi.Tests.Infrastructure;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace ExpertiseApi.Tests.Integration;
+
+/// <summary>
+/// ADR-014 regression guard: an offline-minted, static-issuer token authenticates and
+/// authorizes end-to-end through the UNMODIFIED API, proving the "no code change" claim.
+/// The token carries a <c>roles</c> array of <c>{tenant}:{fully-qualified-scope}</c> and is
+/// validated against a second issuer configured for <c>TenantSource=CompoundRole</c> /
+/// <c>ScopeClaims=["roles"]</c> — the shape <c>scripts/mint_token.py</c> emits.
+///
+/// The issuer is wired here (not in the shared <see cref="JwtApiFactory"/>) so the factory's
+/// default Authentik-style issuer stays untouched; the second scheme's OIDC configuration is
+/// injected in-process so no JWKS HTTP fetch occurs (the live HTTPS metadata fetch is a
+/// framework concern, not an API-behaviour one).
+/// </summary>
+[Collection("Postgres")]
+public class StaticIssuerCompoundRoleTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private WebApplicationFactory<Program> _factory = null!;
+    private JwtApiFactory _baseFactory = null!;
+
+    public StaticIssuerCompoundRoleTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public Task InitializeAsync()
+    {
+        _baseFactory = new JwtApiFactory(_postgres.ConnectionString);
+        _factory = _baseFactory.WithWebHostBuilder(builder =>
+        {
+            // Register the static-LAN CompoundRole issuer as a second issuer (index 1).
+            builder.UseSetting("Auth:Oidc:Issuers:1:Name", JwtTokenMinter.CompoundRoleSchemeName);
+            builder.UseSetting("Auth:Oidc:Issuers:1:Issuer", JwtTokenMinter.CompoundRoleIssuer);
+            builder.UseSetting("Auth:Oidc:Issuers:1:Audience", JwtTokenMinter.TestAudience);
+            builder.UseSetting("Auth:Oidc:Issuers:1:ScopeClaims:0", "roles");
+            builder.UseSetting("Auth:Oidc:Issuers:1:TenantSource", "CompoundRole");
+            builder.UseSetting("Auth:Oidc:Issuers:1:RoleSeparator", ":");
+
+            // Mock embeddings collapse distinct entries; disable dedup so per-row audit
+            // attribution is real (mirrors ActorClassAuditTests).
+            builder.UseSetting("Deduplication:Enabled", "false");
+
+            builder.ConfigureServices(services =>
+            {
+                // Preload OIDC config for the second scheme so JwtBearer skips the JWKS fetch.
+                services.PostConfigure<JwtBearerOptions>(JwtTokenMinter.CompoundRoleSchemeName, options =>
+                {
+                    options.Configuration = new OpenIdConnectConfiguration
+                    {
+                        Issuer = JwtTokenMinter.CompoundRoleIssuer
+                    };
+                    options.Configuration.SigningKeys.Add(JwtTokenMinter.SigningKey);
+                    options.TokenValidationParameters.IssuerSigningKey = JwtTokenMinter.SigningKey;
+                    options.MetadataAddress = null!;
+                    options.ConfigurationManager = null;
+                });
+            });
+        });
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _factory.DisposeAsync();
+        await _baseFactory.DisposeAsync();
+    }
+
+    private HttpClient CompoundRoleClient(string tenant, IEnumerable<string> scopes)
+    {
+        var token = JwtTokenMinter.MintCompoundRole(tenant, scopes);
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
+    }
+
+    private HttpClient AdminClient()
+    {
+        // Cross-tenant admin via the default Authentik-style issuer (group → shared tenant).
+        var token = JwtTokenMinter.Mint(tenant: "shared", scopes: [AuthConstants.AdminScope], groups: ["group-shared"]);
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
+    }
+
+    private static object UniquePayload() => new
+    {
+        domain = "shared",
+        title = $"ADR-014 static-issuer fixture {Guid.NewGuid():N}",
+        body = $"Body for a compound-role authorization test ({Guid.NewGuid()}).",
+        entryType = "Pattern",
+        severity = "Info",
+        source = "test"
+    };
+
+    [Fact]
+    public async Task CompoundRoleToken_WithReadScope_AuthorizesListEndpoint()
+    {
+        // Read scope carried as "test:expertise.read" → ReadAccess policy satisfied.
+        var client = CompoundRoleClient("test", [AuthConstants.ReadScope]);
+
+        var response = await client.GetAsync("/expertise");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task CompoundRoleToken_WriteDraftAndAgent_CreatesInDerivedTenant_AndTagsAgent()
+    {
+        // roles: ["test:expertise.write.draft", "test:expertise.agent"].
+        // Proves the full pipeline: roles-array extraction → CompoundRole parse (tenant=test)
+        // → scope closure (write.draft ⊇ read) → actor-class (agent scope) → tenant attribution.
+        var client = CompoundRoleClient("test", [AuthConstants.WriteDraftScope, AuthConstants.AgentScope]);
+
+        var create = await client.PostAsJsonAsync("/expertise", UniquePayload());
+        create.StatusCode.Should().Be(HttpStatusCode.Created,
+            await create.Content.ReadAsStringAsync());
+        var entryId = (await create.Content.ReadJsonElementAsync()).GetProperty("id").GetGuid();
+
+        var audit = await AdminClient().GetAsync("/audit");
+        audit.StatusCode.Should().Be(HttpStatusCode.OK);
+        var rows = (await audit.Content.ReadJsonElementAsync()).EnumerateArray().ToArray();
+        var row = rows.Single(r => r.GetProperty("entryId").GetGuid() == entryId);
+
+        row.GetProperty("tenant").GetString().Should().Be("test");
+        row.GetProperty("actorClass").GetString().Should().Be("Agent");
+        row.GetProperty("authMethod").GetString().Should().Be(AuthExtensions.BearerScheme);
+    }
+
+    [Fact]
+    public async Task CompoundRoleToken_WithoutWriteScope_IsForbiddenOnCreate()
+    {
+        // Read-only token must NOT satisfy WriteAccess — authorization is enforced, not just parsed.
+        var client = CompoundRoleClient("test", [AuthConstants.ReadScope]);
+
+        var response = await client.PostAsJsonAsync("/expertise", UniquePayload());
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+}


### PR DESCRIPTION
## Summary

Locks ADR-014's static-issuer contract into CI. An offline-minted, static-issuer token (the shape `scripts/mint_token.py` emits) now authenticates and authorizes **end-to-end through the unmodified API**, proving the ADR's central "no code change" claim as an executable regression guard rather than a design-session assertion.

Advances #382 (partial — the artifact-landing checklist item remains).

## What it proves

The token carries a `roles` array of `{tenant}:{fully-qualified-scope}`, validated against a second issuer configured for `TenantSource=CompoundRole` / `ScopeClaims=["roles"]` / `RoleSeparator=":"`. The tests exercise the real pipeline:

- `roles`-array claim extraction (`ExtractRawScopes`)
- compound-role parse → tenant derivation (`ParseCompoundRoles`)
- scope closure (`write.draft ⊇ read`; approve/admin **not** granted — ADR-003 holds)
- actor-class resolution (`expertise.agent` scope → `Agent`)
- authorization actually enforced (read-only token → **403** on create)

This was the gap: `JwtApiFactory` only covered the Authentik shape (`Groups` + `scope`); the CompoundRole/`roles` path had zero end-to-end coverage.

## Changes (additive — no existing behaviour touched)

- **`JwtTokenMinter.MintCompoundRole(...)`** — mints a `roles`-array compound-role token (the existing `Mint` space-joins a single claim and can't produce the array form).
- **`StaticIssuerCompoundRoleTests`** (new) — wires the CompoundRole issuer via `WithWebHostBuilder` so the shared `JwtApiFactory` stays untouched; OIDC config injected in-process (no JWKS HTTP fetch — the live HTTPS metadata fetch is a framework concern, not an API-behaviour one).

## Verification

- 3 new tests pass (podman/Testcontainers).
- 27 existing auth/audit tests (`JwtAuthentication`, `ActorClassAudit`, `JwtTenantContextEvents`) pass — no regression.
- `dotnet format analyzers --verify-no-changes` clean.

## Provenance

Hand-verified first by minting a real token with `mint_token.py` and decoding it, then running it through the API's exact `TokenValidationParameters` + internal pipeline. Confirmed the pinned config contract (`ScopeClaims:["roles"]`, fully-qualified scopes, `CompoundRole`/`":"`, issuer byte-exact incl. trailing slash). This PR is the durable form of that check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
