### PR TITLE
fix(auth): harden embedded static-jwks issuer (adr-015)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,7 +458,7 @@ jobs:
         run: brew services stop postgresql@17 || true
 
   install-smoke-macos-system:
-    name: install.sh end-to-end smoke (macOS / LaunchDaemon / system scope / #145)
+    name: "install.sh end-to-end smoke (macOS / LaunchDaemon / system scope / #145)"
     runs-on: macos-latest
     # Non-blocking until the upstream Homebrew postgresql@17 bottle is fixed (#366).
     # REMOVE when #366 closes.

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,13 @@ src/ExpertiseApi/artifacts/
 
 ## pi extension node_modules
 .pi/extensions/*/node_modules/
+
+## Python bytecode cache (scripts/mint_token.py and any future helper scripts)
+__pycache__/
+*.pyc
+
+## mint_token.py (ADR-015) private key material — NEVER commit. The default KEY_DIR is
+## ./keys and per-client private keys are *.priv.json ("d" JWK material the PEM-oriented
+## secrets-guard does not detect). The API only ever loads the PUBLIC build-jwks output.
+keys/
+*.priv.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,6 +321,7 @@ Notes:
 - **Trailing slash on `Issuer`** must match the `iss` claim byte-exactly. Authentik includes one; Entra v2 does not. Copy from `.well-known/openid-configuration` verbatim.
 - **`TenantSource = "CompoundRole"`** is for Entra `client_credentials` flow, which does not emit `groups` for service principals. Roles are encoded as `{tenant}:{scope}` and parsed at validation time.
 - **`TenantSource = "Groups"`** is for delegated flows (and Authentik). Group claim values are mapped to tenant slugs.
+- **`JwksPath`** (ADR-014/ADR-015) — for LAN/offline issuers with no HTTPS discovery endpoint. Point it at a **public-only** `jwks.json` (produced by `scripts/mint_token.py build-jwks`); the API loads those keys at startup and skips `.well-known`/`Authority` discovery entirely (`Authority` is left unset for that issuer). Loaded **fail-closed**: a missing, malformed, private-key, or symmetric (`kty=oct`) JWKS aborts boot rather than 500ing on first request. Leave unset for cloud issuers (Entra/Authentik), which discover keys via `Authority`. The embedded-key path is pinned to RS256. See `deploy/lan-static-oidc/RUNBOOK.md`.
 
 ### LocalDev token format
 

--- a/README.md
+++ b/README.md
@@ -925,6 +925,7 @@ Adding the label is an explicit human decision recorded on the PR. Anyone with `
 | Cosign-signed published tarball over SDK-on-host for Archetype A2 install | [ADR-011](adrs/011-deployment-artifact-format.md) |
 | Application-level signed + encrypted backup artifact (format, trust policy) | [ADR-012](adrs/012-backup-artifact-format.md) |
 | Aggregator up-sync: draft-only scope as the knowledge-supply-chain control | [ADR-013](adrs/013-aggregator-upsync.md) |
+| LAN/offline embedded static-JWKS issuer (no HTTPS discovery on the API host; fail-closed key load) | [ADR-015](adrs/015-embedded-static-jwks.md) (supersedes [ADR-014](adrs/014-lightweight-oidc-static-jwks.md)) |
 
 ## License
 

--- a/scripts/mint_token.py
+++ b/scripts/mint_token.py
@@ -56,8 +56,14 @@ def keygen(a):
     if os.path.exists(path) and not a.force:
         sys.exit(f"{path} exists; pass --force to overwrite (rotates the client's key)")
     key = jwk.JWK.generate(kty="RSA", size=2048, kid=kid_for(a.client), use="sig", alg="RS256")
-    with open(path, "w") as f: f.write(key.export_private())
-    os.chmod(path, 0o600)
+    # Create the private-key file pre-restricted (0o600) instead of chmod-after-write, which would
+    # leave a brief TOCTOU window where the key inherits the umask default (often world/group
+    # readable). The existence/rotation gate above already owns overwrite intent (--force), so
+    # O_TRUNC replaces in place; O_EXCL is intentionally not used because rotation overwrites.
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as f:
+        f.write(key.export_private())
+    os.chmod(path, 0o600)  # re-assert mode on the rotate path (O_CREAT keeps a pre-existing file's perms)
     print(f"wrote {path} (kid={kid_for(a.client)})")
 
 def build_jwks(a):
@@ -73,10 +79,23 @@ def sign(a):
     path = os.path.join(KEY_DIR, f"{a.client}.priv.json")
     key = jwk.JWK.from_json(open(path).read())
     roles = []
+    privileged = []
     for s in a.scopes.split(","):
         s = s.strip()
         full = SCOPE_MAP.get(s, s)
+        if full in ("expertise.write.approve", "expertise.admin"):
+            privileged.append(full)
         roles.append(f"{a.tenant}:{full}")
+    # ADR-003/ADR-015: write.approve / admin must never be handed to an unattended M2M client.
+    # A stray `--scopes approve` (typo, copy-paste, automation) would otherwise silently mint a
+    # long-lived privileged credential. Require an explicit opt-in flag for attended/admin tokens.
+    if privileged and not a.allow_privileged:
+        sys.exit(
+            f"refusing to mint privileged scope(s) {privileged} for client '{a.client}': "
+            "expertise.write.approve / expertise.admin must not be granted to unattended M2M "
+            "clients (ADR-003/ADR-015). Re-run with --allow-privileged only if this is an "
+            "attended/administrative token you are issuing deliberately."
+        )
     now = int(time.time())
     claims = {
         "iss": ISSUER, "aud": AUDIENCE, "sub": a.client,
@@ -91,5 +110,5 @@ p = argparse.ArgumentParser(description="Offline JWT minter + JWKS builder (ADR-
 sub = p.add_subparsers(required=True)
 g = sub.add_parser("keygen"); g.add_argument("--client", required=True); g.add_argument("--force", action="store_true"); g.set_defaults(fn=keygen)
 b = sub.add_parser("build-jwks"); b.add_argument("--out", default="oidc/jwks.json"); b.set_defaults(fn=build_jwks)
-s = sub.add_parser("sign"); s.add_argument("--client", required=True); s.add_argument("--tenant", required=True); s.add_argument("--scopes", required=True); s.add_argument("--ttl-days", type=int, default=7); s.set_defaults(fn=sign)
+s = sub.add_parser("sign"); s.add_argument("--client", required=True); s.add_argument("--tenant", required=True); s.add_argument("--scopes", required=True); s.add_argument("--ttl-days", type=int, default=7); s.add_argument("--allow-privileged", action="store_true", help="required to mint expertise.write.approve / expertise.admin (ADR-003/ADR-015)"); s.set_defaults(fn=sign)
 a = p.parse_args(); a.fn(a)

--- a/src/ExpertiseApi/Auth/AuthExtensions.cs
+++ b/src/ExpertiseApi/Auth/AuthExtensions.cs
@@ -196,6 +196,14 @@ internal static class AuthExtensions
                 options.Configuration = configuration;
                 options.ConfigurationManager = null;
                 options.TokenValidationParameters.IssuerSigningKeys = staticSigningKeys;
+
+                // Pin RS256 for the embedded-key path (mint_token.py emits RS256 only). Defense in
+                // depth: it constrains signature validation to the asymmetric algorithm these keys
+                // are for, so even a mis-provisioned symmetric/other-alg key that slipped past
+                // LoadStaticSigningKeys' screen cannot validate a forged token via alg substitution.
+                // Cloud/discovery issuers keep their metadata-driven algorithm set (unset here) so an
+                // IdP that signs with ES256/PS256 is not broken.
+                options.TokenValidationParameters.ValidAlgorithms = [SecurityAlgorithms.RsaSha256];
             }
             else
             {
@@ -258,6 +266,24 @@ internal static class AuthExtensions
                     $"Auth:Oidc issuer '{issuer.Name}' JwksPath '{issuer.JwksPath}' contains PRIVATE key material " +
                     $"(kid '{jwk.Kid}'). The API must load a PUBLIC-only JWKS — run 'mint_token.py build-jwks' to " +
                     "produce one; never point JwksPath at a *.priv.json file or the private key directory.");
+            }
+
+            // Reject symmetric (HMAC) keys. A `kty=oct` JWK carries its shared secret in `k`, and
+            // JsonWebKeySet.GetSigningKeys() surfaces it as a usable SymmetricSecurityKey
+            // (SkipUnresolvedJsonWebKeys defaults to false) — so anyone able to read this
+            // network-facing "public" JWKS could forge HS256 tokens the API would accept. An
+            // embedded-key issuer is RS256-only by construction (mint_token.py emits RSA), so any
+            // oct key is a misconfiguration: fail closed rather than load a forgeable secret. The
+            // ValidAlgorithms=RS256 pin on the static path is the compensating control if this is
+            // ever reached, but the shared secret has no business in the file at all.
+            if (string.Equals(jwk.Kty, "oct", StringComparison.OrdinalIgnoreCase)
+                || !string.IsNullOrEmpty(jwk.K))
+            {
+                throw new InvalidOperationException(
+                    $"Auth:Oidc issuer '{issuer.Name}' JwksPath '{issuer.JwksPath}' contains a SYMMETRIC (kty=oct) " +
+                    $"key (kid '{jwk.Kid}'). Embedded-key issuers are RS256-only (asymmetric); a shared-secret key " +
+                    "in a network-facing JWKS is forgeable by anyone who can read the file. Provide an RSA public " +
+                    "JWKS from 'mint_token.py build-jwks'.");
             }
         }
 

--- a/tests/ExpertiseApi.Tests/Unit/AuthModeStartupGuardTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/AuthModeStartupGuardTests.cs
@@ -272,7 +272,7 @@ public class AuthModeStartupGuardTests
         // A symmetric (kty=oct) JWK carries a shared secret in `k`. Loading it into a
         // network-facing JWKS would let anyone who can read the file forge HS256 tokens the API
         // accepts. Embedded-key issuers are RS256-only, so this must fail closed at startup.
-        var path = Path.Combine(Path.GetTempPath(), $"oct-jwks-{Guid.NewGuid():N}.json");
+        var path = Path.Join(Path.GetTempPath(), $"oct-jwks-{Guid.NewGuid():N}.json");
         File.WriteAllText(path, """
             { "keys": [ { "kty": "oct", "kid": "sym-1", "alg": "HS256", "use": "sig",
               "k": "c2VjcmV0LXNoYXJlZC1obWFjLWtleS1tYXRlcmlhbA" } ] }

--- a/tests/ExpertiseApi.Tests/Unit/AuthModeStartupGuardTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/AuthModeStartupGuardTests.cs
@@ -267,6 +267,37 @@ public class AuthModeStartupGuardTests
     }
 
     [Fact]
+    public void LoadStaticSigningKeys_SymmetricKeyMaterial_FailsClosed()
+    {
+        // A symmetric (kty=oct) JWK carries a shared secret in `k`. Loading it into a
+        // network-facing JWKS would let anyone who can read the file forge HS256 tokens the API
+        // accepts. Embedded-key issuers are RS256-only, so this must fail closed at startup.
+        var path = Path.Combine(Path.GetTempPath(), $"oct-jwks-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, """
+            { "keys": [ { "kty": "oct", "kid": "sym-1", "alg": "HS256", "use": "sig",
+              "k": "c2VjcmV0LXNoYXJlZC1obWFjLWtleS1tYXRlcmlhbA" } ] }
+            """);
+        try
+        {
+            var issuer = new OidcIssuerOptions
+            {
+                Name = "LanStatic",
+                Issuer = "https://static-issuer.local/",
+                Audience = "expertise-api",
+                JwksPath = path
+            };
+
+            var act = () => AuthExtensions.LoadStaticSigningKeys(issuer);
+
+            act.Should().Throw<InvalidOperationException>().WithMessage("*SYMMETRIC*");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public void LoadStaticSigningKeys_RealMintTokenOutput_LoadsSuccessfully()
     {
         // Proves scripts/mint_token.py's ACTUAL `build-jwks` output shape (alg/e/kid/kty/n/use,


### PR DESCRIPTION
## Summary

Pre-release hardening surfaced by a full multi-agent review of the `dev`→`main` delta (ADR-015 embedded static-JWKS issuer). No blocking defects were found in the release; these are the actionable hardening + doc-sync items from that review. All findings addressed here are Warning-level or hygiene — the release was already clear to promote.

## Changes

**Auth hardening (`Auth/AuthExtensions.cs`)**
- `LoadStaticSigningKeys` now rejects symmetric `kty=oct` / `k` keys. Previously the public-only guard screened RSA/EC private components (`d`/`p`/`q`) but not a symmetric secret, which `JsonWebKeySet.GetSigningKeys()` would surface as a usable HMAC signing key — forgeable by anyone able to read the network-facing JWKS.
- Embedded-key path pinned to `ValidAlgorithms=["RS256"]` (defense-in-depth against alg substitution). **Cloud/discovery issuers are deliberately untouched**, so IdPs signing with ES256/PS256 are not broken.

**Token minter (`scripts/mint_token.py`)**
- Private-key files are created pre-restricted via `os.open(..., 0o600)` instead of `chmod`-after-write, closing a TOCTOU window where the key briefly inherited the umask default.
- `sign` refuses `expertise.write.approve` / `expertise.admin` unless `--allow-privileged` is passed, so a stray `--scopes approve` cannot silently mint a privileged unattended-client credential (ADR-003/ADR-015).

**Hygiene**
- `.gitignore`: `__pycache__/`·`*.pyc`, plus `keys/`·`*.priv.json` — mint_token private JWK material (`"d"` fields) that the PEM-oriented secrets-guard does not detect.
- `.github/workflows/ci.yml`: quoted the job `name:` so ` #145` is no longer parsed as a YAML inline comment (it was silently truncating the job name in the Actions UI).

## Documentation impact (doc-sync)

| Surface | Classification | Note |
|---|---|---|
| `CLAUDE.md` OIDC-issuers reference | in-scope | Added `JwksPath` (fail-closed load, RS256, public-only) |
| `README.md` Security table | in-scope | Added ADR-014/015 row |
| ADR | not-a-thing | Hardens the already-decided ADR-015 design; no new convention |

## Test evidence

- `dotnet build -c Release` → 0 warnings / 0 errors
- New unit test `LoadStaticSigningKeys_SymmetricKeyMaterial_FailsClosed`; startup-guard suite 33/33; full unit filter 235/236 (the 1 failure is Testcontainers→Docker unavailable in this local run, unchanged from baseline)
- `dotnet format analyzers` + `style --verify-no-changes` → clean (CI Format gate)
- Python privileged-scope guard exercised: `read`→mint, `approve`/`admin`→refuse, `approve --allow-privileged`→mint

## Deferred (not in this PR)

Info-level / deployment-reference items from the review left for a follow-up: `step-ca` digest-pinning in the reference compose, runbook `jwks.json` permission + reserved-tenant callouts, and `mint_token.py` ruff style debt (not an enforced gate).