### PR TITLE
feat(auth): embedded static jwks issuer for lan consumers (adr-015)

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,8 +447,10 @@ The lightweight local defaults above assume loopback. To let **other hosts on yo
 LAN** (e.g. container VMs running agents) consume one A2 instance, three things
 change — and because `Auth:Mode` is hard-`Oidc` outside Development, you need an
 OIDC issuer. You do **not** need a full identity provider. See
-[ADR-014](adrs/014-lightweight-oidc-static-jwks.md) for the decision and
-trade-offs; the short version:
+[ADR-015](adrs/015-embedded-static-jwks.md) (which supersedes
+[ADR-014](adrs/014-lightweight-oidc-static-jwks.md)) for the decision, and
+[`deploy/lan-static-oidc/`](deploy/lan-static-oidc/RUNBOOK.md) for the turnkey
+runbook. The short version:
 
 1. **Bind off loopback.** `scripts/install.sh --bind 0.0.0.0:8080` (or a specific
    LAN interface IP). Remote clients target the host's **LAN IP**, not
@@ -458,20 +460,26 @@ trade-offs; the short version:
    to a remote `Host:` — set `AllowedHosts=<your-lan-hostname>` in `secrets.env`,
    and add the reverse proxy's network to `ForwardedHeaders__KnownNetworks__0` so
    audit IPs are the real client, not the proxy.
-3. **Terminate TLS.** Nothing in the A2 path serves HTTPS. Front the API (and the
-   static issuer below) with a reverse proxy (Caddy) using an internal ACME CA
-   (step-ca) — HTTP-01/TLS-ALPN-01 work LAN-to-LAN with no public DNS. Distribute
-   the CA root to the API host **and** every consumer VM, or TLS fails closed.
+3. **Terminate TLS.** Nothing in the A2 path serves HTTPS. Front the API with a
+   reverse proxy (Caddy, run natively) using an internal ACME CA (step-ca) —
+   TLS-ALPN-01 works LAN-to-LAN with no public DNS. Distribute the CA root to
+   **every consumer VM** so they trust the API's endpoint. Under ADR-015 the
+   **API host itself trusts no CA** (it performs no metadata fetch).
 
-**The issuer, without a daemon:** serve a static `.well-known/openid-configuration`
-+ `jwks.json` over HTTPS (the same proxy can host them), mint per-client RS256 JWTs
-offline carrying a `{tenant}:{scope}` `roles` claim, and add a `LanStatic` entry to
-`Auth:Oidc:Issuers[]` (`TenantSource: CompoundRole`, `RoleSeparator: ":"`). The
-existing scope ([ADR-003](adrs/003-scope-split.md)) and actor-class
+**The issuer, without a daemon or an HTTPS endpoint:** mint per-client RS256 JWTs
+offline (`scripts/mint_token.py`) carrying a `{tenant}:{scope}` `roles` claim, build
+a public `jwks.json`, and point the shipped `LanStatic` issuer
+(`Auth:Oidc:Issuers[2]`, `TenantSource: CompoundRole`, `RoleSeparator: ":"`) at that
+file via `Auth__Oidc__Issuers__2__JwksPath`. The API loads the keys at startup and
+validates **with no discovery fetch** (ADR-015 embedded JWKS) — so there is no
+`.well-known` endpoint to host and no backchannel CA trust on the API host; a
+missing/empty JWKS fails startup closed. The existing scope
+([ADR-003](adrs/003-scope-split.md)) and actor-class
 ([ADR-008](adrs/008-response-hygiene-and-actor-class.md)) semantics apply to minted
-tokens unchanged — no code change. Never mint `expertise.write.approve` for an
-unattended client. When you outgrow manual key rotation or need synchronous
-revocation, escalate to a headless OP (Ory Hydra) — config-only on the API side.
+tokens unchanged. Never mint `expertise.write.approve` for an unattended client.
+Rotation is edit-`jwks.json` + restart (not zero-downtime); when you outgrow that or
+need synchronous revocation, escalate to a headless OP (Ory Hydra) — config-only on
+the API side.
 
 #### Survives reboot?
 

--- a/adrs/014-lightweight-oidc-static-jwks.md
+++ b/adrs/014-lightweight-oidc-static-jwks.md
@@ -1,6 +1,6 @@
 # Static JWKS + offline-minted JWTs as the lightweight OIDC issuer for A2/LAN consumption
 
-- Status: accepted
+- Status: superseded by [ADR-015](015-embedded-static-jwks.md) (metadata-delivery mechanism only — the lightweight-issuer decision over a full IdP stands; ADR-015 flips Option C → Option D)
 - Date: 2026-07-08
 - Companion: [ADR-003](003-scope-split.md) (scope semantics that gate what a minted token can do), [ADR-005](005-multi-issuer-jwt-policy-scheme.md) (multi-issuer JWT plumbing reused verbatim), [ADR-008](008-response-hygiene-and-actor-class.md) (actor-class resolution from the token), [ADR-011](011-deployment-artifact-format.md) (the A2 native-service install this pairs with), [ADR-013](013-aggregator-upsync.md) (distinct: hub↔spoke up-sync keeps `client_credentials` on a shared IdP — NOT in scope here)
 - Tracking issue: [#382](https://github.com/psmfd/agent-expertise-api/issues/382)

--- a/adrs/015-embedded-static-jwks.md
+++ b/adrs/015-embedded-static-jwks.md
@@ -1,0 +1,48 @@
+# Embed static signing keys directly (drop the HTTPS discovery fetch) for the LAN OIDC issuer
+
+- Status: accepted
+- Date: 2026-07-10
+- Supersedes: [ADR-014](014-lightweight-oidc-static-jwks.md) — specifically its **Option-C** metadata-delivery mechanism (static discovery doc + HTTPS `jwks_uri` fetch). ADR-014's rejection of a full IdP (Options A/B) and its token/scope/actor-class model are unchanged and carried forward by reference.
+- Companion: [ADR-003](003-scope-split.md), [ADR-005](005-multi-issuer-jwt-policy-scheme.md), [ADR-008](008-response-hygiene-and-actor-class.md), [ADR-011](011-deployment-artifact-format.md)
+- Tracking issue: [#382](https://github.com/psmfd/agent-expertise-api/issues/382)
+- Surfaced by: 2026-07-10 A2-integration research (multi-agent fan-out across `expertise-api-owner`, `dotnet-expert`, `docker-expert`) into how the ADR-014 pattern composes with the A2 native-service install surface.
+
+## Context and Problem Statement
+
+ADR-014 adopted a lightweight OIDC issuer for A2/LAN M2M consumption and chose **Option C**: serve a static `.well-known/openid-configuration` + `jwks.json` over HTTPS and let the API's `JwtBearer` scheme fetch them via `options.Authority`. Option C was chosen expressly because "it requires no change to the authentication code." Option D (embed the signing keys directly) was described and **deferred** with an explicit trigger: "revisit if the HTTPS-metadata requirement becomes friction."
+
+Researching how Option C actually lands on the A2 native-service surface (systemd `--user` on Linux, launchd on macOS) surfaced that the HTTPS-metadata fetch imposes a real, per-platform **internal-CA-trust burden on the API host**:
+
+- The API must trust the internal ACME CA (e.g. step-ca) root to fetch the issuer's HTTPS metadata. .NET delegates that trust decision entirely to the OS, with **no shared mechanism** across platforms: Linux uses OpenSSL (`update-ca-certificates` / `SSL_CERT_FILE`), while macOS validates exclusively through the Apple Security framework/Keychain (`security add-trusted-cert`) — and .NET 10 removed OpenSSL interop on macOS entirely, so there is no env-var path there at all.
+- The fetch is **lazy** (first authenticated request), so a missing trust step surfaces as a **500 on the first protected request while `/health` and `/metrics` stay green** — a boot-green/broken-on-first-call blind spot that the existing `EnforceOidcIssuersGuard` does not cover.
+
+The "no code change" saving of Option C is therefore paid back, with interest, as divergent per-OS operational plumbing and a latent runtime failure mode. The Option-D trigger has fired.
+
+## Considered Options
+
+- **Keep Option C (status quo).** No code change, keeps zero-downtime `kid` rotation (publish a new `jwks.json`, picked up within the refresh window). Cost: the per-platform CA-trust burden and lazy-fetch 500 blind spot above; requires a live HTTPS metadata endpoint.
+- **Adopt Option D — embed `IssuerSigningKeys` from a local JWKS file.** The API loads `jwks.json` from a local path at startup and validates against it directly; no `Authority`, no discovery fetch, no `jwks_uri`, no metadata TLS handshake. Cost: a small `AuthExtensions` source change (now made) and loss of zero-downtime rotation (rotation becomes edit-`jwks.json` + restart).
+
+## Decision Outcome
+
+Adopt **Option D**. Per-issuer configuration gains `JwksPath`: when set, `AuthExtensions.RegisterJwtBearer` loads the file's keys into `TokenValidationParameters.IssuerSigningKeys`, preloads `options.Configuration` with the pinned issuer, nulls the `ConfigurationManager`, and leaves `Authority` unset — so the issuer never contacts the network. `Issuer` remains required (it pins `ValidIssuer` / must byte-match `iss`). Cloud issuers (Entra, Authentik) with no `JwksPath` keep the Option-C discovery path unchanged — the choice is per-issuer, not global.
+
+A `JwksPath` that is missing, unreadable, malformed, or empty **fails startup closed** (`LoadStaticSigningKeys`, run at service-configuration time) — the embedded-key analogue of `EnforceOidcIssuersGuard`, closing the lazy-fetch blind spot: an embedded-key instance cannot boot green with unusable keys.
+
+## Consequences
+
+- **Good** — the internal-CA-trust requirement on the API host is **eliminated**: there is no metadata TLS handshake to trust, so the divergent Linux/macOS trust plumbing (and .NET 10's macOS-OpenSSL removal) stops mattering for the auth path. CA trust remains only on the **consumer** side (each VM trusts the proxy's cert to reach the API over TLS).
+- **Good** — no HTTPS `.well-known`/`jwks.json` endpoint to stand up; the reverse proxy's only remaining job is terminating TLS on the API's own endpoint.
+- **Good** — failure is **fail-closed at startup**, not a first-request 500 with a green `/health`.
+- **Good** — the token/scope/actor-class model, ADR-005 multi-issuer plumbing, and the offline-mint workflow are otherwise unchanged; the regression guard exercises the real embedded-key path.
+- **Bad** — a small auth-code change was required (now landed + reviewed) — the exact thing Option C optimised against.
+- **Bad** — loss of zero-downtime `kid` rotation: rotating a key is now edit-`jwks.json` + service restart, not "publish a new static file." Tolerable while the roster is small (the same regime ADR-014 already assumed for manual rotation).
+- **Bad** — the `jwks.json` file must be distributed to the API's config directory with integrity (a tampered **public** JWKS can only deny service, not forge tokens — a lower-blast-radius problem than a compromised CA root).
+- **Revisit if** — the roster/rotation churn outgrows restart-based key rolls, or a synchronous revocation requirement appears; escalate to Option B (Ory Hydra) per ADR-014, which remains config-only on the API side.
+
+## Implementation notes (non-normative)
+
+- Config surface: `Auth:Oidc:Issuers:N:JwksPath` (local path). The shipped `appsettings.json` `LanStatic` issuer (index 2) carries a `JwksPath` placeholder instead of relying on discovery.
+- `scripts/mint_token.py`: `keygen` (per-client RS256 keypair) / `build-jwks` (public `jwks.json`) / `sign` (offline token). The discovery-doc emission Option C needed is dropped.
+- `deploy/lan-static-oidc/`: a **native** `Caddyfile` (API inbound TLS only) + a containerized step-ca `compose.yaml` + a runbook whose CA-trust steps are **consumer-side**.
+- Doc-sync on landing: this ADR; ADR-014 status → superseded; `appsettings.json` example; README §Archetype A2; README directory tree.

--- a/deploy/lan-static-oidc/Caddyfile
+++ b/deploy/lan-static-oidc/Caddyfile
@@ -1,0 +1,18 @@
+# ADR-015 — native Caddy (launchd/systemd). API inbound TLS only.
+#
+# Terminates HTTPS for LAN consumers and reverse-proxies to the native API over
+# loopback. Under ADR-015 the API validates tokens against a local embedded JWKS,
+# so this proxy does NOT serve any /.well-known or jwks.json — its only job is TLS
+# for the API endpoint.
+
+{
+	# step-ca's ACME directory (published to host loopback by compose.yaml).
+	acme_ca https://localhost:9000/acme/acme/directory
+	# step-ca root, exported per RUNBOOK.md step 3, so Caddy trusts the ACME API.
+	acme_ca_root /etc/caddy/step-root.crt
+}
+
+# Replace with the API's real LAN hostname (must also be in the API's AllowedHosts).
+expertise.lan.example {
+	reverse_proxy 127.0.0.1:8080
+}

--- a/deploy/lan-static-oidc/RUNBOOK.md
+++ b/deploy/lan-static-oidc/RUNBOOK.md
@@ -1,0 +1,117 @@
+# LAN static-OIDC edge for an A2 native-service install (ADR-015)
+
+Stand up an internal TLS edge so a small, fixed roster of LAN M2M clients can consume
+an A2 native-service expertise-api instance, using **offline-minted JWTs validated
+against a local embedded JWKS** — no IdP daemon, no HTTPS metadata fetch.
+
+## Topology
+
+```
+LAN consumer VM ──HTTPS──►  Caddy (native OS service)  ──HTTP loopback──►  expertise-api
+  (offline-minted JWT)       terminates TLS, proxies                       (A2 native service,
+                             127.0.0.1:8080                                  install.sh)
+                                    ▲ cert via ACME
+                             step-ca (container, compose.yaml)
+
+  mint_token.py ── OFF the API host ──►  jwks.json (copied to the API host)
+                                         + client tokens (handed to each VM)
+```
+
+Key ADR-015 property: **the API host trusts no CA** — it never fetches issuer metadata.
+Only the **consumer VMs** trust step-ca's root (to reach the API's HTTPS endpoint).
+
+## Prerequisites
+
+- Docker or Podman (for step-ca). With Podman: `DOCKER_HOST` + `TESTCONTAINERS_RYUK_DISABLED` per the testing guide.
+- Caddy installed natively: `apt install caddy` (Debian 13) or `brew install caddy` (macOS).
+- Python 3 + `pip install jwcrypto` on the (off-host) minting machine.
+- The API already installed as an A2 service via `scripts/install.sh`.
+
+## Steps
+
+### 1. Start the internal CA
+
+```bash
+cd deploy/lan-static-oidc
+docker compose up -d           # or: podman compose up -d
+```
+
+### 2. Export step-ca's root
+
+```bash
+docker compose exec step-ca step ca root /home/step/root_ca.crt
+docker compose cp step-ca:/home/step/root_ca.crt ./step-root.crt
+sudo cp ./step-root.crt /etc/caddy/step-root.crt      # where the Caddyfile references it
+```
+
+### 3. Run Caddy natively
+
+Put `Caddyfile` at `/etc/caddy/Caddyfile` (edit the hostname), then run Caddy as an OS
+service (`systemctl enable --now caddy` on Debian; `brew services start caddy` on macOS).
+Native Caddy reaches the API at `127.0.0.1:8080` and step-ca at `localhost:9000`.
+
+### 4. Trust step-ca on each CONSUMER VM (not the API host)
+
+This is the only CA-trust step, and it lives on the clients:
+
+- **Debian 13 (Trixie):**
+  ```bash
+  sudo cp step-root.crt /usr/local/share/ca-certificates/expertise-lan-ca.crt
+  sudo update-ca-certificates
+  ```
+- **macOS:**
+  ```bash
+  sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain step-root.crt
+  ```
+
+### 5. Mint keys + build the JWKS (off the API host)
+
+```bash
+export OIDC_ISSUER="https://auth.lan.example/"   # any stable string; must byte-match the API's Issuer + the iss claim
+./scripts/mint_token.py keygen --client vm-alpha
+./scripts/mint_token.py build-jwks --out oidc/jwks.json
+```
+
+Copy `oidc/jwks.json` to the API host, e.g. `~/.config/expertise-api/jwks.json`.
+
+### 6. Configure the API service
+
+Install (or re-run) with a LAN bind, and add the issuer to `secrets.env`:
+
+```bash
+scripts/install.sh --bind 0.0.0.0:8080
+```
+```sh
+# ~/.config/expertise-api/secrets.env
+Auth__Oidc__Issuers__2__Issuer=https://auth.lan.example/
+Auth__Oidc__Issuers__2__JwksPath=/home/<user>/.config/expertise-api/jwks.json
+AllowedHosts=expertise.lan.example
+ForwardedHeaders__KnownNetworks__0=<proxy-subnet-cidr>
+```
+
+Index `2` is the shipped `LanStatic` issuer (`appsettings.json`); `Name`/`Audience`/
+`ScopeClaims`/`TenantSource`/`RoleSeparator` are already correct. A blank/unreadable
+`JwksPath` (or a still-`<TODO…>` `Issuer`) **fails startup closed** — by design.
+
+### 7. Restart and verify
+
+```bash
+scripts/expertise-apictl restart
+
+# Mint a client token and verify a PROTECTED endpoint — NOT just /health, which stays
+# green regardless of auth config:
+TOKEN=$(./scripts/mint_token.py sign --client vm-alpha --tenant team-alpha --scopes read --ttl-days 7)
+curl -sS https://expertise.lan.example/expertise -H "Authorization: Bearer $TOKEN" | head
+```
+
+A `200` (or a valid empty list) confirms end-to-end auth. A `401`/`500` means the token,
+issuer config, or JWKS is wrong — check the service logs.
+
+## Rotation & revocation (ADR-015 tradeoff)
+
+There is **no synchronous revocation** — a token is valid until its `exp`. Keep `--ttl-days`
+short and re-mint on a schedule. To roll a key or revoke a client: re-run `keygen` /
+`build-jwks`, copy the new `jwks.json`, and **restart the API** (`expertise-apictl restart`).
+Embedded JWKS is loaded at startup, so rotation is not zero-downtime — acceptable for the
+small-roster LAN case this targets. If churn outgrows restarts or you need "kill this token
+now," escalate to Ory Hydra (ADR-014 Option B), config-only on the API side.

--- a/deploy/lan-static-oidc/compose.yaml
+++ b/deploy/lan-static-oidc/compose.yaml
@@ -1,0 +1,30 @@
+# ADR-015 LAN OIDC edge — step-ca ONLY.
+#
+# Caddy runs NATIVELY (launchd/systemd — see RUNBOOK.md), not here. That lets it
+# reach the native API over plain loopback (127.0.0.1) and reach step-ca via the
+# published port below — the well-supported direction on every Docker/Podman
+# runtime — instead of relying on host.docker.internal crossing into a native
+# process (ambiguous across Docker Desktop / colima / podman machine).
+#
+# step-ca is the internal ACME CA that issues Caddy's TLS cert for the API's
+# public hostname. Under ADR-015 (embedded JWKS) the API performs NO metadata
+# fetch, so the API host does NOT trust this CA — only the LAN CONSUMER VMs do.
+name: expertise-lan-oidc
+
+services:
+  step-ca:
+    # Pin to a digest before any real use — :latest mints your trust root.
+    image: smallstep/step-ca:0.28.4
+    restart: unless-stopped
+    environment:
+      DOCKER_STEPCA_INIT_NAME: "Expertise LAN CA"
+      DOCKER_STEPCA_INIT_DNS_NAMES: "localhost,step-ca"
+      DOCKER_STEPCA_INIT_ACME: "true"
+    ports:
+      # ACME directory, published to host loopback for the native Caddy service.
+      - "127.0.0.1:9000:9000"
+    volumes:
+      - step-ca-data:/home/step
+
+volumes:
+  step-ca-data:

--- a/scripts/mint_token.py
+++ b/scripts/mint_token.py
@@ -51,6 +51,7 @@ def kid_for(client): return f"{client}"
 
 def keygen(a):
     os.makedirs(KEY_DIR, exist_ok=True)
+    os.chmod(KEY_DIR, 0o700)   # keys are more sensitive than any token; don't leave the dir world-listable
     path = os.path.join(KEY_DIR, f"{a.client}.priv.json")
     if os.path.exists(path) and not a.force:
         sys.exit(f"{path} exists; pass --force to overwrite (rotates the client's key)")

--- a/scripts/mint_token.py
+++ b/scripts/mint_token.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Offline JWT minter + JWKS builder for expertise-api (ADR-015, no IdP daemon).
+
+Runs OFF the API host. Produces (1) a per-client RS256 keypair, (2) a public
+`jwks.json` the API loads via `Auth:Oidc:Issuers:N:JwksPath` (embedded-key path —
+no HTTPS discovery fetch), and (3) offline-signed tokens for LAN M2M clients.
+
+One RSA keypair PER CLIENT so a single client can be revoked by dropping its key
+from jwks.json and restarting the API, without invalidating the others.
+
+Deps:  pip install jwcrypto
+Usage:
+    # 1. one-time per client: generate a keypair (writes <client>.priv.json)
+    ./mint_token.py keygen --client vm-alpha
+    # 2. (re)build the public JWKS from ALL *.priv.json in the key dir, then copy
+    #    it to the API host and point Auth__Oidc__Issuers__2__JwksPath at it
+    ./mint_token.py build-jwks --out oidc/jwks.json
+    # 3. mint a token for a client
+    ./mint_token.py sign --client vm-alpha \
+        --tenant team-alpha --scopes read,write.draft,agent --ttl-days 7
+
+Config contract (verified end-to-end by StaticIssuerCompoundRoleTests):
+  Auth:Oidc:Issuers[N] = { Issuer (byte-exact w/ the `iss` below), Audience,
+    JwksPath, ScopeClaims:["roles"], TenantSource:"CompoundRole", RoleSeparator:":" }
+
+Security: keep the key dir (default ./keys) OFF the API host, chmod 700, encrypt
+at rest. The private keys can mint tokens for any client indefinitely — they are
+more sensitive than any single token. There is NO synchronous revocation: a
+token is valid until its `exp`, so keep --ttl-days short and re-mint on a
+schedule (ADR-015 Consequences).
+"""
+import argparse, json, os, time, glob, sys
+from jwcrypto import jwk, jwt
+
+KEY_DIR = os.environ.get("OIDC_KEY_DIR", "keys")
+ISSUER  = os.environ.get("OIDC_ISSUER", "https://auth.lan.example/")  # byte-exact w/ Issuers[N].Issuer
+AUDIENCE = os.environ.get("OIDC_AUDIENCE", "expertise-api")
+
+# Scope shorthand -> full expertise-api scope string. CompoundRole parses each
+# roles[] entry as "{tenant}:{scope}" splitting on ':' (RoleSeparator).
+SCOPE_MAP = {
+    "read":    "expertise.read",
+    "draft":   "expertise.write.draft",
+    "write.draft": "expertise.write.draft",
+    "approve": "expertise.write.approve",   # do NOT grant to unattended M2M clients
+    "admin":   "expertise.admin",
+    "agent":   "expertise.agent",           # tags ActorClass=agent in the audit log
+}
+
+def kid_for(client): return f"{client}"
+
+def keygen(a):
+    os.makedirs(KEY_DIR, exist_ok=True)
+    path = os.path.join(KEY_DIR, f"{a.client}.priv.json")
+    if os.path.exists(path) and not a.force:
+        sys.exit(f"{path} exists; pass --force to overwrite (rotates the client's key)")
+    key = jwk.JWK.generate(kty="RSA", size=2048, kid=kid_for(a.client), use="sig", alg="RS256")
+    with open(path, "w") as f: f.write(key.export_private())
+    os.chmod(path, 0o600)
+    print(f"wrote {path} (kid={kid_for(a.client)})")
+
+def build_jwks(a):
+    keys = []
+    for p in sorted(glob.glob(os.path.join(KEY_DIR, "*.priv.json"))):
+        k = jwk.JWK.from_json(open(p).read())
+        keys.append(json.loads(k.export_public()))
+    os.makedirs(os.path.dirname(a.out) or ".", exist_ok=True)
+    with open(a.out, "w") as f: json.dump({"keys": keys}, f, indent=2)
+    print(f"wrote {a.out} with {len(keys)} key(s): {[k['kid'] for k in keys]}")
+
+def sign(a):
+    path = os.path.join(KEY_DIR, f"{a.client}.priv.json")
+    key = jwk.JWK.from_json(open(path).read())
+    roles = []
+    for s in a.scopes.split(","):
+        s = s.strip()
+        full = SCOPE_MAP.get(s, s)
+        roles.append(f"{a.tenant}:{full}")
+    now = int(time.time())
+    claims = {
+        "iss": ISSUER, "aud": AUDIENCE, "sub": a.client,
+        "iat": now, "nbf": now, "exp": now + a.ttl_days * 86400,
+        "roles": roles,                     # <-- API config: ScopeClaims:["roles"], RoleSeparator:":"
+    }
+    tok = jwt.JWT(header={"alg": "RS256", "kid": kid_for(a.client), "typ": "JWT"}, claims=claims)
+    tok.make_signed_token(key)
+    print(tok.serialize())
+
+p = argparse.ArgumentParser(description="Offline JWT minter + JWKS builder (ADR-015).")
+sub = p.add_subparsers(required=True)
+g = sub.add_parser("keygen"); g.add_argument("--client", required=True); g.add_argument("--force", action="store_true"); g.set_defaults(fn=keygen)
+b = sub.add_parser("build-jwks"); b.add_argument("--out", default="oidc/jwks.json"); b.set_defaults(fn=build_jwks)
+s = sub.add_parser("sign"); s.add_argument("--client", required=True); s.add_argument("--tenant", required=True); s.add_argument("--scopes", required=True); s.add_argument("--ttl-days", type=int, default=7); s.set_defaults(fn=sign)
+a = p.parse_args(); a.fn(a)

--- a/src/ExpertiseApi/Auth/AuthExtensions.cs
+++ b/src/ExpertiseApi/Auth/AuthExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 
 namespace ExpertiseApi.Auth;
@@ -43,7 +44,14 @@ internal static class AuthExtensions
         {
             foreach (var issuer in issuers)
             {
-                RegisterJwtBearer(authBuilder, issuer);
+                // Eagerly load embedded static keys (ADR-015) here, at service-configuration
+                // time, so a missing/malformed JwksPath fails startup closed rather than 500ing
+                // on the first authenticated request. Discovery-path issuers (JwksPath unset)
+                // pass null and fetch lazily via Authority as before.
+                var staticKeys = string.IsNullOrWhiteSpace(issuer.JwksPath)
+                    ? null
+                    : LoadStaticSigningKeys(issuer);
+                RegisterJwtBearer(authBuilder, issuer, staticKeys);
             }
         }
 
@@ -152,11 +160,13 @@ internal static class AuthExtensions
             .ToList();
     }
 
-    private static void RegisterJwtBearer(AuthenticationBuilder builder, OidcIssuerOptions issuer)
+    private static void RegisterJwtBearer(
+        AuthenticationBuilder builder,
+        OidcIssuerOptions issuer,
+        IList<SecurityKey>? staticSigningKeys)
     {
         builder.AddJwtBearer(issuer.Name, options =>
         {
-            options.Authority = issuer.Issuer;
             options.Audience = issuer.Audience;
             options.MapInboundClaims = false; // keep `sub`, `scp`, etc. as-is for parsing
 
@@ -171,11 +181,76 @@ internal static class AuthExtensions
                 NameClaimType = "sub"
             };
 
+            if (staticSigningKeys is not null)
+            {
+                // ADR-015 (Option D): embedded static JWKS. Preload the configuration with the
+                // issuer + signing keys and null the ConfigurationManager so JwtBearer treats
+                // this as static — it never fetches `.well-known/openid-configuration` or the
+                // `jwks_uri`, so there is no HTTPS metadata endpoint to stand up and no
+                // internal-CA root to trust on the API host. `Authority` is deliberately unset.
+                var configuration = new OpenIdConnectConfiguration { Issuer = issuer.Issuer };
+                foreach (var key in staticSigningKeys)
+                    configuration.SigningKeys.Add(key);
+                options.Configuration = configuration;
+                options.ConfigurationManager = null;
+                options.TokenValidationParameters.IssuerSigningKeys = staticSigningKeys;
+            }
+            else
+            {
+                // Discovery path (cloud issuers): Authority drives lazy `.well-known` + JWKS
+                // fetch. RequireHttpsMetadata stays at its default (true).
+                options.Authority = issuer.Issuer;
+            }
+
             options.Events = new JwtBearerEvents
             {
                 OnTokenValidated = ctx => JwtTenantContextEvents.BuildTenantContext(ctx, issuer)
             };
         });
+    }
+
+    /// <summary>
+    /// Loads and validates an embedded-key issuer's JWKS file (ADR-015, Option D). Runs at
+    /// service-configuration time so any problem fails startup closed — a deliberate parallel
+    /// to <see cref="EnforceOidcIssuersGuard"/>: a networked instance must never boot green
+    /// (<c>/health</c>, <c>/metrics</c>) while its only issuer's keys are missing or malformed
+    /// and every protected request would 500.
+    /// </summary>
+    internal static IList<SecurityKey> LoadStaticSigningKeys(OidcIssuerOptions issuer)
+    {
+        string json;
+        try
+        {
+            json = File.ReadAllText(issuer.JwksPath!);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            throw new InvalidOperationException(
+                $"Auth:Oidc issuer '{issuer.Name}' JwksPath '{issuer.JwksPath}' could not be read: {ex.Message} " +
+                "Provide a readable jwks.json for an embedded-key (ADR-015) issuer, or remove JwksPath to use " +
+                "HTTPS discovery via Authority.", ex);
+        }
+
+        IList<SecurityKey> keys;
+        try
+        {
+            keys = new JsonWebKeySet(json).GetSigningKeys();
+        }
+        catch (Exception ex) when (ex is ArgumentException or System.Text.Json.JsonException)
+        {
+            throw new InvalidOperationException(
+                $"Auth:Oidc issuer '{issuer.Name}' JwksPath '{issuer.JwksPath}' is not a valid JWKS document: " +
+                $"{ex.Message}", ex);
+        }
+
+        if (keys.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Auth:Oidc issuer '{issuer.Name}' JwksPath '{issuer.JwksPath}' contains no signing keys. " +
+                "A JWKS with at least one RSA/EC signing key is required for an embedded-key issuer.");
+        }
+
+        return keys;
     }
 
     [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",

--- a/src/ExpertiseApi/Auth/AuthExtensions.cs
+++ b/src/ExpertiseApi/Auth/AuthExtensions.cs
@@ -184,10 +184,12 @@ internal static class AuthExtensions
             if (staticSigningKeys is not null)
             {
                 // ADR-015 (Option D): embedded static JWKS. Preload the configuration with the
-                // issuer + signing keys and null the ConfigurationManager so JwtBearer treats
-                // this as static — it never fetches `.well-known/openid-configuration` or the
-                // `jwks_uri`, so there is no HTTPS metadata endpoint to stand up and no
-                // internal-CA root to trust on the API host. `Authority` is deliberately unset.
+                // issuer + signing keys. Because Authority/MetadataAddress are unset, the
+                // framework's JwtBearerPostConfigureOptions wraps this Configuration in a
+                // StaticConfigurationManager (nulling ConfigurationManager here just prevents a
+                // discovery-backed one) — GetConfigurationAsync then performs no I/O, so there
+                // is no `.well-known`/`jwks_uri` fetch, no HTTPS metadata endpoint to stand up,
+                // and no internal-CA root to trust on the API host. `Authority` is deliberately unset.
                 var configuration = new OpenIdConnectConfiguration { Issuer = issuer.Issuer };
                 foreach (var key in staticSigningKeys)
                     configuration.SigningKeys.Add(key);
@@ -231,10 +233,10 @@ internal static class AuthExtensions
                 "HTTPS discovery via Authority.", ex);
         }
 
-        IList<SecurityKey> keys;
+        JsonWebKeySet keySet;
         try
         {
-            keys = new JsonWebKeySet(json).GetSigningKeys();
+            keySet = new JsonWebKeySet(json);
         }
         catch (Exception ex) when (ex is ArgumentException or System.Text.Json.JsonException)
         {
@@ -242,6 +244,24 @@ internal static class AuthExtensions
                 $"Auth:Oidc issuer '{issuer.Name}' JwksPath '{issuer.JwksPath}' is not a valid JWKS document: " +
                 $"{ex.Message}", ex);
         }
+
+        // Reject private-key material. The API loads a JWKS only to *validate* signatures, so it
+        // must be public-only. This fails closed on the operator footgun of pointing JwksPath at
+        // mint_token.py's `<client>.priv.json` (or its key dir) instead of the `build-jwks` output
+        // — which would otherwise load a token-forging private key into the network-facing process.
+        // `d` covers RSA and EC private keys; `p`/`q` are RSA CRT components.
+        foreach (var jwk in keySet.Keys)
+        {
+            if (!string.IsNullOrEmpty(jwk.D) || !string.IsNullOrEmpty(jwk.P) || !string.IsNullOrEmpty(jwk.Q))
+            {
+                throw new InvalidOperationException(
+                    $"Auth:Oidc issuer '{issuer.Name}' JwksPath '{issuer.JwksPath}' contains PRIVATE key material " +
+                    $"(kid '{jwk.Kid}'). The API must load a PUBLIC-only JWKS — run 'mint_token.py build-jwks' to " +
+                    "produce one; never point JwksPath at a *.priv.json file or the private key directory.");
+            }
+        }
+
+        var keys = keySet.GetSigningKeys();
 
         if (keys.Count == 0)
         {

--- a/src/ExpertiseApi/Auth/OidcIssuerOptions.cs
+++ b/src/ExpertiseApi/Auth/OidcIssuerOptions.cs
@@ -50,6 +50,19 @@ internal class OidcIssuerOptions
     /// Group claim name (defaults to <c>"groups"</c>).
     /// </summary>
     public string GroupClaim { get; set; } = "groups";
+
+    /// <summary>
+    /// Path to a local JWKS (<c>jwks.json</c>) file. When set, this issuer's signing keys are
+    /// loaded from the file at startup and embedded directly into token validation — the API
+    /// performs <b>no</b> HTTPS discovery / <c>jwks_uri</c> fetch (ADR-015, Option D). This
+    /// removes the backchannel internal-CA-trust requirement on the API host that the
+    /// discovery-fetch path (<see cref="Issuer"/> as <c>Authority</c>) would otherwise impose.
+    /// Mutually exclusive with the discovery path: an issuer carrying a <c>JwksPath</c> never
+    /// contacts the network. <see cref="Issuer"/> is still required — it pins <c>ValidIssuer</c>
+    /// and must byte-match the token's <c>iss</c> claim. A blank/unreadable/empty JWKS fails
+    /// startup closed.
+    /// </summary>
+    public string? JwksPath { get; set; }
 }
 
 internal enum TenantSource

--- a/src/ExpertiseApi/appsettings.json
+++ b/src/ExpertiseApi/appsettings.json
@@ -48,6 +48,7 @@
         {
           "Name": "LanStatic",
           "Issuer": "<TODO_LAN_STATIC_ISSUER>",
+          "JwksPath": "<TODO_LAN_STATIC_JWKS_PATH>",
           "Audience": "expertise-api",
           "AdditionalAudiences": [],
           "ScopeClaims": ["roles"],

--- a/tests/ExpertiseApi.Tests/Infrastructure/JwtTokenMinter.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/JwtTokenMinter.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography;
+using System.Text.Json;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 
@@ -100,5 +101,24 @@ public static class JwtTokenMinter
         };
 
         return handler.CreateToken(descriptor);
+    }
+
+    /// <summary>
+    /// Public-only JWKS JSON for <see cref="SigningKey"/> — the shape an embedded-key
+    /// (ADR-015) issuer's <c>jwks.json</c> carries. Tests write this to a temp file and point
+    /// <c>Auth:Oidc:Issuers:N:JwksPath</c> at it so the real production embedded-key branch in
+    /// <c>AuthExtensions.RegisterJwtBearer</c> loads and validates against it.
+    /// </summary>
+    public static string StaticJwksJson()
+    {
+        var jwk = JsonWebKeyConverter.ConvertFromSecurityKey(SigningKey);
+        var doc = new
+        {
+            keys = new[]
+            {
+                new { kty = "RSA", kid = jwk.Kid, use = "sig", alg = SecurityAlgorithms.RsaSha256, n = jwk.N, e = jwk.E }
+            }
+        };
+        return JsonSerializer.Serialize(doc);
     }
 }

--- a/tests/ExpertiseApi.Tests/Infrastructure/JwtTokenMinter.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/JwtTokenMinter.cs
@@ -38,7 +38,8 @@ public static class JwtTokenMinter
         string tenant,
         IEnumerable<string> scopes,
         string? sub = null,
-        TimeSpan? expiresIn = null)
+        TimeSpan? expiresIn = null,
+        SecurityKey? signingKey = null)
     {
         var handler = new JsonWebTokenHandler();
 
@@ -54,10 +55,34 @@ public static class JwtTokenMinter
             Audience = TestAudience,
             Claims = claims,
             Expires = DateTime.UtcNow.Add(expiresIn ?? TimeSpan.FromHours(1)),
-            SigningCredentials = new SigningCredentials(SigningKey, SecurityAlgorithms.RsaSha256)
+            // Defaults to the key embedded in the API's JWKS; pass a foreign key to prove a
+            // token whose kid is absent from the JWKS is rejected (the revocation mechanism).
+            SigningCredentials = new SigningCredentials(signingKey ?? SigningKey, SecurityAlgorithms.RsaSha256)
         };
 
         return handler.CreateToken(descriptor);
+    }
+
+    /// <summary>
+    /// PRIVATE JWKS JSON for <see cref="SigningKey"/> (carries <c>d</c>/<c>p</c>/<c>q</c>) — the
+    /// shape a JWKS would wrongly have if an operator pointed <c>JwksPath</c> at mint_token.py's
+    /// <c>*.priv.json</c>. Used to assert the loader rejects private-key material.
+    /// </summary>
+    public static string PrivateJwksJson()
+    {
+        var jwk = JsonWebKeyConverter.ConvertFromSecurityKey(SigningKey);
+        var doc = new
+        {
+            keys = new[]
+            {
+                new
+                {
+                    kty = "RSA", kid = jwk.Kid, use = "sig", alg = SecurityAlgorithms.RsaSha256,
+                    n = jwk.N, e = jwk.E, d = jwk.D, p = jwk.P, q = jwk.Q
+                }
+            }
+        };
+        return JsonSerializer.Serialize(doc);
     }
 
     public static string Mint(

--- a/tests/ExpertiseApi.Tests/Integration/StaticIssuerCompoundRoleTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/StaticIssuerCompoundRoleTests.cs
@@ -1,27 +1,25 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using System.Text.Json;
 using ExpertiseApi.Auth;
 using ExpertiseApi.Tests.Infrastructure;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
 namespace ExpertiseApi.Tests.Integration;
 
 /// <summary>
-/// ADR-014 regression guard: an offline-minted, static-issuer token authenticates and
-/// authorizes end-to-end through the UNMODIFIED API, proving the "no code change" claim.
-/// The token carries a <c>roles</c> array of <c>{tenant}:{fully-qualified-scope}</c> and is
-/// validated against a second issuer configured for <c>TenantSource=CompoundRole</c> /
+/// ADR-014/ADR-015 regression guard: an offline-minted, static-issuer token authenticates and
+/// authorizes end-to-end through the UNMODIFIED API, proving the "no code change to accept the
+/// token" claim. The token carries a <c>roles</c> array of <c>{tenant}:{fully-qualified-scope}</c>
+/// and is validated against a second issuer configured for <c>TenantSource=CompoundRole</c> /
 /// <c>ScopeClaims=["roles"]</c> — the shape <c>scripts/mint_token.py</c> emits.
 ///
-/// The issuer is wired here (not in the shared <see cref="JwtApiFactory"/>) so the factory's
-/// default Authentik-style issuer stays untouched; the second scheme's OIDC configuration is
-/// injected in-process so no JWKS HTTP fetch occurs (the live HTTPS metadata fetch is a
-/// framework concern, not an API-behaviour one).
+/// This exercises the real ADR-015 <b>embedded-key</b> path: a public <c>jwks.json</c> is
+/// written to a temp file and <c>Auth:Oidc:Issuers:1:JwksPath</c> points at it, so the
+/// production <c>AuthExtensions.RegisterJwtBearer</c> embedded-key branch (not a test-only
+/// PostConfigure) loads the keys with no HTTPS discovery fetch. The issuer is wired here rather
+/// than in the shared <see cref="JwtApiFactory"/> so the factory's default Authentik-style
+/// discovery issuer stays untouched.
 /// </summary>
 [Collection("Postgres")]
 public class StaticIssuerCompoundRoleTests : IAsyncLifetime
@@ -29,41 +27,32 @@ public class StaticIssuerCompoundRoleTests : IAsyncLifetime
     private readonly PostgresFixture _postgres;
     private WebApplicationFactory<Program> _factory = null!;
     private JwtApiFactory _baseFactory = null!;
+    private string _jwksPath = null!;
 
     public StaticIssuerCompoundRoleTests(PostgresFixture postgres) => _postgres = postgres;
 
     public Task InitializeAsync()
     {
+        // A real on-disk public JWKS for the embedded-key issuer — the production code reads it.
+        _jwksPath = Path.Combine(Path.GetTempPath(), $"adr015-jwks-{Guid.NewGuid():N}.json");
+        File.WriteAllText(_jwksPath, JwtTokenMinter.StaticJwksJson());
+
         _baseFactory = new JwtApiFactory(_postgres.ConnectionString);
         _factory = _baseFactory.WithWebHostBuilder(builder =>
         {
-            // Register the static-LAN CompoundRole issuer as a second issuer (index 1).
+            // Register the static-LAN CompoundRole issuer as a second issuer (index 1),
+            // embedded-key (ADR-015): JwksPath set, no Authority/discovery.
             builder.UseSetting("Auth:Oidc:Issuers:1:Name", JwtTokenMinter.CompoundRoleSchemeName);
             builder.UseSetting("Auth:Oidc:Issuers:1:Issuer", JwtTokenMinter.CompoundRoleIssuer);
             builder.UseSetting("Auth:Oidc:Issuers:1:Audience", JwtTokenMinter.TestAudience);
             builder.UseSetting("Auth:Oidc:Issuers:1:ScopeClaims:0", "roles");
             builder.UseSetting("Auth:Oidc:Issuers:1:TenantSource", "CompoundRole");
             builder.UseSetting("Auth:Oidc:Issuers:1:RoleSeparator", ":");
+            builder.UseSetting("Auth:Oidc:Issuers:1:JwksPath", _jwksPath);
 
             // Mock embeddings collapse distinct entries; disable dedup so per-row audit
             // attribution is real (mirrors ActorClassAuditTests).
             builder.UseSetting("Deduplication:Enabled", "false");
-
-            builder.ConfigureServices(services =>
-            {
-                // Preload OIDC config for the second scheme so JwtBearer skips the JWKS fetch.
-                services.PostConfigure<JwtBearerOptions>(JwtTokenMinter.CompoundRoleSchemeName, options =>
-                {
-                    options.Configuration = new OpenIdConnectConfiguration
-                    {
-                        Issuer = JwtTokenMinter.CompoundRoleIssuer
-                    };
-                    options.Configuration.SigningKeys.Add(JwtTokenMinter.SigningKey);
-                    options.TokenValidationParameters.IssuerSigningKey = JwtTokenMinter.SigningKey;
-                    options.MetadataAddress = null!;
-                    options.ConfigurationManager = null;
-                });
-            });
         });
         return Task.CompletedTask;
     }
@@ -72,6 +61,8 @@ public class StaticIssuerCompoundRoleTests : IAsyncLifetime
     {
         await _factory.DisposeAsync();
         await _baseFactory.DisposeAsync();
+        if (File.Exists(_jwksPath))
+            File.Delete(_jwksPath);
     }
 
     private HttpClient CompoundRoleClient(string tenant, IEnumerable<string> scopes)
@@ -94,7 +85,7 @@ public class StaticIssuerCompoundRoleTests : IAsyncLifetime
     private static object UniquePayload() => new
     {
         domain = "shared",
-        title = $"ADR-014 static-issuer fixture {Guid.NewGuid():N}",
+        title = $"ADR-015 static-issuer fixture {Guid.NewGuid():N}",
         body = $"Body for a compound-role authorization test ({Guid.NewGuid()}).",
         entryType = "Pattern",
         severity = "Info",
@@ -102,9 +93,10 @@ public class StaticIssuerCompoundRoleTests : IAsyncLifetime
     };
 
     [Fact]
-    public async Task CompoundRoleToken_WithReadScope_AuthorizesListEndpoint()
+    public async Task EmbeddedKeyToken_WithReadScope_AuthorizesListEndpoint()
     {
-        // Read scope carried as "test:expertise.read" → ReadAccess policy satisfied.
+        // Read scope carried as "test:expertise.read" → ReadAccess policy satisfied, validated
+        // against the embedded JWKS with no discovery fetch.
         var client = CompoundRoleClient("test", [AuthConstants.ReadScope]);
 
         var response = await client.GetAsync("/expertise");
@@ -114,11 +106,12 @@ public class StaticIssuerCompoundRoleTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task CompoundRoleToken_WriteDraftAndAgent_CreatesInDerivedTenant_AndTagsAgent()
+    public async Task EmbeddedKeyToken_WriteDraftAndAgent_CreatesInDerivedTenant_AndTagsAgent()
     {
         // roles: ["test:expertise.write.draft", "test:expertise.agent"].
-        // Proves the full pipeline: roles-array extraction → CompoundRole parse (tenant=test)
-        // → scope closure (write.draft ⊇ read) → actor-class (agent scope) → tenant attribution.
+        // Proves the full pipeline: embedded-key validation → roles-array extraction →
+        // CompoundRole parse (tenant=test) → scope closure (write.draft ⊇ read) →
+        // actor-class (agent scope) → tenant attribution.
         var client = CompoundRoleClient("test", [AuthConstants.WriteDraftScope, AuthConstants.AgentScope]);
 
         var create = await client.PostAsJsonAsync("/expertise", UniquePayload());
@@ -137,7 +130,7 @@ public class StaticIssuerCompoundRoleTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task CompoundRoleToken_WithoutWriteScope_IsForbiddenOnCreate()
+    public async Task EmbeddedKeyToken_WithoutWriteScope_IsForbiddenOnCreate()
     {
         // Read-only token must NOT satisfy WriteAccess — authorization is enforced, not just parsed.
         var client = CompoundRoleClient("test", [AuthConstants.ReadScope]);

--- a/tests/ExpertiseApi.Tests/Integration/StaticIssuerCompoundRoleTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/StaticIssuerCompoundRoleTests.cs
@@ -1,9 +1,11 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Security.Cryptography;
 using ExpertiseApi.Auth;
 using ExpertiseApi.Tests.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.IdentityModel.Tokens;
 
 namespace ExpertiseApi.Tests.Integration;
 
@@ -138,5 +140,23 @@ public class StaticIssuerCompoundRoleTests : IAsyncLifetime
         var response = await client.PostAsJsonAsync("/expertise", UniquePayload());
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task EmbeddedKeyToken_SignedWithKeyNotInJwks_IsUnauthorized()
+    {
+        // Revocation mechanism: a token signed with a key whose kid is absent from the embedded
+        // JWKS must be rejected (dropping a client's key + restart is how ADR-015 revokes it).
+        using var foreignKey = RSA.Create(2048);
+        var token = JwtTokenMinter.MintCompoundRole(
+            "test",
+            [AuthConstants.ReadScope],
+            signingKey: new RsaSecurityKey(foreignKey) { KeyId = "not-in-jwks" });
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await client.GetAsync("/expertise");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 }

--- a/tests/ExpertiseApi.Tests/Unit/AuthModeStartupGuardTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/AuthModeStartupGuardTests.cs
@@ -239,6 +239,78 @@ public class AuthModeStartupGuardTests
         }
     }
 
+    [Fact]
+    public void LoadStaticSigningKeys_PrivateKeyMaterial_FailsClosed()
+    {
+        // Operator footgun: JwksPath points at mint_token.py's *.priv.json (private key) instead
+        // of the build-jwks public output. Must fail closed, not load a forging key into the API.
+        var path = Path.Combine(Path.GetTempPath(), $"private-jwks-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, Infrastructure.JwtTokenMinter.PrivateJwksJson());
+        try
+        {
+            var issuer = new OidcIssuerOptions
+            {
+                Name = "LanStatic",
+                Issuer = "https://static-issuer.local/",
+                Audience = "expertise-api",
+                JwksPath = path
+            };
+
+            var act = () => AuthExtensions.LoadStaticSigningKeys(issuer);
+
+            act.Should().Throw<InvalidOperationException>().WithMessage("*PRIVATE key material*");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void LoadStaticSigningKeys_RealMintTokenOutput_LoadsSuccessfully()
+    {
+        // Proves scripts/mint_token.py's ACTUAL `build-jwks` output shape (alg/e/kid/kty/n/use,
+        // public-only) is consumable by the production loader — locking the Python-tool ↔ API
+        // config contract that the C#-side StaticJwksJson() helper alone would not guarantee.
+        var path = Path.Combine(Path.GetTempPath(), $"real-jwks-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, RealMintTokenJwks);
+        try
+        {
+            var issuer = new OidcIssuerOptions
+            {
+                Name = "LanStatic",
+                Issuer = "https://auth.lan.example/",
+                Audience = "expertise-api",
+                JwksPath = path
+            };
+
+            var keys = AuthExtensions.LoadStaticSigningKeys(issuer);
+
+            keys.Should().ContainSingle();
+            keys[0].KeyId.Should().Be("vm-alpha");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    // Verbatim output of `scripts/mint_token.py build-jwks` (public-only), captured 2026-07-10.
+    private const string RealMintTokenJwks = """
+        {
+          "keys": [
+            {
+              "alg": "RS256",
+              "e": "AQAB",
+              "kid": "vm-alpha",
+              "kty": "RSA",
+              "n": "2Cy1UNsX24KYM-Sqo6qAY5XFPa68v1fgUKMCf2qgUTx2-eHz3Tfs1iIusxrQfaAKzMIbaSwWhP5MExqWP-0O6vexZktmU2erTICZNzbielVeMwR0iZI5TmZYEwj2upr8Eprf8ujKAKFeQZ8SNd6pa1NgKdc9IDVhgT5GiXSoIx-89e0Ns4JdZnqp7D23AC9l3V2bYu6MATANXa7A8oXp4QqpXA3UIe5OT4k5c-HEcngP_vmMVCnrSLd6pNxAhvMZ--67wipjTYRJzg-iE2hNSAWFmehnHGyE5-C58mqbMydUG4aAE34QiwmvHGhmPrWyUX9Gykco3vUWe42InpO-gw",
+              "use": "sig"
+            }
+          ]
+        }
+        """;
+
     private class HostingEnvironment : IHostEnvironment
     {
         public string EnvironmentName { get; set; } = Environments.Development;

--- a/tests/ExpertiseApi.Tests/Unit/AuthModeStartupGuardTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/AuthModeStartupGuardTests.cs
@@ -146,6 +146,99 @@ public class AuthModeStartupGuardTests
         act.Should().NotThrow();
     }
 
+    [Fact]
+    public void LoadStaticSigningKeys_MissingFile_FailsClosed()
+    {
+        // ADR-015: an embedded-key issuer whose JWKS file is absent must fail startup, not 500
+        // on first request. This is the embedded-key analogue of EnforceOidcIssuersGuard.
+        var issuer = new OidcIssuerOptions
+        {
+            Name = "LanStatic",
+            Issuer = "https://static-issuer.local/",
+            Audience = "expertise-api",
+            JwksPath = Path.Combine(Path.GetTempPath(), $"does-not-exist-{Guid.NewGuid():N}.json")
+        };
+
+        var act = () => AuthExtensions.LoadStaticSigningKeys(issuer);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*could not be read*");
+    }
+
+    [Fact]
+    public void LoadStaticSigningKeys_EmptyKeySet_FailsClosed()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"empty-jwks-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, "{\"keys\":[]}");
+        try
+        {
+            var issuer = new OidcIssuerOptions
+            {
+                Name = "LanStatic",
+                Issuer = "https://static-issuer.local/",
+                Audience = "expertise-api",
+                JwksPath = path
+            };
+
+            var act = () => AuthExtensions.LoadStaticSigningKeys(issuer);
+
+            act.Should().Throw<InvalidOperationException>().WithMessage("*no signing keys*");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void LoadStaticSigningKeys_MalformedJson_FailsClosed()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"bad-jwks-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, "this is not json");
+        try
+        {
+            var issuer = new OidcIssuerOptions
+            {
+                Name = "LanStatic",
+                Issuer = "https://static-issuer.local/",
+                Audience = "expertise-api",
+                JwksPath = path
+            };
+
+            var act = () => AuthExtensions.LoadStaticSigningKeys(issuer);
+
+            act.Should().Throw<InvalidOperationException>();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void LoadStaticSigningKeys_ValidJwks_ReturnsKeys()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"good-jwks-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, Infrastructure.JwtTokenMinter.StaticJwksJson());
+        try
+        {
+            var issuer = new OidcIssuerOptions
+            {
+                Name = "LanStatic",
+                Issuer = "https://static-issuer.local/",
+                Audience = "expertise-api",
+                JwksPath = path
+            };
+
+            var keys = AuthExtensions.LoadStaticSigningKeys(issuer);
+
+            keys.Should().ContainSingle();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
     private class HostingEnvironment : IHostEnvironment
     {
         public string EnvironmentName { get; set; } = Environments.Development;


### PR DESCRIPTION
## Summary

Switches the LAN OIDC issuer from ADR-014's Option C (static discovery doc + HTTPS `jwks_uri` fetch) to **Option D — embedded static JWKS** (ADR-015), and lands the deployment artifacts. Chosen after A2-integration research found the HTTPS-metadata fetch imposes a per-platform internal-CA-trust burden on the **API host** (Linux `update-ca-certificates` vs macOS Keychain — .NET 10 dropped OpenSSL on macOS) with a lazy-fetch → 500 blind spot. Embedding the keys deletes that entire problem on the API host; CA trust moves to the **consumer** side.

**Closes #382.** Unblocks #394 (install.sh secrets-stub enrichment, deferred).

## Code (per-issuer, additive)

- `OidcIssuerOptions.JwksPath` — when set, `AuthExtensions.RegisterJwtBearer` loads the local JWKS into `IssuerSigningKeys`, preloads `Configuration`, and leaves `Authority` unset (no network fetch). Cloud issuers (Entra/Authentik) keep the discovery path unchanged.
- `LoadStaticSigningKeys` runs at **startup** and fails closed on missing/unreadable/malformed/empty JWKS — and **rejects private-key material** (the `*.priv.json` footgun).

## Artifacts & docs

- `scripts/mint_token.py` (keygen / build-jwks / sign; key-dir `chmod 0700`).
- `deploy/lan-static-oidc/` — native `Caddyfile` (API inbound TLS only) + containerized step-ca `compose.yaml` + `RUNBOOK.md` (per-platform **consumer-side** CA trust + protected-endpoint verify).
- ADR-015 (new); ADR-014 → superseded (mechanism only); README §A2; `appsettings.json` `LanStatic` → `JwksPath`.

## Review gate

`security-review-expert` + `code-review-expert` both **PASS_WITH_WARNINGS** (no Critical/Error). All warnings fixed in this PR:

| Finding | Fix |
|---|---|
| Loader accepted a private JWKS | reject `d`/`p`/`q` material, fail closed |
| `mint_token.py` key **dir** world-listable | `chmod 0700` |
| No `kid`-mismatch negative test | foreign-key → 401 test |
| Python JWKS shape untested | real `build-jwks` output inlined + parse test |

`ValidAlgorithms` pin (Info) accepted-not-fixed: `JsonWebKeySet.GetSigningKeys()` returns no symmetric keys, so alg-confusion isn't reachable.

## Verification

- 52 auth tests pass (podman/Testcontainers): 4 embedded-key integration cases (real `JwksPath`), 6 fail-closed startup guards incl. private-key + real-output, plus the existing JwtAuthentication/ActorClassAudit suites — no regression.
- `dotnet build` 0/0; `dotnet format analyzers --verify-no-changes` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
