### PR TITLE
docs(install): add lan static-oidc guidance to secrets stub

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -741,8 +741,16 @@ ensure_config_stubs() {
 # EnvironmentFile= parser is literal and tolerates the unquoted form, but
 # the launchd-on-macOS path and the migrate scripts both use the bash sourcer.
 #
-# When Auth:Mode=Oidc, populate per-issuer overrides via Auth__Oidc__Issuers__N__*
-# environment variables — see appsettings.json for the shape.
+# When Auth:Mode=Oidc (the default outside Development), populate per-issuer
+# overrides via Auth__Oidc__Issuers__N__* env vars — see appsettings.json for the
+# shape. For the shipped LAN static issuer (index 2 = "LanStatic", ADR-015 embedded
+# JWKS), a networked A2 instance consumed by LAN clients needs:
+#   Auth__Oidc__Issuers__2__Issuer="https://auth.lan.example/"   # byte-exact w/ token iss
+#   Auth__Oidc__Issuers__2__JwksPath="${CONFIG_DIR}/jwks.json"   # local public JWKS; no HTTPS fetch
+#   AllowedHosts="your-lan-hostname"                             # else HostFiltering 400s the LAN Host
+#   ForwardedHeaders__KnownNetworks__0="10.0.0.0/24"             # proxy CIDR; else audit IP = the proxy
+# and a non-loopback bind (default is 127.0.0.1:8080): scripts/install.sh --bind 0.0.0.0:8080
+# Full runbook: deploy/lan-static-oidc/RUNBOOK.md
 #
 # Aggregator up-sync (ADR-013, spoke role only — leave unset for a standalone
 # instance). The hub credential must carry expertise.write.draft ONLY:


### PR DESCRIPTION
## Summary

Enriches the `secrets.env` stub that `install.sh` generates with concrete LAN-consumer OIDC guidance — completing ADR-014/ADR-015's implementation note that never landed.

**Closes #394.**

## Change

Replaces the terse two-line `Auth__Oidc__Issuers__N__*` pointer in `ensure_config_stubs` with commented, copy-pasteable guidance naming the shipped `LanStatic` issuer (index 2) and the three things a networked A2 instance actually needs:

- `Auth__Oidc__Issuers__2__Issuer` + `__JwksPath` (ADR-015 embedded JWKS)
- `AllowedHosts` (else HostFiltering 400s the LAN `Host:`)
- `ForwardedHeaders__KnownNetworks__0` (else audit IP = the proxy)
- the non-loopback `--bind` reminder (default is `127.0.0.1:8080`)
- a pointer to `deploy/lan-static-oidc/RUNBOOK.md`

`${CONFIG_DIR}` interpolates at install time, so the operator sees the exact path to drop `jwks.json`.

## Verification

- `bash -n` + `shellcheck` clean; heredoc `${CONFIG_DIR}` interpolation verified.
- Comment-only change to the stub heredoc; no test asserts stub content (the upgrade-roundtrip test seeds its own `secrets.env`). CI install-smoke/guard jobs cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)