### PR TITLE
chore(release): promote dev to main (adr-015 static jwks + hardening)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,15 @@ updates:
       # AwesomeAssertions (Apache 2.0 community fork). Any future Dependabot PR
       # that tries to re-add FluentAssertions must be rejected.
       - dependency-name: "FluentAssertions"
+      # Microsoft.OpenApi is a direct security pin held at the 2.x major (see
+      # src/ExpertiseApi/ExpertiseApi.csproj). The 3.x major made
+      # IOpenApiMediaType.Example read-only, which the Microsoft.AspNetCore.OpenApi
+      # 10.0.x source generator still assigns to (CS0200 build failure). Ignore
+      # only the major bump so 2.x minor/patch security updates keep flowing.
+      # Drop this once Microsoft.AspNetCore.OpenApi's generator supports 3.x (#390).
+      - dependency-name: "Microsoft.OpenApi"
+        update-types:
+          - "version-update:semver-major"
     groups:
       ef-core:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,7 +46,7 @@ updates:
     groups:
       codeql-action:
         patterns:
-          - "github/codeql-action"
+          - "github/codeql-action*"
 
   - package-ecosystem: docker
     directory: /

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           global-json-file: global.json
 
@@ -380,7 +380,7 @@ jobs:
         # The install.sh path on macOS runs `dotnet publish` against the
         # repo's csproj, so the SDK (not just the runtime) must match
         # global.json. Matches the Build & Test job above.
-        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           global-json-file: global.json
 
@@ -475,7 +475,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           global-json-file: global.json
 
@@ -552,7 +552,7 @@ jobs:
           path: base
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           global-json-file: head/global.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Helm
-        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
           version: v3.18.3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,7 +458,7 @@ jobs:
         run: brew services stop postgresql@17 || true
 
   install-smoke-macos-system:
-    name: install.sh end-to-end smoke (macOS / LaunchDaemon / system scope / #145)
+    name: "install.sh end-to-end smoke (macOS / LaunchDaemon / system scope / #145)"
     runs-on: macos-latest
     # Non-blocking until the upstream Homebrew postgresql@17 bottle is fixed (#366).
     # REMOVE when #366 closes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           global-json-file: global.json
 
       - name: Cache NuGet packages
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
@@ -557,7 +557,7 @@ jobs:
           global-json-file: head/global.json
 
       - name: Cache NuGet packages
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.nuget/packages
           # Distinct from build-and-test cache (different working trees, both

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,6 +57,6 @@ jobs:
         run: dotnet build ExpertiseApi.slnx --configuration Release --no-restore --disable-build-servers
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: '/language:csharp'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           global-json-file: global.json
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,7 @@ jobs:
           global-json-file: global.json
 
       - name: Cache NuGet packages
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,7 +43,7 @@ jobs:
           restore-keys: nuget-${{ runner.os }}-
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: csharp
           build-mode: manual

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,6 +57,6 @@ jobs:
         run: dotnet build ExpertiseApi.slnx --configuration Release --no-restore --disable-build-servers
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           category: '/language:csharp'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,7 +43,7 @@ jobs:
           restore-keys: nuget-${{ runner.os }}-
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           languages: csharp
           build-mode: manual

--- a/.github/workflows/install-smoke-from-release.yml
+++ b/.github/workflows/install-smoke-from-release.yml
@@ -58,7 +58,7 @@ jobs:
         # Verification (cosign verify-blob) does not require id-token:write —
         # that is only needed for signing. The verifier contacts Rekor over
         # HTTPS using its public read API.
-        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Resolve latest release tag
         id: release
@@ -188,7 +188,7 @@ jobs:
           global-json-file: global.json
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Resolve latest release tag
         id: release

--- a/.github/workflows/install-smoke-from-release.yml
+++ b/.github/workflows/install-smoke-from-release.yml
@@ -183,7 +183,7 @@ jobs:
         # for the migrate step. The SDK (sdk ⊇ runtime) is installed so
         # rc_check_aspnetcore_runtime_floor passes and the migrate verb runs.
         # Matches the setup used by install-smoke-macos in ci.yml.
-        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           global-json-file: global.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
           test -f src/ExpertiseApi/artifacts/openapi/ExpertiseApi.json
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         with:
           platforms: arm64
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,7 @@ jobs:
       # it with the same keyless OIDC identity. Consumers can install via
       # `helm install foo oci://ghcr.io/thesemicolon/charts/expertise-api`.
       - name: Install Helm
-        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
           version: v3.18.3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
       # release attaches as a pinned asset for downstream integrators (#147, #148).
       # See docs/security/integration-threat-model.md Part D C8.
       - name: Setup .NET (for build-time OpenAPI emission)
-        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           global-json-file: global.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Cache ONNX model files
         id: model-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: src/ExpertiseApi/models
           key: onnx-bge-micro-v2-quantized-${{ hashFiles('scripts/download-models.sh') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,7 @@ jobs:
       # long-lived keys to manage; signatures land as adjacent OCI
       # artifacts (.sig) in GHCR. Verification recipe in README.
       - name: Install cosign
-        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign Docker image by digest (keyless)
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Upload Trivy SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           sarif_file: trivy-results.sarif
           category: trivy-fs
@@ -68,7 +68,7 @@ jobs:
 
       - name: Upload Hadolint SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           sarif_file: hadolint-results.sarif
           category: hadolint

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Upload Trivy SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           sarif_file: trivy-results.sarif
           category: trivy-fs
@@ -68,7 +68,7 @@ jobs:
 
       - name: Upload Hadolint SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           sarif_file: hadolint-results.sarif
           category: hadolint

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ src/ExpertiseApi/Models/tokenizer*.json
 ## Claude Code worktrees
 .claude/worktrees/
 
+## Claude Code per-agent runtime memory (subagent scratch; not part of the repo)
+.claude/agent-memory/
+
 ## Part D C8: build-time OpenAPI document emission (Microsoft.Extensions.ApiDescription.Server)
 ## Output of _GenerateOpenApiDocuments MSBuild target; published as a GitHub Release asset via release.yml.
 src/ExpertiseApi/artifacts/

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,13 @@ src/ExpertiseApi/artifacts/
 
 ## pi extension node_modules
 .pi/extensions/*/node_modules/
+
+## Python bytecode cache (scripts/mint_token.py and any future helper scripts)
+__pycache__/
+*.pyc
+
+## mint_token.py (ADR-015) private key material — NEVER commit. The default KEY_DIR is
+## ./keys and per-client private keys are *.priv.json ("d" JWK material the PEM-oriented
+## secrets-guard does not detect). The API only ever loads the PUBLIC build-jwks output.
+keys/
+*.priv.json

--- a/.pi/extensions/expertise-api/package-lock.json
+++ b/.pi/extensions/expertise-api/package-lock.json
@@ -3808,9 +3808,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,6 +321,7 @@ Notes:
 - **Trailing slash on `Issuer`** must match the `iss` claim byte-exactly. Authentik includes one; Entra v2 does not. Copy from `.well-known/openid-configuration` verbatim.
 - **`TenantSource = "CompoundRole"`** is for Entra `client_credentials` flow, which does not emit `groups` for service principals. Roles are encoded as `{tenant}:{scope}` and parsed at validation time.
 - **`TenantSource = "Groups"`** is for delegated flows (and Authentik). Group claim values are mapped to tenant slugs.
+- **`JwksPath`** (ADR-014/ADR-015) — for LAN/offline issuers with no HTTPS discovery endpoint. Point it at a **public-only** `jwks.json` (produced by `scripts/mint_token.py build-jwks`); the API loads those keys at startup and skips `.well-known`/`Authority` discovery entirely (`Authority` is left unset for that issuer). Loaded **fail-closed**: a missing, malformed, private-key, or symmetric (`kty=oct`) JWKS aborts boot rather than 500ing on first request. Leave unset for cloud issuers (Entra/Authentik), which discover keys via `Authority`. The embedded-key path is pinned to RS256. See `deploy/lan-static-oidc/RUNBOOK.md`.
 
 ### LocalDev token format
 

--- a/README.md
+++ b/README.md
@@ -447,8 +447,10 @@ The lightweight local defaults above assume loopback. To let **other hosts on yo
 LAN** (e.g. container VMs running agents) consume one A2 instance, three things
 change — and because `Auth:Mode` is hard-`Oidc` outside Development, you need an
 OIDC issuer. You do **not** need a full identity provider. See
-[ADR-014](adrs/014-lightweight-oidc-static-jwks.md) for the decision and
-trade-offs; the short version:
+[ADR-015](adrs/015-embedded-static-jwks.md) (which supersedes
+[ADR-014](adrs/014-lightweight-oidc-static-jwks.md)) for the decision, and
+[`deploy/lan-static-oidc/`](deploy/lan-static-oidc/RUNBOOK.md) for the turnkey
+runbook. The short version:
 
 1. **Bind off loopback.** `scripts/install.sh --bind 0.0.0.0:8080` (or a specific
    LAN interface IP). Remote clients target the host's **LAN IP**, not
@@ -458,20 +460,26 @@ trade-offs; the short version:
    to a remote `Host:` — set `AllowedHosts=<your-lan-hostname>` in `secrets.env`,
    and add the reverse proxy's network to `ForwardedHeaders__KnownNetworks__0` so
    audit IPs are the real client, not the proxy.
-3. **Terminate TLS.** Nothing in the A2 path serves HTTPS. Front the API (and the
-   static issuer below) with a reverse proxy (Caddy) using an internal ACME CA
-   (step-ca) — HTTP-01/TLS-ALPN-01 work LAN-to-LAN with no public DNS. Distribute
-   the CA root to the API host **and** every consumer VM, or TLS fails closed.
+3. **Terminate TLS.** Nothing in the A2 path serves HTTPS. Front the API with a
+   reverse proxy (Caddy, run natively) using an internal ACME CA (step-ca) —
+   TLS-ALPN-01 works LAN-to-LAN with no public DNS. Distribute the CA root to
+   **every consumer VM** so they trust the API's endpoint. Under ADR-015 the
+   **API host itself trusts no CA** (it performs no metadata fetch).
 
-**The issuer, without a daemon:** serve a static `.well-known/openid-configuration`
-+ `jwks.json` over HTTPS (the same proxy can host them), mint per-client RS256 JWTs
-offline carrying a `{tenant}:{scope}` `roles` claim, and add a `LanStatic` entry to
-`Auth:Oidc:Issuers[]` (`TenantSource: CompoundRole`, `RoleSeparator: ":"`). The
-existing scope ([ADR-003](adrs/003-scope-split.md)) and actor-class
+**The issuer, without a daemon or an HTTPS endpoint:** mint per-client RS256 JWTs
+offline (`scripts/mint_token.py`) carrying a `{tenant}:{scope}` `roles` claim, build
+a public `jwks.json`, and point the shipped `LanStatic` issuer
+(`Auth:Oidc:Issuers[2]`, `TenantSource: CompoundRole`, `RoleSeparator: ":"`) at that
+file via `Auth__Oidc__Issuers__2__JwksPath`. The API loads the keys at startup and
+validates **with no discovery fetch** (ADR-015 embedded JWKS) — so there is no
+`.well-known` endpoint to host and no backchannel CA trust on the API host; a
+missing/empty JWKS fails startup closed. The existing scope
+([ADR-003](adrs/003-scope-split.md)) and actor-class
 ([ADR-008](adrs/008-response-hygiene-and-actor-class.md)) semantics apply to minted
-tokens unchanged — no code change. Never mint `expertise.write.approve` for an
-unattended client. When you outgrow manual key rotation or need synchronous
-revocation, escalate to a headless OP (Ory Hydra) — config-only on the API side.
+tokens unchanged. Never mint `expertise.write.approve` for an unattended client.
+Rotation is edit-`jwks.json` + restart (not zero-downtime); when you outgrow that or
+need synchronous revocation, escalate to a headless OP (Ory Hydra) — config-only on
+the API side.
 
 #### Survives reboot?
 

--- a/README.md
+++ b/README.md
@@ -925,6 +925,7 @@ Adding the label is an explicit human decision recorded on the PR. Anyone with `
 | Cosign-signed published tarball over SDK-on-host for Archetype A2 install | [ADR-011](adrs/011-deployment-artifact-format.md) |
 | Application-level signed + encrypted backup artifact (format, trust policy) | [ADR-012](adrs/012-backup-artifact-format.md) |
 | Aggregator up-sync: draft-only scope as the knowledge-supply-chain control | [ADR-013](adrs/013-aggregator-upsync.md) |
+| LAN/offline embedded static-JWKS issuer (no HTTPS discovery on the API host; fail-closed key load) | [ADR-015](adrs/015-embedded-static-jwks.md) (supersedes [ADR-014](adrs/014-lightweight-oidc-static-jwks.md)) |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -441,6 +441,38 @@ Every value is overridable. On macOS/Linux, set the same variable in
 e.g. `DOTNET_gcServer=1` or `Metrics__Enabled=true`. On Windows, edit the
 `Environment` `REG_MULTI_SZ` value on the service key and restart the service.
 
+#### Networked LAN consumers (OIDC without standing up an IdP)
+
+The lightweight local defaults above assume loopback. To let **other hosts on your
+LAN** (e.g. container VMs running agents) consume one A2 instance, three things
+change — and because `Auth:Mode` is hard-`Oidc` outside Development, you need an
+OIDC issuer. You do **not** need a full identity provider. See
+[ADR-014](adrs/014-lightweight-oidc-static-jwks.md) for the decision and
+trade-offs; the short version:
+
+1. **Bind off loopback.** `scripts/install.sh --bind 0.0.0.0:8080` (or a specific
+   LAN interface IP). Remote clients target the host's **LAN IP**, not
+   `host.docker.internal`.
+2. **Allow the LAN Host header.** The default `AllowedHosts`
+   (`localhost;127.0.0.1;[::1]`) makes ASP.NET Core's host-filtering return **400**
+   to a remote `Host:` — set `AllowedHosts=<your-lan-hostname>` in `secrets.env`,
+   and add the reverse proxy's network to `ForwardedHeaders__KnownNetworks__0` so
+   audit IPs are the real client, not the proxy.
+3. **Terminate TLS.** Nothing in the A2 path serves HTTPS. Front the API (and the
+   static issuer below) with a reverse proxy (Caddy) using an internal ACME CA
+   (step-ca) — HTTP-01/TLS-ALPN-01 work LAN-to-LAN with no public DNS. Distribute
+   the CA root to the API host **and** every consumer VM, or TLS fails closed.
+
+**The issuer, without a daemon:** serve a static `.well-known/openid-configuration`
++ `jwks.json` over HTTPS (the same proxy can host them), mint per-client RS256 JWTs
+offline carrying a `{tenant}:{scope}` `roles` claim, and add a `LanStatic` entry to
+`Auth:Oidc:Issuers[]` (`TenantSource: CompoundRole`, `RoleSeparator: ":"`). The
+existing scope ([ADR-003](adrs/003-scope-split.md)) and actor-class
+([ADR-008](adrs/008-response-hygiene-and-actor-class.md)) semantics apply to minted
+tokens unchanged — no code change. Never mint `expertise.write.approve` for an
+unattended client. When you outgrow manual key rotation or need synchronous
+revocation, escalate to a headless OP (Ory Hydra) — config-only on the API side.
+
 #### Survives reboot?
 
 | OS | Mode | Survives reboot? | Notes |

--- a/adrs/014-lightweight-oidc-static-jwks.md
+++ b/adrs/014-lightweight-oidc-static-jwks.md
@@ -1,0 +1,60 @@
+# Static JWKS + offline-minted JWTs as the lightweight OIDC issuer for A2/LAN consumption
+
+- Status: accepted
+- Date: 2026-07-08
+- Companion: [ADR-003](003-scope-split.md) (scope semantics that gate what a minted token can do), [ADR-005](005-multi-issuer-jwt-policy-scheme.md) (multi-issuer JWT plumbing reused verbatim), [ADR-008](008-response-hygiene-and-actor-class.md) (actor-class resolution from the token), [ADR-011](011-deployment-artifact-format.md) (the A2 native-service install this pairs with), [ADR-013](013-aggregator-upsync.md) (distinct: hub↔spoke up-sync keeps `client_credentials` on a shared IdP — NOT in scope here)
+- Tracking issue: [#382](https://github.com/psmfd/agent-expertise-api/issues/382)
+- Surfaced by: 2026-07-08 A2-networked-consumers design session (multi-agent fan-out across `expertise-api-owner`, `dotnet-expert`, `general-purpose`). User challenge — "are you taking the lightest-weight approach?" — drove the pivot away from a full IdP.
+
+## Context and Problem Statement
+
+An A2 native-service instance (ADR-011) is to be consumed over the LAN by a small, fixed roster (~3–5) of machine-to-machine (M2M) agent/VM clients. Outside `Development`, `AuthExtensions.EnforceModeGuard` hard-fails any `Auth:Mode` other than `Oidc`, and the install wrapper defaults `ASPNETCORE_ENVIRONMENT=Production`. There is no shared-secret path: a networked instance MUST validate OIDC JWTs.
+
+The naive reading is "stand up an identity provider." But the API only ever **validates** tokens — it never initiates an interactive flow; every client is M2M. The question this ADR answers: what is the lightest-weight issuer that produces tokens this codebase accepts **unmodified**, without over-provisioning a full IdP whose flow engine, admin UI, worker, and database run almost entirely unused just to mint machine tokens?
+
+## Considered Options
+
+- **A. Full IdP as sole issuer (Authentik).** Real `client_credentials` endpoint, admin UI, revocation, rotation. Footprint post-2025.10 (Redis removed): `server` + `worker` + Postgres, ~2–3 GB RAM, 3–4 containers, its own upgrade/patch cadence. Everything the API needs (custom `{tenant}:{scope}` claims via Python Scope Mappings) is expressible, but ~99% of the product is unused for pure token minting.
+- **B. Headless OAuth2/OIDC server (Ory Hydra).** No user management; `client_credentials` skips login/consent. Custom claims for client_credentials require a **token-hook webhook** (an extra small service). Footprint: Hydra (~5 MB image, ~0.3–1 GB RAM) + a database (reuse the existing Postgres 17; SQLite is dev-only) + the token-hook service. Real `/oauth2/revoke`.
+- **C. Static discovery doc + static JWKS, no IdP daemon; JWTs minted offline.** The API's per-issuer `JwtBearer` scheme (ADR-005) uses `options.Authority`, which performs standard `.well-known/openid-configuration` + `jwks_uri` discovery — those can be **flat JSON files** served over HTTPS by the reverse proxy already required for TLS. Per-client RS256 keypairs; tokens minted by a ~40-line script carrying `iss`/`aud`/`exp` and a `roles` claim of `{tenant}:{scope}` values. No token/introspection/userinfo endpoint is ever touched. Footprint delta over the API alone: **zero new daemons** (reuses the proxy + internal CA needed for TLS regardless). Verified against the code and the test minter (`JwtTokenMinter`): no `sub`/`jti`/`nonce`/`azp`/`typ` claim is required.
+- **D. (variant of C) Embed `TokenValidationParameters.IssuerSigningKeys` directly; drop the HTTP discovery fetch entirely.** Lightest possible — no HTTPS metadata endpoint at all — but the current code sets `Authority`, so this requires a source change in `AuthExtensions`. Deferred; see Sub-decisions.
+
+## Decision Outcome
+
+**Chosen: Option C**, for the small-fixed-roster LAN case, with **Option B (Hydra) documented as the escalation path** and Option A rejected as disproportionate at this scale.
+
+Chosen because the trade-offs C accepts are cheap in exactly this context — a fixed, small client roster on a trusted LAN — while the marginal infrastructure cost is effectively zero: the only running pieces (a reverse proxy + an internal CA) are already required to terminate TLS for the API regardless, versus the ≈2–3 GB / 3–4 dedicated containers a full IdP (Option A) would add purely to mint tokens. Decisively, **it requires no change to the authentication code**: `Auth:Mode=Oidc` with a single `Issuers[]` entry (`TenantSource: CompoundRole`, `RoleSeparator: ":"`) pointed at the static issuer URL satisfies `EnforceOidcIssuersGuard` and validates offline-minted tokens as-is. The existing scope semantics (ADR-003) and actor-class resolution (ADR-008) apply unchanged: a minted token carrying `expertise.agent` is tagged `ActorClass=agent`; a token minted with only `{tenant}:expertise.read` cannot write. The supply-chain control is the existing authorization layer, not new issuer logic.
+
+The non-negotiable operational contract: **offline minting has no synchronous revocation.** The only levers are token `exp`, a per-client `kid` (drop one client's public key from the JWKS to revoke just that client on the next JWKS refresh), and a re-mint job. This is acceptable for ~3–5 LAN-trusted clients where a revocation event is rare and "kill the key, re-mint" is an acceptable manual runbook — and it is the explicit trigger for escalating to Option B.
+
+### Sub-decisions
+
+**TLS via an internal ACME CA (step-ca), not Let's Encrypt staging.** `RequireHttpsMetadata=true` is never overridden in the codebase, so the static discovery/JWKS host MUST be HTTPS, and LAN clients consume the API over HTTPS. LE (staging or prod) can't satisfy HTTP-01/TLS-ALPN-01 on a NAT'd home LAN, and DNS-01 demands a public domain + a DNS-API token for a purely-internal service. step-ca provides the identical "untrusted-by-default root you must distribute" property with no public dependency and no rate limits, and HTTP-01/TLS-ALPN-01 work LAN-to-LAN. `Caddy` (zero-config challenge, also serves the static JWKS files) over Traefik, since the DNS-01 rationale that favored Traefik evaporates once LE is dropped. LE-staging remains a documented one-line swap for a future public-exposure rehearsal.
+
+**Per-client RS256 keypair, shared public JWKS.** One private key per client so a single client is revocable by removing its public key (`kid`) from `jwks.json` without invalidating the others. The private keys are the crown jewels of this design — more sensitive than any single token — and MUST live off the API host, permission-restricted, encrypted at rest.
+
+**Custom claim = `roles` array of `{tenant}:{scope}` strings.** Since we mint the token, we control the claim shape; `Auth:Oidc:Issuers[].ScopeClaims` is pinned to whatever a decoded real token shows before config is committed (the one item the design fan-out could not confirm from docs: `roles` vs `scp`, and fully-qualified `expertise.write.draft` vs short `write.draft`). `expertise.write.approve` is never minted for an unattended M2M client — this is ADR-003's general prohibition on granting `write.approve` to long-lived non-interactive service principals (ADR-013's spoke credential is a prior *application* of that same rule, not its origin).
+
+**Option D deferred, gated on a code change + its own follow-up.** Setting `IssuerSigningKeys` directly (no HTTP discovery, no HTTPS-metadata requirement, no proxy-served JWKS) is lighter still but touches `AuthExtensions`. Not adopted now to keep this a **zero-code-change** deployment pattern; revisit if the HTTPS-metadata requirement becomes friction (e.g. an air-gapped instance where even an internal CA is unwanted).
+
+**Relationship to ADR-013.** The aggregator up-sync path deliberately keeps `client_credentials` on a shared IdP (hub↔spoke federation, `sub==azp` ⇒ `ActorClass=Service`). This ADR governs the **local-consumption** issuer only — the `Auth:Oidc:Issuers[]` schemes that *validate inbound* bearer tokens — and does not alter ADR-013. The two are orthogonal: a spoke's *outbound* sync credential is acquired via the `Sync:TokenEndpoint`/`Sync:ClientId` token-acquisition client, **not** an `Issuers[]` entry, so a spoke that also serves local LAN agents has exactly **one** `Issuers[]` entry (the static issuer). It is a **hub** instance that legitimately carries **two** independent `Issuers[]` entries — the shared-IdP entry that validates incoming spoke pushes, plus a static-issuer entry for its own local LAN agents.
+
+## Consequences
+
+- **Good** — zero net new daemons: the only running extras (reverse proxy + internal CA) are already required for TLS, so the issuer's marginal footprint is ≈0, versus the ≈2–3 GB of dedicated IdP infrastructure Option A would add.
+- **Good** — no source change: the ADR-005 multi-issuer plumbing, ADR-003 scopes, and ADR-008 actor-class all apply to minted tokens unmodified.
+- **Good** — no IdP database, no IdP upgrade/patch cadence, no admin UI attack surface.
+- **Good** — per-client `kid` gives granular (if asynchronous) revocation; audience pinning bounds blast radius to this one API.
+- **Bad** — no synchronous revocation; token `exp` is the incident-response window, so short TTL + a re-mint job is load-bearing, not optional.
+- **Bad** — the offline signing key is a high-value standing secret whose custody discipline is entirely on the operator; its compromise mints arbitrary tokens for any client until the key is rolled.
+- **Bad** — manual rotation runbook (keygen → rebuild JWKS with kid overlap → re-mint → redeploy) that a real OP would automate; tolerable only while the roster is small.
+- **Bad** — the internal-CA root must be trusted in two places (API host OS store + every consumer VM); a missed trust step fails closed at TLS.
+- **Revisit if** — client count or churn outgrows manual rotation, a genuine synchronous "kill this token now" requirement appears, or clients stop being fully LAN-trusted; escalate to Option B (Hydra), which is config-only on the API side (repoint `Issuers[].Issuer` at Hydra's public URL, no auth-code change).
+
+## Implementation notes (non-normative)
+
+- Reference artifacts drafted alongside this ADR (scratchpad, pre-repo): `docker-compose.yml` (Caddy + step-ca), `Caddyfile`, `mint_token.py` (keygen / build-jwks / sign), `RUNBOOK.md` (10-step end-to-end), and the Hydra-variant compose sketch for the Option-B escalation.
+- Static discovery doc minimal fields (.NET parses regardless of content-type): `{"issuer": "<Authority, byte-exact>", "jwks_uri": "<.../jwks.json>"}`.
+- JWKS refresh: `Microsoft.IdentityModel` defaults are 12 h automatic / 5 min forced-refresh cooldown; on a `kid` miss the triggering request 401s and the next picks up new keys — keep old+new `kid` in the JWKS for one `exp` window for zero-401 rotation.
+- API-side config surfaces if this lands in-repo: `appsettings.json` `_comment` example for a static issuer; README §Archetype A2 gains a "networked consumers" subsection; `install.sh` secrets stub gains `AllowedHosts` + `ForwardedHeaders__KnownNetworks__0` guidance (both required for a reverse-proxied LAN bind, per the same design session).
+- Doc-sync on landing: this ADR + README §Archetype A2 + `appsettings.json` example + (if a helper ships in-tree) the mint script under `scripts/`. No agent/rule catalog surfaces are touched.

--- a/adrs/014-lightweight-oidc-static-jwks.md
+++ b/adrs/014-lightweight-oidc-static-jwks.md
@@ -1,6 +1,6 @@
 # Static JWKS + offline-minted JWTs as the lightweight OIDC issuer for A2/LAN consumption
 
-- Status: accepted
+- Status: superseded by [ADR-015](015-embedded-static-jwks.md) (metadata-delivery mechanism only — the lightweight-issuer decision over a full IdP stands; ADR-015 flips Option C → Option D)
 - Date: 2026-07-08
 - Companion: [ADR-003](003-scope-split.md) (scope semantics that gate what a minted token can do), [ADR-005](005-multi-issuer-jwt-policy-scheme.md) (multi-issuer JWT plumbing reused verbatim), [ADR-008](008-response-hygiene-and-actor-class.md) (actor-class resolution from the token), [ADR-011](011-deployment-artifact-format.md) (the A2 native-service install this pairs with), [ADR-013](013-aggregator-upsync.md) (distinct: hub↔spoke up-sync keeps `client_credentials` on a shared IdP — NOT in scope here)
 - Tracking issue: [#382](https://github.com/psmfd/agent-expertise-api/issues/382)

--- a/adrs/015-embedded-static-jwks.md
+++ b/adrs/015-embedded-static-jwks.md
@@ -1,0 +1,48 @@
+# Embed static signing keys directly (drop the HTTPS discovery fetch) for the LAN OIDC issuer
+
+- Status: accepted
+- Date: 2026-07-10
+- Supersedes: [ADR-014](014-lightweight-oidc-static-jwks.md) — specifically its **Option-C** metadata-delivery mechanism (static discovery doc + HTTPS `jwks_uri` fetch). ADR-014's rejection of a full IdP (Options A/B) and its token/scope/actor-class model are unchanged and carried forward by reference.
+- Companion: [ADR-003](003-scope-split.md), [ADR-005](005-multi-issuer-jwt-policy-scheme.md), [ADR-008](008-response-hygiene-and-actor-class.md), [ADR-011](011-deployment-artifact-format.md)
+- Tracking issue: [#382](https://github.com/psmfd/agent-expertise-api/issues/382)
+- Surfaced by: 2026-07-10 A2-integration research (multi-agent fan-out across `expertise-api-owner`, `dotnet-expert`, `docker-expert`) into how the ADR-014 pattern composes with the A2 native-service install surface.
+
+## Context and Problem Statement
+
+ADR-014 adopted a lightweight OIDC issuer for A2/LAN M2M consumption and chose **Option C**: serve a static `.well-known/openid-configuration` + `jwks.json` over HTTPS and let the API's `JwtBearer` scheme fetch them via `options.Authority`. Option C was chosen expressly because "it requires no change to the authentication code." Option D (embed the signing keys directly) was described and **deferred** with an explicit trigger: "revisit if the HTTPS-metadata requirement becomes friction."
+
+Researching how Option C actually lands on the A2 native-service surface (systemd `--user` on Linux, launchd on macOS) surfaced that the HTTPS-metadata fetch imposes a real, per-platform **internal-CA-trust burden on the API host**:
+
+- The API must trust the internal ACME CA (e.g. step-ca) root to fetch the issuer's HTTPS metadata. .NET delegates that trust decision entirely to the OS, with **no shared mechanism** across platforms: Linux uses OpenSSL (`update-ca-certificates` / `SSL_CERT_FILE`), while macOS validates exclusively through the Apple Security framework/Keychain (`security add-trusted-cert`) — and .NET 10 removed OpenSSL interop on macOS entirely, so there is no env-var path there at all.
+- The fetch is **lazy** (first authenticated request), so a missing trust step surfaces as a **500 on the first protected request while `/health` and `/metrics` stay green** — a boot-green/broken-on-first-call blind spot that the existing `EnforceOidcIssuersGuard` does not cover.
+
+The "no code change" saving of Option C is therefore paid back, with interest, as divergent per-OS operational plumbing and a latent runtime failure mode. The Option-D trigger has fired.
+
+## Considered Options
+
+- **Keep Option C (status quo).** No code change, keeps zero-downtime `kid` rotation (publish a new `jwks.json`, picked up within the refresh window). Cost: the per-platform CA-trust burden and lazy-fetch 500 blind spot above; requires a live HTTPS metadata endpoint.
+- **Adopt Option D — embed `IssuerSigningKeys` from a local JWKS file.** The API loads `jwks.json` from a local path at startup and validates against it directly; no `Authority`, no discovery fetch, no `jwks_uri`, no metadata TLS handshake. Cost: a small `AuthExtensions` source change (now made) and loss of zero-downtime rotation (rotation becomes edit-`jwks.json` + restart).
+
+## Decision Outcome
+
+Adopt **Option D**. Per-issuer configuration gains `JwksPath`: when set, `AuthExtensions.RegisterJwtBearer` loads the file's keys into `TokenValidationParameters.IssuerSigningKeys`, preloads `options.Configuration` with the pinned issuer, nulls the `ConfigurationManager`, and leaves `Authority` unset — so the issuer never contacts the network. `Issuer` remains required (it pins `ValidIssuer` / must byte-match `iss`). Cloud issuers (Entra, Authentik) with no `JwksPath` keep the Option-C discovery path unchanged — the choice is per-issuer, not global.
+
+A `JwksPath` that is missing, unreadable, malformed, or empty **fails startup closed** (`LoadStaticSigningKeys`, run at service-configuration time) — the embedded-key analogue of `EnforceOidcIssuersGuard`, closing the lazy-fetch blind spot: an embedded-key instance cannot boot green with unusable keys.
+
+## Consequences
+
+- **Good** — the internal-CA-trust requirement on the API host is **eliminated**: there is no metadata TLS handshake to trust, so the divergent Linux/macOS trust plumbing (and .NET 10's macOS-OpenSSL removal) stops mattering for the auth path. CA trust remains only on the **consumer** side (each VM trusts the proxy's cert to reach the API over TLS).
+- **Good** — no HTTPS `.well-known`/`jwks.json` endpoint to stand up; the reverse proxy's only remaining job is terminating TLS on the API's own endpoint.
+- **Good** — failure is **fail-closed at startup**, not a first-request 500 with a green `/health`.
+- **Good** — the token/scope/actor-class model, ADR-005 multi-issuer plumbing, and the offline-mint workflow are otherwise unchanged; the regression guard exercises the real embedded-key path.
+- **Bad** — a small auth-code change was required (now landed + reviewed) — the exact thing Option C optimised against.
+- **Bad** — loss of zero-downtime `kid` rotation: rotating a key is now edit-`jwks.json` + service restart, not "publish a new static file." Tolerable while the roster is small (the same regime ADR-014 already assumed for manual rotation).
+- **Bad** — the `jwks.json` file must be distributed to the API's config directory with integrity (a tampered **public** JWKS can only deny service, not forge tokens — a lower-blast-radius problem than a compromised CA root).
+- **Revisit if** — the roster/rotation churn outgrows restart-based key rolls, or a synchronous revocation requirement appears; escalate to Option B (Ory Hydra) per ADR-014, which remains config-only on the API side.
+
+## Implementation notes (non-normative)
+
+- Config surface: `Auth:Oidc:Issuers:N:JwksPath` (local path). The shipped `appsettings.json` `LanStatic` issuer (index 2) carries a `JwksPath` placeholder instead of relying on discovery.
+- `scripts/mint_token.py`: `keygen` (per-client RS256 keypair) / `build-jwks` (public `jwks.json`) / `sign` (offline token). The discovery-doc emission Option C needed is dropped.
+- `deploy/lan-static-oidc/`: a **native** `Caddyfile` (API inbound TLS only) + a containerized step-ca `compose.yaml` + a runbook whose CA-trust steps are **consumer-side**.
+- Doc-sync on landing: this ADR; ADR-014 status → superseded; `appsettings.json` example; README §Archetype A2; README directory tree.

--- a/deploy/lan-static-oidc/Caddyfile
+++ b/deploy/lan-static-oidc/Caddyfile
@@ -1,0 +1,18 @@
+# ADR-015 — native Caddy (launchd/systemd). API inbound TLS only.
+#
+# Terminates HTTPS for LAN consumers and reverse-proxies to the native API over
+# loopback. Under ADR-015 the API validates tokens against a local embedded JWKS,
+# so this proxy does NOT serve any /.well-known or jwks.json — its only job is TLS
+# for the API endpoint.
+
+{
+	# step-ca's ACME directory (published to host loopback by compose.yaml).
+	acme_ca https://localhost:9000/acme/acme/directory
+	# step-ca root, exported per RUNBOOK.md step 3, so Caddy trusts the ACME API.
+	acme_ca_root /etc/caddy/step-root.crt
+}
+
+# Replace with the API's real LAN hostname (must also be in the API's AllowedHosts).
+expertise.lan.example {
+	reverse_proxy 127.0.0.1:8080
+}

--- a/deploy/lan-static-oidc/RUNBOOK.md
+++ b/deploy/lan-static-oidc/RUNBOOK.md
@@ -1,0 +1,117 @@
+# LAN static-OIDC edge for an A2 native-service install (ADR-015)
+
+Stand up an internal TLS edge so a small, fixed roster of LAN M2M clients can consume
+an A2 native-service expertise-api instance, using **offline-minted JWTs validated
+against a local embedded JWKS** — no IdP daemon, no HTTPS metadata fetch.
+
+## Topology
+
+```
+LAN consumer VM ──HTTPS──►  Caddy (native OS service)  ──HTTP loopback──►  expertise-api
+  (offline-minted JWT)       terminates TLS, proxies                       (A2 native service,
+                             127.0.0.1:8080                                  install.sh)
+                                    ▲ cert via ACME
+                             step-ca (container, compose.yaml)
+
+  mint_token.py ── OFF the API host ──►  jwks.json (copied to the API host)
+                                         + client tokens (handed to each VM)
+```
+
+Key ADR-015 property: **the API host trusts no CA** — it never fetches issuer metadata.
+Only the **consumer VMs** trust step-ca's root (to reach the API's HTTPS endpoint).
+
+## Prerequisites
+
+- Docker or Podman (for step-ca). With Podman: `DOCKER_HOST` + `TESTCONTAINERS_RYUK_DISABLED` per the testing guide.
+- Caddy installed natively: `apt install caddy` (Debian 13) or `brew install caddy` (macOS).
+- Python 3 + `pip install jwcrypto` on the (off-host) minting machine.
+- The API already installed as an A2 service via `scripts/install.sh`.
+
+## Steps
+
+### 1. Start the internal CA
+
+```bash
+cd deploy/lan-static-oidc
+docker compose up -d           # or: podman compose up -d
+```
+
+### 2. Export step-ca's root
+
+```bash
+docker compose exec step-ca step ca root /home/step/root_ca.crt
+docker compose cp step-ca:/home/step/root_ca.crt ./step-root.crt
+sudo cp ./step-root.crt /etc/caddy/step-root.crt      # where the Caddyfile references it
+```
+
+### 3. Run Caddy natively
+
+Put `Caddyfile` at `/etc/caddy/Caddyfile` (edit the hostname), then run Caddy as an OS
+service (`systemctl enable --now caddy` on Debian; `brew services start caddy` on macOS).
+Native Caddy reaches the API at `127.0.0.1:8080` and step-ca at `localhost:9000`.
+
+### 4. Trust step-ca on each CONSUMER VM (not the API host)
+
+This is the only CA-trust step, and it lives on the clients:
+
+- **Debian 13 (Trixie):**
+  ```bash
+  sudo cp step-root.crt /usr/local/share/ca-certificates/expertise-lan-ca.crt
+  sudo update-ca-certificates
+  ```
+- **macOS:**
+  ```bash
+  sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain step-root.crt
+  ```
+
+### 5. Mint keys + build the JWKS (off the API host)
+
+```bash
+export OIDC_ISSUER="https://auth.lan.example/"   # any stable string; must byte-match the API's Issuer + the iss claim
+./scripts/mint_token.py keygen --client vm-alpha
+./scripts/mint_token.py build-jwks --out oidc/jwks.json
+```
+
+Copy `oidc/jwks.json` to the API host, e.g. `~/.config/expertise-api/jwks.json`.
+
+### 6. Configure the API service
+
+Install (or re-run) with a LAN bind, and add the issuer to `secrets.env`:
+
+```bash
+scripts/install.sh --bind 0.0.0.0:8080
+```
+```sh
+# ~/.config/expertise-api/secrets.env
+Auth__Oidc__Issuers__2__Issuer=https://auth.lan.example/
+Auth__Oidc__Issuers__2__JwksPath=/home/<user>/.config/expertise-api/jwks.json
+AllowedHosts=expertise.lan.example
+ForwardedHeaders__KnownNetworks__0=<proxy-subnet-cidr>
+```
+
+Index `2` is the shipped `LanStatic` issuer (`appsettings.json`); `Name`/`Audience`/
+`ScopeClaims`/`TenantSource`/`RoleSeparator` are already correct. A blank/unreadable
+`JwksPath` (or a still-`<TODO…>` `Issuer`) **fails startup closed** — by design.
+
+### 7. Restart and verify
+
+```bash
+scripts/expertise-apictl restart
+
+# Mint a client token and verify a PROTECTED endpoint — NOT just /health, which stays
+# green regardless of auth config:
+TOKEN=$(./scripts/mint_token.py sign --client vm-alpha --tenant team-alpha --scopes read --ttl-days 7)
+curl -sS https://expertise.lan.example/expertise -H "Authorization: Bearer $TOKEN" | head
+```
+
+A `200` (or a valid empty list) confirms end-to-end auth. A `401`/`500` means the token,
+issuer config, or JWKS is wrong — check the service logs.
+
+## Rotation & revocation (ADR-015 tradeoff)
+
+There is **no synchronous revocation** — a token is valid until its `exp`. Keep `--ttl-days`
+short and re-mint on a schedule. To roll a key or revoke a client: re-run `keygen` /
+`build-jwks`, copy the new `jwks.json`, and **restart the API** (`expertise-apictl restart`).
+Embedded JWKS is loaded at startup, so rotation is not zero-downtime — acceptable for the
+small-roster LAN case this targets. If churn outgrows restarts or you need "kill this token
+now," escalate to Ory Hydra (ADR-014 Option B), config-only on the API side.

--- a/deploy/lan-static-oidc/compose.yaml
+++ b/deploy/lan-static-oidc/compose.yaml
@@ -1,0 +1,30 @@
+# ADR-015 LAN OIDC edge — step-ca ONLY.
+#
+# Caddy runs NATIVELY (launchd/systemd — see RUNBOOK.md), not here. That lets it
+# reach the native API over plain loopback (127.0.0.1) and reach step-ca via the
+# published port below — the well-supported direction on every Docker/Podman
+# runtime — instead of relying on host.docker.internal crossing into a native
+# process (ambiguous across Docker Desktop / colima / podman machine).
+#
+# step-ca is the internal ACME CA that issues Caddy's TLS cert for the API's
+# public hostname. Under ADR-015 (embedded JWKS) the API performs NO metadata
+# fetch, so the API host does NOT trust this CA — only the LAN CONSUMER VMs do.
+name: expertise-lan-oidc
+
+services:
+  step-ca:
+    # Pin to a digest before any real use — :latest mints your trust root.
+    image: smallstep/step-ca:0.28.4
+    restart: unless-stopped
+    environment:
+      DOCKER_STEPCA_INIT_NAME: "Expertise LAN CA"
+      DOCKER_STEPCA_INIT_DNS_NAMES: "localhost,step-ca"
+      DOCKER_STEPCA_INIT_ACME: "true"
+    ports:
+      # ACME directory, published to host loopback for the native Caddy service.
+      - "127.0.0.1:9000:9000"
+    volumes:
+      - step-ca-data:/home/step
+
+volumes:
+  step-ca-data:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -741,8 +741,16 @@ ensure_config_stubs() {
 # EnvironmentFile= parser is literal and tolerates the unquoted form, but
 # the launchd-on-macOS path and the migrate scripts both use the bash sourcer.
 #
-# When Auth:Mode=Oidc, populate per-issuer overrides via Auth__Oidc__Issuers__N__*
-# environment variables — see appsettings.json for the shape.
+# When Auth:Mode=Oidc (the default outside Development), populate per-issuer
+# overrides via Auth__Oidc__Issuers__N__* env vars — see appsettings.json for the
+# shape. For the shipped LAN static issuer (index 2 = "LanStatic", ADR-015 embedded
+# JWKS), a networked A2 instance consumed by LAN clients needs:
+#   Auth__Oidc__Issuers__2__Issuer="https://auth.lan.example/"   # byte-exact w/ token iss
+#   Auth__Oidc__Issuers__2__JwksPath="${CONFIG_DIR}/jwks.json"   # local public JWKS; no HTTPS fetch
+#   AllowedHosts="your-lan-hostname"                             # else HostFiltering 400s the LAN Host
+#   ForwardedHeaders__KnownNetworks__0="10.0.0.0/24"             # proxy CIDR; else audit IP = the proxy
+# and a non-loopback bind (default is 127.0.0.1:8080): scripts/install.sh --bind 0.0.0.0:8080
+# Full runbook: deploy/lan-static-oidc/RUNBOOK.md
 #
 # Aggregator up-sync (ADR-013, spoke role only — leave unset for a standalone
 # instance). The hub credential must carry expertise.write.draft ONLY:

--- a/scripts/mint_token.py
+++ b/scripts/mint_token.py
@@ -56,8 +56,14 @@ def keygen(a):
     if os.path.exists(path) and not a.force:
         sys.exit(f"{path} exists; pass --force to overwrite (rotates the client's key)")
     key = jwk.JWK.generate(kty="RSA", size=2048, kid=kid_for(a.client), use="sig", alg="RS256")
-    with open(path, "w") as f: f.write(key.export_private())
-    os.chmod(path, 0o600)
+    # Create the private-key file pre-restricted (0o600) instead of chmod-after-write, which would
+    # leave a brief TOCTOU window where the key inherits the umask default (often world/group
+    # readable). The existence/rotation gate above already owns overwrite intent (--force), so
+    # O_TRUNC replaces in place; O_EXCL is intentionally not used because rotation overwrites.
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as f:
+        f.write(key.export_private())
+    os.chmod(path, 0o600)  # re-assert mode on the rotate path (O_CREAT keeps a pre-existing file's perms)
     print(f"wrote {path} (kid={kid_for(a.client)})")
 
 def build_jwks(a):
@@ -73,10 +79,23 @@ def sign(a):
     path = os.path.join(KEY_DIR, f"{a.client}.priv.json")
     key = jwk.JWK.from_json(open(path).read())
     roles = []
+    privileged = []
     for s in a.scopes.split(","):
         s = s.strip()
         full = SCOPE_MAP.get(s, s)
+        if full in ("expertise.write.approve", "expertise.admin"):
+            privileged.append(full)
         roles.append(f"{a.tenant}:{full}")
+    # ADR-003/ADR-015: write.approve / admin must never be handed to an unattended M2M client.
+    # A stray `--scopes approve` (typo, copy-paste, automation) would otherwise silently mint a
+    # long-lived privileged credential. Require an explicit opt-in flag for attended/admin tokens.
+    if privileged and not a.allow_privileged:
+        sys.exit(
+            f"refusing to mint privileged scope(s) {privileged} for client '{a.client}': "
+            "expertise.write.approve / expertise.admin must not be granted to unattended M2M "
+            "clients (ADR-003/ADR-015). Re-run with --allow-privileged only if this is an "
+            "attended/administrative token you are issuing deliberately."
+        )
     now = int(time.time())
     claims = {
         "iss": ISSUER, "aud": AUDIENCE, "sub": a.client,
@@ -91,5 +110,5 @@ p = argparse.ArgumentParser(description="Offline JWT minter + JWKS builder (ADR-
 sub = p.add_subparsers(required=True)
 g = sub.add_parser("keygen"); g.add_argument("--client", required=True); g.add_argument("--force", action="store_true"); g.set_defaults(fn=keygen)
 b = sub.add_parser("build-jwks"); b.add_argument("--out", default="oidc/jwks.json"); b.set_defaults(fn=build_jwks)
-s = sub.add_parser("sign"); s.add_argument("--client", required=True); s.add_argument("--tenant", required=True); s.add_argument("--scopes", required=True); s.add_argument("--ttl-days", type=int, default=7); s.set_defaults(fn=sign)
+s = sub.add_parser("sign"); s.add_argument("--client", required=True); s.add_argument("--tenant", required=True); s.add_argument("--scopes", required=True); s.add_argument("--ttl-days", type=int, default=7); s.add_argument("--allow-privileged", action="store_true", help="required to mint expertise.write.approve / expertise.admin (ADR-003/ADR-015)"); s.set_defaults(fn=sign)
 a = p.parse_args(); a.fn(a)

--- a/scripts/mint_token.py
+++ b/scripts/mint_token.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Offline JWT minter + JWKS builder for expertise-api (ADR-015, no IdP daemon).
+
+Runs OFF the API host. Produces (1) a per-client RS256 keypair, (2) a public
+`jwks.json` the API loads via `Auth:Oidc:Issuers:N:JwksPath` (embedded-key path —
+no HTTPS discovery fetch), and (3) offline-signed tokens for LAN M2M clients.
+
+One RSA keypair PER CLIENT so a single client can be revoked by dropping its key
+from jwks.json and restarting the API, without invalidating the others.
+
+Deps:  pip install jwcrypto
+Usage:
+    # 1. one-time per client: generate a keypair (writes <client>.priv.json)
+    ./mint_token.py keygen --client vm-alpha
+    # 2. (re)build the public JWKS from ALL *.priv.json in the key dir, then copy
+    #    it to the API host and point Auth__Oidc__Issuers__2__JwksPath at it
+    ./mint_token.py build-jwks --out oidc/jwks.json
+    # 3. mint a token for a client
+    ./mint_token.py sign --client vm-alpha \
+        --tenant team-alpha --scopes read,write.draft,agent --ttl-days 7
+
+Config contract (verified end-to-end by StaticIssuerCompoundRoleTests):
+  Auth:Oidc:Issuers[N] = { Issuer (byte-exact w/ the `iss` below), Audience,
+    JwksPath, ScopeClaims:["roles"], TenantSource:"CompoundRole", RoleSeparator:":" }
+
+Security: keep the key dir (default ./keys) OFF the API host, chmod 700, encrypt
+at rest. The private keys can mint tokens for any client indefinitely — they are
+more sensitive than any single token. There is NO synchronous revocation: a
+token is valid until its `exp`, so keep --ttl-days short and re-mint on a
+schedule (ADR-015 Consequences).
+"""
+import argparse, json, os, time, glob, sys
+from jwcrypto import jwk, jwt
+
+KEY_DIR = os.environ.get("OIDC_KEY_DIR", "keys")
+ISSUER  = os.environ.get("OIDC_ISSUER", "https://auth.lan.example/")  # byte-exact w/ Issuers[N].Issuer
+AUDIENCE = os.environ.get("OIDC_AUDIENCE", "expertise-api")
+
+# Scope shorthand -> full expertise-api scope string. CompoundRole parses each
+# roles[] entry as "{tenant}:{scope}" splitting on ':' (RoleSeparator).
+SCOPE_MAP = {
+    "read":    "expertise.read",
+    "draft":   "expertise.write.draft",
+    "write.draft": "expertise.write.draft",
+    "approve": "expertise.write.approve",   # do NOT grant to unattended M2M clients
+    "admin":   "expertise.admin",
+    "agent":   "expertise.agent",           # tags ActorClass=agent in the audit log
+}
+
+def kid_for(client): return f"{client}"
+
+def keygen(a):
+    os.makedirs(KEY_DIR, exist_ok=True)
+    os.chmod(KEY_DIR, 0o700)   # keys are more sensitive than any token; don't leave the dir world-listable
+    path = os.path.join(KEY_DIR, f"{a.client}.priv.json")
+    if os.path.exists(path) and not a.force:
+        sys.exit(f"{path} exists; pass --force to overwrite (rotates the client's key)")
+    key = jwk.JWK.generate(kty="RSA", size=2048, kid=kid_for(a.client), use="sig", alg="RS256")
+    with open(path, "w") as f: f.write(key.export_private())
+    os.chmod(path, 0o600)
+    print(f"wrote {path} (kid={kid_for(a.client)})")
+
+def build_jwks(a):
+    keys = []
+    for p in sorted(glob.glob(os.path.join(KEY_DIR, "*.priv.json"))):
+        k = jwk.JWK.from_json(open(p).read())
+        keys.append(json.loads(k.export_public()))
+    os.makedirs(os.path.dirname(a.out) or ".", exist_ok=True)
+    with open(a.out, "w") as f: json.dump({"keys": keys}, f, indent=2)
+    print(f"wrote {a.out} with {len(keys)} key(s): {[k['kid'] for k in keys]}")
+
+def sign(a):
+    path = os.path.join(KEY_DIR, f"{a.client}.priv.json")
+    key = jwk.JWK.from_json(open(path).read())
+    roles = []
+    for s in a.scopes.split(","):
+        s = s.strip()
+        full = SCOPE_MAP.get(s, s)
+        roles.append(f"{a.tenant}:{full}")
+    now = int(time.time())
+    claims = {
+        "iss": ISSUER, "aud": AUDIENCE, "sub": a.client,
+        "iat": now, "nbf": now, "exp": now + a.ttl_days * 86400,
+        "roles": roles,                     # <-- API config: ScopeClaims:["roles"], RoleSeparator:":"
+    }
+    tok = jwt.JWT(header={"alg": "RS256", "kid": kid_for(a.client), "typ": "JWT"}, claims=claims)
+    tok.make_signed_token(key)
+    print(tok.serialize())
+
+p = argparse.ArgumentParser(description="Offline JWT minter + JWKS builder (ADR-015).")
+sub = p.add_subparsers(required=True)
+g = sub.add_parser("keygen"); g.add_argument("--client", required=True); g.add_argument("--force", action="store_true"); g.set_defaults(fn=keygen)
+b = sub.add_parser("build-jwks"); b.add_argument("--out", default="oidc/jwks.json"); b.set_defaults(fn=build_jwks)
+s = sub.add_parser("sign"); s.add_argument("--client", required=True); s.add_argument("--tenant", required=True); s.add_argument("--scopes", required=True); s.add_argument("--ttl-days", type=int, default=7); s.set_defaults(fn=sign)
+a = p.parse_args(); a.fn(a)

--- a/src/ExpertiseApi/Auth/AuthExtensions.cs
+++ b/src/ExpertiseApi/Auth/AuthExtensions.cs
@@ -196,6 +196,14 @@ internal static class AuthExtensions
                 options.Configuration = configuration;
                 options.ConfigurationManager = null;
                 options.TokenValidationParameters.IssuerSigningKeys = staticSigningKeys;
+
+                // Pin RS256 for the embedded-key path (mint_token.py emits RS256 only). Defense in
+                // depth: it constrains signature validation to the asymmetric algorithm these keys
+                // are for, so even a mis-provisioned symmetric/other-alg key that slipped past
+                // LoadStaticSigningKeys' screen cannot validate a forged token via alg substitution.
+                // Cloud/discovery issuers keep their metadata-driven algorithm set (unset here) so an
+                // IdP that signs with ES256/PS256 is not broken.
+                options.TokenValidationParameters.ValidAlgorithms = [SecurityAlgorithms.RsaSha256];
             }
             else
             {
@@ -258,6 +266,24 @@ internal static class AuthExtensions
                     $"Auth:Oidc issuer '{issuer.Name}' JwksPath '{issuer.JwksPath}' contains PRIVATE key material " +
                     $"(kid '{jwk.Kid}'). The API must load a PUBLIC-only JWKS — run 'mint_token.py build-jwks' to " +
                     "produce one; never point JwksPath at a *.priv.json file or the private key directory.");
+            }
+
+            // Reject symmetric (HMAC) keys. A `kty=oct` JWK carries its shared secret in `k`, and
+            // JsonWebKeySet.GetSigningKeys() surfaces it as a usable SymmetricSecurityKey
+            // (SkipUnresolvedJsonWebKeys defaults to false) — so anyone able to read this
+            // network-facing "public" JWKS could forge HS256 tokens the API would accept. An
+            // embedded-key issuer is RS256-only by construction (mint_token.py emits RSA), so any
+            // oct key is a misconfiguration: fail closed rather than load a forgeable secret. The
+            // ValidAlgorithms=RS256 pin on the static path is the compensating control if this is
+            // ever reached, but the shared secret has no business in the file at all.
+            if (string.Equals(jwk.Kty, "oct", StringComparison.OrdinalIgnoreCase)
+                || !string.IsNullOrEmpty(jwk.K))
+            {
+                throw new InvalidOperationException(
+                    $"Auth:Oidc issuer '{issuer.Name}' JwksPath '{issuer.JwksPath}' contains a SYMMETRIC (kty=oct) " +
+                    $"key (kid '{jwk.Kid}'). Embedded-key issuers are RS256-only (asymmetric); a shared-secret key " +
+                    "in a network-facing JWKS is forgeable by anyone who can read the file. Provide an RSA public " +
+                    "JWKS from 'mint_token.py build-jwks'.");
             }
         }
 

--- a/src/ExpertiseApi/Auth/AuthExtensions.cs
+++ b/src/ExpertiseApi/Auth/AuthExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 
 namespace ExpertiseApi.Auth;
@@ -43,7 +44,14 @@ internal static class AuthExtensions
         {
             foreach (var issuer in issuers)
             {
-                RegisterJwtBearer(authBuilder, issuer);
+                // Eagerly load embedded static keys (ADR-015) here, at service-configuration
+                // time, so a missing/malformed JwksPath fails startup closed rather than 500ing
+                // on the first authenticated request. Discovery-path issuers (JwksPath unset)
+                // pass null and fetch lazily via Authority as before.
+                var staticKeys = string.IsNullOrWhiteSpace(issuer.JwksPath)
+                    ? null
+                    : LoadStaticSigningKeys(issuer);
+                RegisterJwtBearer(authBuilder, issuer, staticKeys);
             }
         }
 
@@ -152,11 +160,13 @@ internal static class AuthExtensions
             .ToList();
     }
 
-    private static void RegisterJwtBearer(AuthenticationBuilder builder, OidcIssuerOptions issuer)
+    private static void RegisterJwtBearer(
+        AuthenticationBuilder builder,
+        OidcIssuerOptions issuer,
+        IList<SecurityKey>? staticSigningKeys)
     {
         builder.AddJwtBearer(issuer.Name, options =>
         {
-            options.Authority = issuer.Issuer;
             options.Audience = issuer.Audience;
             options.MapInboundClaims = false; // keep `sub`, `scp`, etc. as-is for parsing
 
@@ -171,11 +181,96 @@ internal static class AuthExtensions
                 NameClaimType = "sub"
             };
 
+            if (staticSigningKeys is not null)
+            {
+                // ADR-015 (Option D): embedded static JWKS. Preload the configuration with the
+                // issuer + signing keys. Because Authority/MetadataAddress are unset, the
+                // framework's JwtBearerPostConfigureOptions wraps this Configuration in a
+                // StaticConfigurationManager (nulling ConfigurationManager here just prevents a
+                // discovery-backed one) — GetConfigurationAsync then performs no I/O, so there
+                // is no `.well-known`/`jwks_uri` fetch, no HTTPS metadata endpoint to stand up,
+                // and no internal-CA root to trust on the API host. `Authority` is deliberately unset.
+                var configuration = new OpenIdConnectConfiguration { Issuer = issuer.Issuer };
+                foreach (var key in staticSigningKeys)
+                    configuration.SigningKeys.Add(key);
+                options.Configuration = configuration;
+                options.ConfigurationManager = null;
+                options.TokenValidationParameters.IssuerSigningKeys = staticSigningKeys;
+            }
+            else
+            {
+                // Discovery path (cloud issuers): Authority drives lazy `.well-known` + JWKS
+                // fetch. RequireHttpsMetadata stays at its default (true).
+                options.Authority = issuer.Issuer;
+            }
+
             options.Events = new JwtBearerEvents
             {
                 OnTokenValidated = ctx => JwtTenantContextEvents.BuildTenantContext(ctx, issuer)
             };
         });
+    }
+
+    /// <summary>
+    /// Loads and validates an embedded-key issuer's JWKS file (ADR-015, Option D). Runs at
+    /// service-configuration time so any problem fails startup closed — a deliberate parallel
+    /// to <see cref="EnforceOidcIssuersGuard"/>: a networked instance must never boot green
+    /// (<c>/health</c>, <c>/metrics</c>) while its only issuer's keys are missing or malformed
+    /// and every protected request would 500.
+    /// </summary>
+    internal static IList<SecurityKey> LoadStaticSigningKeys(OidcIssuerOptions issuer)
+    {
+        string json;
+        try
+        {
+            json = File.ReadAllText(issuer.JwksPath!);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            throw new InvalidOperationException(
+                $"Auth:Oidc issuer '{issuer.Name}' JwksPath '{issuer.JwksPath}' could not be read: {ex.Message} " +
+                "Provide a readable jwks.json for an embedded-key (ADR-015) issuer, or remove JwksPath to use " +
+                "HTTPS discovery via Authority.", ex);
+        }
+
+        JsonWebKeySet keySet;
+        try
+        {
+            keySet = new JsonWebKeySet(json);
+        }
+        catch (Exception ex) when (ex is ArgumentException or System.Text.Json.JsonException)
+        {
+            throw new InvalidOperationException(
+                $"Auth:Oidc issuer '{issuer.Name}' JwksPath '{issuer.JwksPath}' is not a valid JWKS document: " +
+                $"{ex.Message}", ex);
+        }
+
+        // Reject private-key material. The API loads a JWKS only to *validate* signatures, so it
+        // must be public-only. This fails closed on the operator footgun of pointing JwksPath at
+        // mint_token.py's `<client>.priv.json` (or its key dir) instead of the `build-jwks` output
+        // — which would otherwise load a token-forging private key into the network-facing process.
+        // `d` covers RSA and EC private keys; `p`/`q` are RSA CRT components.
+        foreach (var jwk in keySet.Keys)
+        {
+            if (!string.IsNullOrEmpty(jwk.D) || !string.IsNullOrEmpty(jwk.P) || !string.IsNullOrEmpty(jwk.Q))
+            {
+                throw new InvalidOperationException(
+                    $"Auth:Oidc issuer '{issuer.Name}' JwksPath '{issuer.JwksPath}' contains PRIVATE key material " +
+                    $"(kid '{jwk.Kid}'). The API must load a PUBLIC-only JWKS — run 'mint_token.py build-jwks' to " +
+                    "produce one; never point JwksPath at a *.priv.json file or the private key directory.");
+            }
+        }
+
+        var keys = keySet.GetSigningKeys();
+
+        if (keys.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Auth:Oidc issuer '{issuer.Name}' JwksPath '{issuer.JwksPath}' contains no signing keys. " +
+                "A JWKS with at least one RSA/EC signing key is required for an embedded-key issuer.");
+        }
+
+        return keys;
     }
 
     [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",

--- a/src/ExpertiseApi/Auth/OidcIssuerOptions.cs
+++ b/src/ExpertiseApi/Auth/OidcIssuerOptions.cs
@@ -50,6 +50,19 @@ internal class OidcIssuerOptions
     /// Group claim name (defaults to <c>"groups"</c>).
     /// </summary>
     public string GroupClaim { get; set; } = "groups";
+
+    /// <summary>
+    /// Path to a local JWKS (<c>jwks.json</c>) file. When set, this issuer's signing keys are
+    /// loaded from the file at startup and embedded directly into token validation — the API
+    /// performs <b>no</b> HTTPS discovery / <c>jwks_uri</c> fetch (ADR-015, Option D). This
+    /// removes the backchannel internal-CA-trust requirement on the API host that the
+    /// discovery-fetch path (<see cref="Issuer"/> as <c>Authority</c>) would otherwise impose.
+    /// Mutually exclusive with the discovery path: an issuer carrying a <c>JwksPath</c> never
+    /// contacts the network. <see cref="Issuer"/> is still required — it pins <c>ValidIssuer</c>
+    /// and must byte-match the token's <c>iss</c> claim. A blank/unreadable/empty JWKS fails
+    /// startup closed.
+    /// </summary>
+    public string? JwksPath { get; set; }
 }
 
 internal enum TenantSource

--- a/src/ExpertiseApi/ExpertiseApi.csproj
+++ b/src/ExpertiseApi/ExpertiseApi.csproj
@@ -70,8 +70,17 @@
       latest patched 2.x — API-compatible within the 2.x major, so the parent
       package resolves against it. Drop this once Microsoft.AspNetCore.OpenApi
       references a patched Microsoft.OpenApi transitively.
+
+      Held at the 2.x major deliberately. Microsoft.OpenApi 3.x made
+      IOpenApiMediaType.Example read-only, but the Microsoft.AspNetCore.OpenApi
+      10.0.9 XML-comment source generator still assigns to it, so a 3.x bump
+      fails to compile (CS0200). Microsoft.AspNetCore.OpenApi 10.0.9 depends on
+      Microsoft.OpenApi (>= 2.0.0) and does not require 3.x, so there is no
+      forward path until its generator supports the 3.x example model. The 3.x
+      major is Dependabot-ignored (.github/dependabot.yml) until then; 2.x
+      minor/patch security bumps still flow. Tracked in #390.
     -->
-    <PackageReference Include="Microsoft.OpenApi" Version="2.9.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.10.0" />
     <!--
       Build-time OpenAPI document generator (Part D C8). PrivateAssets=all keeps the
       package out of the published output (it's an MSBuild task, not a runtime dependency).

--- a/src/ExpertiseApi/ExpertiseApi.csproj
+++ b/src/ExpertiseApi/ExpertiseApi.csproj
@@ -97,7 +97,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
     <PackageReference Include="Pgvector.EntityFrameworkCore" Version="0.3.0" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.16.6" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.16.10" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
   </ItemGroup>

--- a/src/ExpertiseApi/ExpertiseApi.csproj
+++ b/src/ExpertiseApi/ExpertiseApi.csproj
@@ -97,7 +97,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
     <PackageReference Include="Pgvector.EntityFrameworkCore" Version="0.3.0" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.16.10" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.16.11" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
   </ItemGroup>

--- a/src/ExpertiseApi/appsettings.json
+++ b/src/ExpertiseApi/appsettings.json
@@ -44,6 +44,17 @@
           "RoleSeparator": ":",
           "GroupClaim": "groups",
           "GroupToTenantMapping": {}
+        },
+        {
+          "Name": "LanStatic",
+          "Issuer": "<TODO_LAN_STATIC_ISSUER>",
+          "Audience": "expertise-api",
+          "AdditionalAudiences": [],
+          "ScopeClaims": ["roles"],
+          "TenantSource": "CompoundRole",
+          "RoleSeparator": ":",
+          "GroupClaim": "groups",
+          "GroupToTenantMapping": {}
         }
       ]
     },

--- a/src/ExpertiseApi/appsettings.json
+++ b/src/ExpertiseApi/appsettings.json
@@ -48,6 +48,7 @@
         {
           "Name": "LanStatic",
           "Issuer": "<TODO_LAN_STATIC_ISSUER>",
+          "JwksPath": "<TODO_LAN_STATIC_JWKS_PATH>",
           "Audience": "expertise-api",
           "AdditionalAudiences": [],
           "ScopeClaims": ["roles"],

--- a/tests/ExpertiseApi.Tests/Infrastructure/JwtTokenMinter.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/JwtTokenMinter.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography;
+using System.Text.Json;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 
@@ -37,7 +38,8 @@ public static class JwtTokenMinter
         string tenant,
         IEnumerable<string> scopes,
         string? sub = null,
-        TimeSpan? expiresIn = null)
+        TimeSpan? expiresIn = null,
+        SecurityKey? signingKey = null)
     {
         var handler = new JsonWebTokenHandler();
 
@@ -53,10 +55,34 @@ public static class JwtTokenMinter
             Audience = TestAudience,
             Claims = claims,
             Expires = DateTime.UtcNow.Add(expiresIn ?? TimeSpan.FromHours(1)),
-            SigningCredentials = new SigningCredentials(SigningKey, SecurityAlgorithms.RsaSha256)
+            // Defaults to the key embedded in the API's JWKS; pass a foreign key to prove a
+            // token whose kid is absent from the JWKS is rejected (the revocation mechanism).
+            SigningCredentials = new SigningCredentials(signingKey ?? SigningKey, SecurityAlgorithms.RsaSha256)
         };
 
         return handler.CreateToken(descriptor);
+    }
+
+    /// <summary>
+    /// PRIVATE JWKS JSON for <see cref="SigningKey"/> (carries <c>d</c>/<c>p</c>/<c>q</c>) — the
+    /// shape a JWKS would wrongly have if an operator pointed <c>JwksPath</c> at mint_token.py's
+    /// <c>*.priv.json</c>. Used to assert the loader rejects private-key material.
+    /// </summary>
+    public static string PrivateJwksJson()
+    {
+        var jwk = JsonWebKeyConverter.ConvertFromSecurityKey(SigningKey);
+        var doc = new
+        {
+            keys = new[]
+            {
+                new
+                {
+                    kty = "RSA", kid = jwk.Kid, use = "sig", alg = SecurityAlgorithms.RsaSha256,
+                    n = jwk.N, e = jwk.E, d = jwk.D, p = jwk.P, q = jwk.Q
+                }
+            }
+        };
+        return JsonSerializer.Serialize(doc);
     }
 
     public static string Mint(
@@ -100,5 +126,24 @@ public static class JwtTokenMinter
         };
 
         return handler.CreateToken(descriptor);
+    }
+
+    /// <summary>
+    /// Public-only JWKS JSON for <see cref="SigningKey"/> — the shape an embedded-key
+    /// (ADR-015) issuer's <c>jwks.json</c> carries. Tests write this to a temp file and point
+    /// <c>Auth:Oidc:Issuers:N:JwksPath</c> at it so the real production embedded-key branch in
+    /// <c>AuthExtensions.RegisterJwtBearer</c> loads and validates against it.
+    /// </summary>
+    public static string StaticJwksJson()
+    {
+        var jwk = JsonWebKeyConverter.ConvertFromSecurityKey(SigningKey);
+        var doc = new
+        {
+            keys = new[]
+            {
+                new { kty = "RSA", kid = jwk.Kid, use = "sig", alg = SecurityAlgorithms.RsaSha256, n = jwk.N, e = jwk.E }
+            }
+        };
+        return JsonSerializer.Serialize(doc);
     }
 }

--- a/tests/ExpertiseApi.Tests/Infrastructure/JwtTokenMinter.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/JwtTokenMinter.cs
@@ -15,10 +15,49 @@ public static class JwtTokenMinter
     public const string TestAudience = "test-audience";
     public const string TestSchemeName = "TestIssuer";
 
+    // ADR-014 static-LAN issuer: CompoundRole tenancy with scopes carried in a
+    // `roles` array claim (TenantSource=CompoundRole, ScopeClaims=["roles"],
+    // RoleSeparator=":"). Distinct issuer URL so the policy scheme routes by `iss`;
+    // shares SigningKey so JwtApiFactory can inject one OIDC config per scheme.
+    public const string CompoundRoleIssuer = "https://static-issuer.local/";
+    public const string CompoundRoleSchemeName = "StaticLan";
+
     public static readonly RsaSecurityKey SigningKey = new(RSA.Create(2048))
     {
         KeyId = "test-key-1"
     };
+
+    /// <summary>
+    /// Mints a static-LAN CompoundRole token exactly as <c>scripts/mint_token.py</c> emits:
+    /// each scope becomes a <c>roles</c> array entry of the form <c>{tenant}:{scope}</c>.
+    /// <paramref name="scopes"/> are fully-qualified scope strings (e.g.
+    /// <see cref="AuthConstants.WriteDraftScope"/>), matching the confirmed ADR-014 contract.
+    /// </summary>
+    public static string MintCompoundRole(
+        string tenant,
+        IEnumerable<string> scopes,
+        string? sub = null,
+        TimeSpan? expiresIn = null)
+    {
+        var handler = new JsonWebTokenHandler();
+
+        var claims = new Dictionary<string, object>
+        {
+            ["sub"] = sub ?? "static-lan-client",
+            ["roles"] = scopes.Select(s => $"{tenant}:{s}").ToArray()
+        };
+
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = CompoundRoleIssuer,
+            Audience = TestAudience,
+            Claims = claims,
+            Expires = DateTime.UtcNow.Add(expiresIn ?? TimeSpan.FromHours(1)),
+            SigningCredentials = new SigningCredentials(SigningKey, SecurityAlgorithms.RsaSha256)
+        };
+
+        return handler.CreateToken(descriptor);
+    }
 
     public static string Mint(
         string tenant,

--- a/tests/ExpertiseApi.Tests/Integration/StaticIssuerCompoundRoleTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/StaticIssuerCompoundRoleTests.cs
@@ -1,27 +1,27 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using System.Text.Json;
+using System.Security.Cryptography;
 using ExpertiseApi.Auth;
 using ExpertiseApi.Tests.Infrastructure;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
 
 namespace ExpertiseApi.Tests.Integration;
 
 /// <summary>
-/// ADR-014 regression guard: an offline-minted, static-issuer token authenticates and
-/// authorizes end-to-end through the UNMODIFIED API, proving the "no code change" claim.
-/// The token carries a <c>roles</c> array of <c>{tenant}:{fully-qualified-scope}</c> and is
-/// validated against a second issuer configured for <c>TenantSource=CompoundRole</c> /
+/// ADR-014/ADR-015 regression guard: an offline-minted, static-issuer token authenticates and
+/// authorizes end-to-end through the UNMODIFIED API, proving the "no code change to accept the
+/// token" claim. The token carries a <c>roles</c> array of <c>{tenant}:{fully-qualified-scope}</c>
+/// and is validated against a second issuer configured for <c>TenantSource=CompoundRole</c> /
 /// <c>ScopeClaims=["roles"]</c> — the shape <c>scripts/mint_token.py</c> emits.
 ///
-/// The issuer is wired here (not in the shared <see cref="JwtApiFactory"/>) so the factory's
-/// default Authentik-style issuer stays untouched; the second scheme's OIDC configuration is
-/// injected in-process so no JWKS HTTP fetch occurs (the live HTTPS metadata fetch is a
-/// framework concern, not an API-behaviour one).
+/// This exercises the real ADR-015 <b>embedded-key</b> path: a public <c>jwks.json</c> is
+/// written to a temp file and <c>Auth:Oidc:Issuers:1:JwksPath</c> points at it, so the
+/// production <c>AuthExtensions.RegisterJwtBearer</c> embedded-key branch (not a test-only
+/// PostConfigure) loads the keys with no HTTPS discovery fetch. The issuer is wired here rather
+/// than in the shared <see cref="JwtApiFactory"/> so the factory's default Authentik-style
+/// discovery issuer stays untouched.
 /// </summary>
 [Collection("Postgres")]
 public class StaticIssuerCompoundRoleTests : IAsyncLifetime
@@ -29,41 +29,32 @@ public class StaticIssuerCompoundRoleTests : IAsyncLifetime
     private readonly PostgresFixture _postgres;
     private WebApplicationFactory<Program> _factory = null!;
     private JwtApiFactory _baseFactory = null!;
+    private string _jwksPath = null!;
 
     public StaticIssuerCompoundRoleTests(PostgresFixture postgres) => _postgres = postgres;
 
     public Task InitializeAsync()
     {
+        // A real on-disk public JWKS for the embedded-key issuer — the production code reads it.
+        _jwksPath = Path.Combine(Path.GetTempPath(), $"adr015-jwks-{Guid.NewGuid():N}.json");
+        File.WriteAllText(_jwksPath, JwtTokenMinter.StaticJwksJson());
+
         _baseFactory = new JwtApiFactory(_postgres.ConnectionString);
         _factory = _baseFactory.WithWebHostBuilder(builder =>
         {
-            // Register the static-LAN CompoundRole issuer as a second issuer (index 1).
+            // Register the static-LAN CompoundRole issuer as a second issuer (index 1),
+            // embedded-key (ADR-015): JwksPath set, no Authority/discovery.
             builder.UseSetting("Auth:Oidc:Issuers:1:Name", JwtTokenMinter.CompoundRoleSchemeName);
             builder.UseSetting("Auth:Oidc:Issuers:1:Issuer", JwtTokenMinter.CompoundRoleIssuer);
             builder.UseSetting("Auth:Oidc:Issuers:1:Audience", JwtTokenMinter.TestAudience);
             builder.UseSetting("Auth:Oidc:Issuers:1:ScopeClaims:0", "roles");
             builder.UseSetting("Auth:Oidc:Issuers:1:TenantSource", "CompoundRole");
             builder.UseSetting("Auth:Oidc:Issuers:1:RoleSeparator", ":");
+            builder.UseSetting("Auth:Oidc:Issuers:1:JwksPath", _jwksPath);
 
             // Mock embeddings collapse distinct entries; disable dedup so per-row audit
             // attribution is real (mirrors ActorClassAuditTests).
             builder.UseSetting("Deduplication:Enabled", "false");
-
-            builder.ConfigureServices(services =>
-            {
-                // Preload OIDC config for the second scheme so JwtBearer skips the JWKS fetch.
-                services.PostConfigure<JwtBearerOptions>(JwtTokenMinter.CompoundRoleSchemeName, options =>
-                {
-                    options.Configuration = new OpenIdConnectConfiguration
-                    {
-                        Issuer = JwtTokenMinter.CompoundRoleIssuer
-                    };
-                    options.Configuration.SigningKeys.Add(JwtTokenMinter.SigningKey);
-                    options.TokenValidationParameters.IssuerSigningKey = JwtTokenMinter.SigningKey;
-                    options.MetadataAddress = null!;
-                    options.ConfigurationManager = null;
-                });
-            });
         });
         return Task.CompletedTask;
     }
@@ -72,6 +63,8 @@ public class StaticIssuerCompoundRoleTests : IAsyncLifetime
     {
         await _factory.DisposeAsync();
         await _baseFactory.DisposeAsync();
+        if (File.Exists(_jwksPath))
+            File.Delete(_jwksPath);
     }
 
     private HttpClient CompoundRoleClient(string tenant, IEnumerable<string> scopes)
@@ -94,7 +87,7 @@ public class StaticIssuerCompoundRoleTests : IAsyncLifetime
     private static object UniquePayload() => new
     {
         domain = "shared",
-        title = $"ADR-014 static-issuer fixture {Guid.NewGuid():N}",
+        title = $"ADR-015 static-issuer fixture {Guid.NewGuid():N}",
         body = $"Body for a compound-role authorization test ({Guid.NewGuid()}).",
         entryType = "Pattern",
         severity = "Info",
@@ -102,9 +95,10 @@ public class StaticIssuerCompoundRoleTests : IAsyncLifetime
     };
 
     [Fact]
-    public async Task CompoundRoleToken_WithReadScope_AuthorizesListEndpoint()
+    public async Task EmbeddedKeyToken_WithReadScope_AuthorizesListEndpoint()
     {
-        // Read scope carried as "test:expertise.read" → ReadAccess policy satisfied.
+        // Read scope carried as "test:expertise.read" → ReadAccess policy satisfied, validated
+        // against the embedded JWKS with no discovery fetch.
         var client = CompoundRoleClient("test", [AuthConstants.ReadScope]);
 
         var response = await client.GetAsync("/expertise");
@@ -114,11 +108,12 @@ public class StaticIssuerCompoundRoleTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task CompoundRoleToken_WriteDraftAndAgent_CreatesInDerivedTenant_AndTagsAgent()
+    public async Task EmbeddedKeyToken_WriteDraftAndAgent_CreatesInDerivedTenant_AndTagsAgent()
     {
         // roles: ["test:expertise.write.draft", "test:expertise.agent"].
-        // Proves the full pipeline: roles-array extraction → CompoundRole parse (tenant=test)
-        // → scope closure (write.draft ⊇ read) → actor-class (agent scope) → tenant attribution.
+        // Proves the full pipeline: embedded-key validation → roles-array extraction →
+        // CompoundRole parse (tenant=test) → scope closure (write.draft ⊇ read) →
+        // actor-class (agent scope) → tenant attribution.
         var client = CompoundRoleClient("test", [AuthConstants.WriteDraftScope, AuthConstants.AgentScope]);
 
         var create = await client.PostAsJsonAsync("/expertise", UniquePayload());
@@ -137,7 +132,7 @@ public class StaticIssuerCompoundRoleTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task CompoundRoleToken_WithoutWriteScope_IsForbiddenOnCreate()
+    public async Task EmbeddedKeyToken_WithoutWriteScope_IsForbiddenOnCreate()
     {
         // Read-only token must NOT satisfy WriteAccess — authorization is enforced, not just parsed.
         var client = CompoundRoleClient("test", [AuthConstants.ReadScope]);
@@ -145,5 +140,23 @@ public class StaticIssuerCompoundRoleTests : IAsyncLifetime
         var response = await client.PostAsJsonAsync("/expertise", UniquePayload());
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task EmbeddedKeyToken_SignedWithKeyNotInJwks_IsUnauthorized()
+    {
+        // Revocation mechanism: a token signed with a key whose kid is absent from the embedded
+        // JWKS must be rejected (dropping a client's key + restart is how ADR-015 revokes it).
+        using var foreignKey = RSA.Create(2048);
+        var token = JwtTokenMinter.MintCompoundRole(
+            "test",
+            [AuthConstants.ReadScope],
+            signingKey: new RsaSecurityKey(foreignKey) { KeyId = "not-in-jwks" });
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await client.GetAsync("/expertise");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 }

--- a/tests/ExpertiseApi.Tests/Integration/StaticIssuerCompoundRoleTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/StaticIssuerCompoundRoleTests.cs
@@ -1,0 +1,149 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ExpertiseApi.Auth;
+using ExpertiseApi.Tests.Infrastructure;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace ExpertiseApi.Tests.Integration;
+
+/// <summary>
+/// ADR-014 regression guard: an offline-minted, static-issuer token authenticates and
+/// authorizes end-to-end through the UNMODIFIED API, proving the "no code change" claim.
+/// The token carries a <c>roles</c> array of <c>{tenant}:{fully-qualified-scope}</c> and is
+/// validated against a second issuer configured for <c>TenantSource=CompoundRole</c> /
+/// <c>ScopeClaims=["roles"]</c> — the shape <c>scripts/mint_token.py</c> emits.
+///
+/// The issuer is wired here (not in the shared <see cref="JwtApiFactory"/>) so the factory's
+/// default Authentik-style issuer stays untouched; the second scheme's OIDC configuration is
+/// injected in-process so no JWKS HTTP fetch occurs (the live HTTPS metadata fetch is a
+/// framework concern, not an API-behaviour one).
+/// </summary>
+[Collection("Postgres")]
+public class StaticIssuerCompoundRoleTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private WebApplicationFactory<Program> _factory = null!;
+    private JwtApiFactory _baseFactory = null!;
+
+    public StaticIssuerCompoundRoleTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public Task InitializeAsync()
+    {
+        _baseFactory = new JwtApiFactory(_postgres.ConnectionString);
+        _factory = _baseFactory.WithWebHostBuilder(builder =>
+        {
+            // Register the static-LAN CompoundRole issuer as a second issuer (index 1).
+            builder.UseSetting("Auth:Oidc:Issuers:1:Name", JwtTokenMinter.CompoundRoleSchemeName);
+            builder.UseSetting("Auth:Oidc:Issuers:1:Issuer", JwtTokenMinter.CompoundRoleIssuer);
+            builder.UseSetting("Auth:Oidc:Issuers:1:Audience", JwtTokenMinter.TestAudience);
+            builder.UseSetting("Auth:Oidc:Issuers:1:ScopeClaims:0", "roles");
+            builder.UseSetting("Auth:Oidc:Issuers:1:TenantSource", "CompoundRole");
+            builder.UseSetting("Auth:Oidc:Issuers:1:RoleSeparator", ":");
+
+            // Mock embeddings collapse distinct entries; disable dedup so per-row audit
+            // attribution is real (mirrors ActorClassAuditTests).
+            builder.UseSetting("Deduplication:Enabled", "false");
+
+            builder.ConfigureServices(services =>
+            {
+                // Preload OIDC config for the second scheme so JwtBearer skips the JWKS fetch.
+                services.PostConfigure<JwtBearerOptions>(JwtTokenMinter.CompoundRoleSchemeName, options =>
+                {
+                    options.Configuration = new OpenIdConnectConfiguration
+                    {
+                        Issuer = JwtTokenMinter.CompoundRoleIssuer
+                    };
+                    options.Configuration.SigningKeys.Add(JwtTokenMinter.SigningKey);
+                    options.TokenValidationParameters.IssuerSigningKey = JwtTokenMinter.SigningKey;
+                    options.MetadataAddress = null!;
+                    options.ConfigurationManager = null;
+                });
+            });
+        });
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _factory.DisposeAsync();
+        await _baseFactory.DisposeAsync();
+    }
+
+    private HttpClient CompoundRoleClient(string tenant, IEnumerable<string> scopes)
+    {
+        var token = JwtTokenMinter.MintCompoundRole(tenant, scopes);
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
+    }
+
+    private HttpClient AdminClient()
+    {
+        // Cross-tenant admin via the default Authentik-style issuer (group → shared tenant).
+        var token = JwtTokenMinter.Mint(tenant: "shared", scopes: [AuthConstants.AdminScope], groups: ["group-shared"]);
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
+    }
+
+    private static object UniquePayload() => new
+    {
+        domain = "shared",
+        title = $"ADR-014 static-issuer fixture {Guid.NewGuid():N}",
+        body = $"Body for a compound-role authorization test ({Guid.NewGuid()}).",
+        entryType = "Pattern",
+        severity = "Info",
+        source = "test"
+    };
+
+    [Fact]
+    public async Task CompoundRoleToken_WithReadScope_AuthorizesListEndpoint()
+    {
+        // Read scope carried as "test:expertise.read" → ReadAccess policy satisfied.
+        var client = CompoundRoleClient("test", [AuthConstants.ReadScope]);
+
+        var response = await client.GetAsync("/expertise");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task CompoundRoleToken_WriteDraftAndAgent_CreatesInDerivedTenant_AndTagsAgent()
+    {
+        // roles: ["test:expertise.write.draft", "test:expertise.agent"].
+        // Proves the full pipeline: roles-array extraction → CompoundRole parse (tenant=test)
+        // → scope closure (write.draft ⊇ read) → actor-class (agent scope) → tenant attribution.
+        var client = CompoundRoleClient("test", [AuthConstants.WriteDraftScope, AuthConstants.AgentScope]);
+
+        var create = await client.PostAsJsonAsync("/expertise", UniquePayload());
+        create.StatusCode.Should().Be(HttpStatusCode.Created,
+            await create.Content.ReadAsStringAsync());
+        var entryId = (await create.Content.ReadJsonElementAsync()).GetProperty("id").GetGuid();
+
+        var audit = await AdminClient().GetAsync("/audit");
+        audit.StatusCode.Should().Be(HttpStatusCode.OK);
+        var rows = (await audit.Content.ReadJsonElementAsync()).EnumerateArray().ToArray();
+        var row = rows.Single(r => r.GetProperty("entryId").GetGuid() == entryId);
+
+        row.GetProperty("tenant").GetString().Should().Be("test");
+        row.GetProperty("actorClass").GetString().Should().Be("Agent");
+        row.GetProperty("authMethod").GetString().Should().Be(AuthExtensions.BearerScheme);
+    }
+
+    [Fact]
+    public async Task CompoundRoleToken_WithoutWriteScope_IsForbiddenOnCreate()
+    {
+        // Read-only token must NOT satisfy WriteAccess — authorization is enforced, not just parsed.
+        var client = CompoundRoleClient("test", [AuthConstants.ReadScope]);
+
+        var response = await client.PostAsJsonAsync("/expertise", UniquePayload());
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+}

--- a/tests/ExpertiseApi.Tests/Unit/AuthModeStartupGuardTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/AuthModeStartupGuardTests.cs
@@ -146,6 +146,171 @@ public class AuthModeStartupGuardTests
         act.Should().NotThrow();
     }
 
+    [Fact]
+    public void LoadStaticSigningKeys_MissingFile_FailsClosed()
+    {
+        // ADR-015: an embedded-key issuer whose JWKS file is absent must fail startup, not 500
+        // on first request. This is the embedded-key analogue of EnforceOidcIssuersGuard.
+        var issuer = new OidcIssuerOptions
+        {
+            Name = "LanStatic",
+            Issuer = "https://static-issuer.local/",
+            Audience = "expertise-api",
+            JwksPath = Path.Combine(Path.GetTempPath(), $"does-not-exist-{Guid.NewGuid():N}.json")
+        };
+
+        var act = () => AuthExtensions.LoadStaticSigningKeys(issuer);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*could not be read*");
+    }
+
+    [Fact]
+    public void LoadStaticSigningKeys_EmptyKeySet_FailsClosed()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"empty-jwks-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, "{\"keys\":[]}");
+        try
+        {
+            var issuer = new OidcIssuerOptions
+            {
+                Name = "LanStatic",
+                Issuer = "https://static-issuer.local/",
+                Audience = "expertise-api",
+                JwksPath = path
+            };
+
+            var act = () => AuthExtensions.LoadStaticSigningKeys(issuer);
+
+            act.Should().Throw<InvalidOperationException>().WithMessage("*no signing keys*");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void LoadStaticSigningKeys_MalformedJson_FailsClosed()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"bad-jwks-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, "this is not json");
+        try
+        {
+            var issuer = new OidcIssuerOptions
+            {
+                Name = "LanStatic",
+                Issuer = "https://static-issuer.local/",
+                Audience = "expertise-api",
+                JwksPath = path
+            };
+
+            var act = () => AuthExtensions.LoadStaticSigningKeys(issuer);
+
+            act.Should().Throw<InvalidOperationException>();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void LoadStaticSigningKeys_ValidJwks_ReturnsKeys()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"good-jwks-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, Infrastructure.JwtTokenMinter.StaticJwksJson());
+        try
+        {
+            var issuer = new OidcIssuerOptions
+            {
+                Name = "LanStatic",
+                Issuer = "https://static-issuer.local/",
+                Audience = "expertise-api",
+                JwksPath = path
+            };
+
+            var keys = AuthExtensions.LoadStaticSigningKeys(issuer);
+
+            keys.Should().ContainSingle();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void LoadStaticSigningKeys_PrivateKeyMaterial_FailsClosed()
+    {
+        // Operator footgun: JwksPath points at mint_token.py's *.priv.json (private key) instead
+        // of the build-jwks public output. Must fail closed, not load a forging key into the API.
+        var path = Path.Combine(Path.GetTempPath(), $"private-jwks-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, Infrastructure.JwtTokenMinter.PrivateJwksJson());
+        try
+        {
+            var issuer = new OidcIssuerOptions
+            {
+                Name = "LanStatic",
+                Issuer = "https://static-issuer.local/",
+                Audience = "expertise-api",
+                JwksPath = path
+            };
+
+            var act = () => AuthExtensions.LoadStaticSigningKeys(issuer);
+
+            act.Should().Throw<InvalidOperationException>().WithMessage("*PRIVATE key material*");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void LoadStaticSigningKeys_RealMintTokenOutput_LoadsSuccessfully()
+    {
+        // Proves scripts/mint_token.py's ACTUAL `build-jwks` output shape (alg/e/kid/kty/n/use,
+        // public-only) is consumable by the production loader — locking the Python-tool ↔ API
+        // config contract that the C#-side StaticJwksJson() helper alone would not guarantee.
+        var path = Path.Combine(Path.GetTempPath(), $"real-jwks-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, RealMintTokenJwks);
+        try
+        {
+            var issuer = new OidcIssuerOptions
+            {
+                Name = "LanStatic",
+                Issuer = "https://auth.lan.example/",
+                Audience = "expertise-api",
+                JwksPath = path
+            };
+
+            var keys = AuthExtensions.LoadStaticSigningKeys(issuer);
+
+            keys.Should().ContainSingle();
+            keys[0].KeyId.Should().Be("vm-alpha");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    // Verbatim output of `scripts/mint_token.py build-jwks` (public-only), captured 2026-07-10.
+    private const string RealMintTokenJwks = """
+        {
+          "keys": [
+            {
+              "alg": "RS256",
+              "e": "AQAB",
+              "kid": "vm-alpha",
+              "kty": "RSA",
+              "n": "2Cy1UNsX24KYM-Sqo6qAY5XFPa68v1fgUKMCf2qgUTx2-eHz3Tfs1iIusxrQfaAKzMIbaSwWhP5MExqWP-0O6vexZktmU2erTICZNzbielVeMwR0iZI5TmZYEwj2upr8Eprf8ujKAKFeQZ8SNd6pa1NgKdc9IDVhgT5GiXSoIx-89e0Ns4JdZnqp7D23AC9l3V2bYu6MATANXa7A8oXp4QqpXA3UIe5OT4k5c-HEcngP_vmMVCnrSLd6pNxAhvMZ--67wipjTYRJzg-iE2hNSAWFmehnHGyE5-C58mqbMydUG4aAE34QiwmvHGhmPrWyUX9Gykco3vUWe42InpO-gw",
+              "use": "sig"
+            }
+          ]
+        }
+        """;
+
     private class HostingEnvironment : IHostEnvironment
     {
         public string EnvironmentName { get; set; } = Environments.Development;

--- a/tests/ExpertiseApi.Tests/Unit/AuthModeStartupGuardTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/AuthModeStartupGuardTests.cs
@@ -267,6 +267,37 @@ public class AuthModeStartupGuardTests
     }
 
     [Fact]
+    public void LoadStaticSigningKeys_SymmetricKeyMaterial_FailsClosed()
+    {
+        // A symmetric (kty=oct) JWK carries a shared secret in `k`. Loading it into a
+        // network-facing JWKS would let anyone who can read the file forge HS256 tokens the API
+        // accepts. Embedded-key issuers are RS256-only, so this must fail closed at startup.
+        var path = Path.Join(Path.GetTempPath(), $"oct-jwks-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, """
+            { "keys": [ { "kty": "oct", "kid": "sym-1", "alg": "HS256", "use": "sig",
+              "k": "c2VjcmV0LXNoYXJlZC1obWFjLWtleS1tYXRlcmlhbA" } ] }
+            """);
+        try
+        {
+            var issuer = new OidcIssuerOptions
+            {
+                Name = "LanStatic",
+                Issuer = "https://static-issuer.local/",
+                Audience = "expertise-api",
+                JwksPath = path
+            };
+
+            var act = () => AuthExtensions.LoadStaticSigningKeys(issuer);
+
+            act.Should().Throw<InvalidOperationException>().WithMessage("*SYMMETRIC*");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public void LoadStaticSigningKeys_RealMintTokenOutput_LoadsSuccessfully()
     {
         // Proves scripts/mint_token.py's ACTUAL `build-jwks` output shape (alg/e/kid/kty/n/use,


### PR DESCRIPTION
## Release promotion: `dev` → `main`

Promotes the accumulated `dev` work since **v1.3.0**. semantic-release will compute the bump from the Conventional Commits below — the headline is the ADR-015 `feat`, so this is a **MINOR** release (expected **v1.4.0**).

### Headline changes
- **feat(auth):** embedded static-JWKS issuer for LAN consumers — ADR-015 (supersedes ADR-014). No HTTPS discovery / CA-trust on the API host; fail-closed key load. (#395, #393, #383, #396)
- **fix(auth):** pre-release hardening of that path — reject symmetric `kty=oct` keys, pin embedded path to RS256, mint_token.py private-key TOCTOU + privileged-scope guard, gitignore private JWK material, doc-sync. (#397)
- Dependabot maintenance bumps (actions + NuGet).

### Review evidence
Full four-way pre-release review (security / code / domain-owner / linter) — zero Critical/Error findings; all Warning-level items addressed in #397. All `dev` CI checks green on the final commit.

### Merge mechanics (per github-flow / semver-tagging)
- **Merge method: Create a merge commit** (NOT squash) — preserves the squash SHAs `dev` carries so `dev` and `main` do not diverge.
- After merge, `release.yml` runs semantic-release on `main`: cuts the `v`-tag, builds multi-arch images, publishes the cosign-signed A2 tarball + Helm chart, and syncs `Chart.yaml` version/appVersion to the new version.
- Do not merge `main` back to `dev`.