### PR TITLE
fix(search): bge query prefix, websearch tsquery, keyword limit, 400 on binding failure

### DIFF
--- a/.agents/skills/expertise-api/references/DESIGN.md
+++ b/.agents/skills/expertise-api/references/DESIGN.md
@@ -117,7 +117,7 @@ Single-row `EmbeddingMetadata` table tracks model name, dimensions, and `LastRee
 | GET | `/expertise/drafts` | `expertise.write.approve` | List Draft + Rejected entries in caller's tenant | |
 | POST | `/expertise/{id}/approve` | `expertise.write.approve` | Transition Draft → Approved | |
 | POST | `/expertise/{id}/reject` | `expertise.write.approve` | Transition Draft → Rejected (requires reason) | |
-| GET | `/expertise/search?q=` | `expertise.read` | Keyword full-text search (tsvector) | `includeDeprecated` |
+| GET | `/expertise/search?q=` | `expertise.read` | Keyword full-text search (`websearch_to_tsquery` over tsvector, `ts_rank_cd` ranked; supports quoted phrases, OR, `-negation`) | `limit` (1-100, default 50), `includeDeprecated` |
 | GET | `/expertise/search/semantic?q=` | `expertise.read` | Semantic vector search (pgvector) | `limit` (1-100, default 10), `includeDeprecated` |
 | GET | `/audit` | `expertise.admin` | Cross-tenant audit log | `entryId`, `principal`, `action`, `from`, `to`, `limit` (1-200, default 50), cursor (`afterTimestamp` + `afterId`) |
 | GET | `/health` | none | Liveness probe | |
@@ -262,7 +262,8 @@ scripts/                   # download-models.sh
 - **SOPS key:** Back up age private key separately — if lost, encrypted secrets are unrecoverable.
 - **k3s:** Must disable Traefik with `--disable=traefik` at install time.
 - **`reembed` CLI:** Run as a one-off k8s Job, not from a running API replica, to avoid concurrent row writes.
-- **Keyword search uses raw SQL:** The stored `SearchVector` column cannot be queried via LINQ — `KeywordSearchAsync` uses `FromSqlInterpolated`.
+- **Keyword search uses raw SQL:** The stored `SearchVector` column cannot be queried via LINQ — `KeywordSearchAsync` uses `FromSqlInterpolated` (`websearch_to_tsquery` + `ts_rank_cd` + `LIMIT`; all filtering and ordering must stay inside the SQL string — composing LINQ on top wraps it in a subquery and can drop the inner ORDER BY).
+- **bge query-instruction prefix:** bge-family embedding models are trained asymmetrically — QUERY-side text must be prefixed with `Represent this sentence for searching relevant passages: ` (see `EmbeddingService.QueryInstruction`); document-side text is embedded unprefixed. Semantic search uses `GenerateQueryEmbeddingAsync`; create/reembed/dedup paths use the unprefixed document path. A model swap must re-verify the instruction wording against the new model's card.
 - **ONNX model files not committed:** `src/ExpertiseApi/models/` is gitignored. Model files must be present at runtime for embedding generation and semantic search. CRUD and keyword search work without them.
 - **`EmbeddingMetadata` not auto-updated:** The metadata row is only written by the `reembed` CLI command, not by normal POST/PATCH operations.
 

--- a/src/ExpertiseApi/Data/ExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/ExpertiseRepository.cs
@@ -394,31 +394,38 @@ internal class ExpertiseRepository(
             .FirstOrDefaultAsync(ct);
     }
 
-    public async Task<List<ExpertiseEntry>> KeywordSearchAsync(string query, TenantContext ctx, bool includeDeprecated, CancellationToken ct)
+    public async Task<List<ExpertiseEntry>> KeywordSearchAsync(string query, TenantContext ctx, bool includeDeprecated, int limit, CancellationToken ct)
     {
         // Tenant + ReviewState + DeprecatedAt filters live inside the raw SQL alongside
-        // ORDER BY ts_rank because composing LINQ Where on top of FromSqlInterpolated
-        // wraps the original query in a subquery — the planner may then drop the inner
-        // ORDER BY since the subquery has no LIMIT, leaving result order undefined.
+        // ORDER BY because composing LINQ Where on top of FromSqlInterpolated wraps the
+        // original query in a subquery — the planner may then drop the inner ORDER BY
+        // since the subquery has no LIMIT, leaving result order undefined.
+        //
+        // websearch_to_tsquery over plainto_tsquery: adds phrase quoting, OR, and
+        // -negation while never throwing on malformed input. ts_rank_cd over ts_rank:
+        // cover-density ranking rewards term proximity, which performs better on the
+        // short few-word queries agent callers issue (#424).
         var tenant = RequireTenant(ctx);
         var approvedState = nameof(ReviewState.Approved);
 
         if (includeDeprecated)
             return await db.ExpertiseEntries.FromSqlInterpolated($"""
                 SELECT *, xmin FROM "ExpertiseEntries"
-                WHERE "SearchVector" @@ plainto_tsquery('english', {query})
+                WHERE "SearchVector" @@ websearch_to_tsquery('english', {query})
                   AND ("Tenant" = {tenant} OR "Tenant" = 'shared')
                   AND "ReviewState" = {approvedState}
-                ORDER BY ts_rank("SearchVector", plainto_tsquery('english', {query})) DESC
+                ORDER BY ts_rank_cd("SearchVector", websearch_to_tsquery('english', {query})) DESC
+                LIMIT {limit}
                 """).ToListAsync(ct);
 
         return await db.ExpertiseEntries.FromSqlInterpolated($"""
             SELECT *, xmin FROM "ExpertiseEntries"
-            WHERE "SearchVector" @@ plainto_tsquery('english', {query})
+            WHERE "SearchVector" @@ websearch_to_tsquery('english', {query})
               AND ("Tenant" = {tenant} OR "Tenant" = 'shared')
               AND "ReviewState" = {approvedState}
               AND "DeprecatedAt" IS NULL
-            ORDER BY ts_rank("SearchVector", plainto_tsquery('english', {query})) DESC
+            ORDER BY ts_rank_cd("SearchVector", websearch_to_tsquery('english', {query})) DESC
+            LIMIT {limit}
             """).ToListAsync(ct);
     }
 

--- a/src/ExpertiseApi/Data/IExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/IExpertiseRepository.cs
@@ -81,7 +81,7 @@ internal interface IExpertiseRepository
     /// </summary>
     Task<ExpertiseAuditLog?> GetAuditByIdAsync(Guid id, CancellationToken ct = default);
 
-    Task<List<ExpertiseEntry>> KeywordSearchAsync(string query, TenantContext ctx, bool includeDeprecated = false, CancellationToken ct = default);
+    Task<List<ExpertiseEntry>> KeywordSearchAsync(string query, TenantContext ctx, bool includeDeprecated = false, int limit = 50, CancellationToken ct = default);
 
     Task<List<ExpertiseEntry>> SemanticSearchAsync(Vector queryVector, TenantContext ctx, int limit = 10, bool includeDeprecated = false, CancellationToken ct = default);
 

--- a/src/ExpertiseApi/Diagnostics/UnhandledExceptionLogger.cs
+++ b/src/ExpertiseApi/Diagnostics/UnhandledExceptionLogger.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.WebUtilities;
 
 namespace ExpertiseApi.Diagnostics;
 
@@ -7,11 +8,15 @@ namespace ExpertiseApi.Diagnostics;
 /// — the .NET 8+ preferred shape for global exception logging without claiming the
 /// response body (Part D C4).
 ///
-/// Returns <c>false</c> from <see cref="TryHandleAsync"/> so the framework's default
+/// Returns <c>false</c> from <see cref="TryHandleAsync"/> for genuinely unhandled
+/// exceptions so the framework's default
 /// <see cref="Microsoft.AspNetCore.Http.IProblemDetailsService"/> writer produces the
 /// response, which means the sanitizer registered in <c>AddProblemDetails(...)</c> in
 /// <c>Program.cs</c> fires for both <c>Results.Problem(...)</c> and unhandled-exception
-/// paths.
+/// paths. The one handled case is <see cref="BadHttpRequestException"/> (minimal-API
+/// binding failures), which is written with the exception's own status code instead of
+/// the middleware's generic 500 (#329) — still via <c>IProblemDetailsService</c>, so the
+/// same customizer fires.
 ///
 /// Critically, the full exception (message, type, stack) is logged server-side with
 /// the request path here; the customizer then strips Detail/Instance from the wire
@@ -29,20 +34,50 @@ namespace ExpertiseApi.Diagnostics;
 /// also be routed through <see cref="SanitizeForLog"/>.
 /// </para>
 /// </summary>
-internal sealed class UnhandledExceptionLogger(ILogger<UnhandledExceptionLogger> log)
+internal sealed class UnhandledExceptionLogger(
+    ILogger<UnhandledExceptionLogger> log,
+    IProblemDetailsService problemDetails)
     : IExceptionHandler
 {
-    public ValueTask<bool> TryHandleAsync(
+    public async ValueTask<bool> TryHandleAsync(
         HttpContext ctx,
         Exception ex,
         CancellationToken ct)
     {
+        // Minimal-API model binding throws BadHttpRequestException (e.g. a missing
+        // required [FromQuery] parameter, or a non-numeric value for an int param)
+        // BEFORE the handler's own validation guards run. Left to the default path,
+        // the exception middleware writes a generic 500 — a misleading "server error"
+        // for what is a malformed request (#329). Surface the exception's own status
+        // code via IProblemDetailsService so the AddProblemDetails customizer still
+        // fires (traceId + non-Development Detail scrub).
+        if (ex is BadHttpRequestException badRequest)
+        {
+            log.LogWarning("Bad request ({StatusCode}) for {Method} {Path}: {Reason}",
+                badRequest.StatusCode,
+                SanitizeForLog(ctx.Request.Method),
+                SanitizeForLog(ctx.Request.Path.Value),
+                SanitizeForLog(badRequest.Message));
+
+            ctx.Response.StatusCode = badRequest.StatusCode;
+            return await problemDetails.TryWriteAsync(new ProblemDetailsContext
+            {
+                HttpContext = ctx,
+                ProblemDetails =
+                {
+                    Status = badRequest.StatusCode,
+                    Title = ReasonPhrases.GetReasonPhrase(badRequest.StatusCode),
+                    Detail = badRequest.Message,
+                },
+            });
+        }
+
         log.LogError(ex, "Unhandled exception for {Method} {Path}",
             SanitizeForLog(ctx.Request.Method),
             SanitizeForLog(ctx.Request.Path.Value));
         // false = let the default IProblemDetailsService writer handle the response body
         // so the AddProblemDetails customizer in Program.cs runs (correlation ID + sanitization).
-        return ValueTask.FromResult(false);
+        return false;
     }
 
     /// <summary>

--- a/src/ExpertiseApi/Endpoints/SearchEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/SearchEndpoints.cs
@@ -18,8 +18,10 @@ internal static class SearchEndpoints
 
         group.MapGet("/", KeywordSearch)
             .WithSummary("Keyword search over entry title + body")
-            .WithDescription("PostgreSQL full-text search (`to_tsvector`) over Approved entries visible to the caller's tenant. " +
-                             "Query string `q` is required. Set `includeDeprecated=true` to surface soft-deleted entries.")
+            .WithDescription("PostgreSQL full-text search (`websearch_to_tsquery`, cover-density ranked) over Approved entries " +
+                             "visible to the caller's tenant. Query string `q` is required and supports web-search syntax " +
+                             "(quoted phrases, OR, -negation). Returns the top `limit` (clamped 1–100, default 50) matches. " +
+                             "Set `includeDeprecated=true` to surface soft-deleted entries.")
             .Produces<List<ExpertiseEntryResponse>>(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
@@ -35,13 +37,15 @@ internal static class SearchEndpoints
         IResponseHygiene hygiene,
         [FromQuery] string q,
         [FromQuery] bool includeDeprecated = false,
+        [FromQuery] int limit = 50,
         CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(q))
             return Results.Problem("Query parameter 'q' is required.", statusCode: 400);
 
         var tenantContext = httpContext.RequireTenantContext();
-        var results = await repo.KeywordSearchAsync(q, tenantContext, includeDeprecated, ct);
+        var clampedLimit = Math.Clamp(limit, 1, 100);
+        var results = await repo.KeywordSearchAsync(q, tenantContext, includeDeprecated, clampedLimit, ct);
         return Results.Ok(ExpertiseEntryResponse.FromMany(results, hygiene));
     }
 }

--- a/src/ExpertiseApi/Endpoints/SemanticSearchEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/SemanticSearchEndpoints.cs
@@ -46,7 +46,7 @@ internal static class SemanticSearchEndpoints
 
         var tenantContext = httpContext.RequireTenantContext();
         var clampedLimit = Math.Clamp(limit, 1, 100);
-        var queryVector = await embeddingService.GenerateEmbeddingAsync(q, ct);
+        var queryVector = await embeddingService.GenerateQueryEmbeddingAsync(q, ct);
         var results = await repo.SemanticSearchAsync(queryVector, tenantContext, clampedLimit, includeDeprecated, ct);
         return Results.Ok(ExpertiseEntryResponse.FromMany(results, hygiene));
     }

--- a/src/ExpertiseApi/Services/EmbeddingService.cs
+++ b/src/ExpertiseApi/Services/EmbeddingService.cs
@@ -5,7 +5,21 @@ namespace ExpertiseApi.Services;
 
 internal class EmbeddingService(IEmbeddingGenerator<string, Embedding<float>> generator)
 {
+    // bge-family models are trained asymmetrically for retrieval: the QUERY side carries
+    // this instruction, the document side never does. bge-micro-v2's own card omits it,
+    // but the model is distilled from BAAI/bge-small-en-v1.5, whose card specifies it
+    // (optional in v1.5 — "slight degradation" without — and most beneficial for short
+    // queries, which is exactly this API's agent query profile). Documents embedded via
+    // BuildInputText and the dedup path stay unprefixed: dedup compares document-vs-
+    // document, which is symmetric (#424).
+    internal const string QueryInstruction = "Represent this sentence for searching relevant passages: ";
+
     public static string BuildInputText(string title, string body) => $"{title} {body}";
+
+    public static string BuildQueryInputText(string query) => $"{QueryInstruction}{query}";
+
+    public Task<Vector> GenerateQueryEmbeddingAsync(string query, CancellationToken ct = default)
+        => GenerateEmbeddingAsync(BuildQueryInputText(query), ct);
 
     public async Task<Vector> GenerateEmbeddingAsync(string text, CancellationToken ct = default)
     {

--- a/tests/ExpertiseApi.Tests/Integration/SearchEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/SearchEndpointTests.cs
@@ -42,13 +42,61 @@ public class SearchEndpointTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task KeywordSearch_WhenMissingQuery_ReturnsError()
+    public async Task KeywordSearch_WhenMissingQuery_Returns400()
     {
-        // When 'q' is completely absent, ASP.NET Core binding fails before the handler runs.
-        // This produces a 500 rather than a clean 400 — a known gap (see #28 for similar issue).
+        // When 'q' is completely absent, binding throws BadHttpRequestException before
+        // the handler runs; UnhandledExceptionLogger maps it to the exception's own
+        // status code instead of a generic 500 (#329).
         var response = await _client.GetAsync("/expertise/search");
 
-        ((int)response.StatusCode).Should().BeOneOf(400, 500);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task KeywordSearch_WhenMissingQuery_ProblemDetailsCarriesTraceId()
+    {
+        var response = await _client.GetAsync("/expertise/search");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetProperty("status").GetInt32().Should().Be(400);
+        json.TryGetProperty("traceId", out _).Should().BeTrue(
+            "the AddProblemDetails customizer must fire on the binding-failure path");
+    }
+
+    [Fact]
+    public async Task KeywordSearch_RespectsLimit()
+    {
+        await SeedEntryViaRepo("dotnet", "Migration ordering first entry",
+            "Notes about migration ordering in EF Core, entry one.");
+        await SeedEntryViaRepo("dotnet", "Migration ordering second entry",
+            "Notes about migration ordering in EF Core, entry two.");
+        await SeedEntryViaRepo("dotnet", "Migration ordering third entry",
+            "Notes about migration ordering in EF Core, entry three.");
+
+        var response = await _client.GetAsync("/expertise/search?q=migration&limit=2");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetArrayLength().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task KeywordSearch_SupportsWebsearchSyntax()
+    {
+        await SeedEntryViaRepo("dotnet", "EF Core migration conflict resolution",
+            "When running migrations against a shared database, conflicts can arise.");
+        await SeedEntryViaRepo("kubernetes", "Pod scheduling strategy",
+            "Kubernetes pod scheduling uses taints and tolerations.");
+
+        // websearch_to_tsquery: -negation excludes; malformed operator input must not throw.
+        var negated = await _client.GetAsync("/expertise/search?q=migration%20-kubernetes");
+        negated.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await negated.Content.ReadJsonElementAsync();
+        json.GetArrayLength().Should().BeGreaterThan(0);
+
+        var malformed = await _client.GetAsync("/expertise/search?q=%22unbalanced%20AND%20OR%20(");
+        malformed.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [Fact]

--- a/tests/ExpertiseApi.Tests/Unit/EmbeddingServiceTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/EmbeddingServiceTests.cs
@@ -41,4 +41,47 @@ public class EmbeddingServiceTests
                 $"output {i} must correspond to input {i} — a reorder would attach the wrong embedding to an entry");
         }
     }
+
+    [Fact]
+    public void BuildQueryInputText_PrefixesBgeQueryInstruction()
+    {
+        // bge-family asymmetric retrieval: the query side carries the instruction, the
+        // document side (BuildInputText) never does (#424). If the instruction wording
+        // ever changes (model swap), stored document embeddings stay valid — only
+        // query-side embedding changes — but this pin forces the change to be deliberate.
+        EmbeddingService.BuildQueryInputText("pgvector index tuning")
+            .Should().Be("Represent this sentence for searching relevant passages: pgvector index tuning");
+
+        EmbeddingService.BuildInputText("title", "body")
+            .Should().Be("title body", "document-side input must remain unprefixed");
+    }
+
+    [Fact]
+    public async Task GenerateQueryEmbeddingAsync_EmbedsPrefixedQuery_NotRawQuery()
+    {
+        var generator = Substitute.For<IEmbeddingGenerator<string, Embedding<float>>>();
+        generator.GenerateAsync(
+                Arg.Any<IEnumerable<string>>(),
+                Arg.Any<EmbeddingGenerationOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var inputs = ci.ArgAt<IEnumerable<string>>(0).ToList();
+                var res = new GeneratedEmbeddings<Embedding<float>>();
+                foreach (var input in inputs)
+                    res.Add(new Embedding<float>(TestHelpers.CreateContentEmbedding(input)));
+                return Task.FromResult(res);
+            });
+
+        var service = new EmbeddingService(generator);
+
+        var queryVector = await service.GenerateQueryEmbeddingAsync("kafka rebalance");
+
+        queryVector.ToArray().Should().Equal(
+            TestHelpers.CreateContentEmbedding(EmbeddingService.BuildQueryInputText("kafka rebalance")),
+            "the query embedding must be generated from the instruction-prefixed text");
+        queryVector.ToArray().Should().NotEqual(
+            TestHelpers.CreateContentEmbedding("kafka rebalance"),
+            "embedding the raw query would silently drop the bge query instruction");
+    }
 }

--- a/tests/ExpertiseApi.Tests/Unit/RepositoryQueryTranslationTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/RepositoryQueryTranslationTests.cs
@@ -229,13 +229,15 @@ public class RepositoryQueryTranslationTests
         // ToQueryString on FromSql renders the raw SQL with its parameters — this pins the
         // interpolation/parameterization (it does not validate the tsquery against a live
         // server; SearchEndpointTests covers execution correctness).
+        var limit = 50;
         var query = db.ExpertiseEntries.FromSqlInterpolated($"""
             SELECT *, xmin FROM "ExpertiseEntries"
-            WHERE "SearchVector" @@ plainto_tsquery('english', {q})
+            WHERE "SearchVector" @@ websearch_to_tsquery('english', {q})
               AND ("Tenant" = {tenant} OR "Tenant" = 'shared')
               AND "ReviewState" = {approvedState}
               AND "DeprecatedAt" IS NULL
-            ORDER BY ts_rank("SearchVector", plainto_tsquery('english', {q})) DESC
+            ORDER BY ts_rank_cd("SearchVector", websearch_to_tsquery('english', {q})) DESC
+            LIMIT {limit}
             """);
 
         AssertTranslates(query, "keyword-search raw SQL must parameterize without throwing");


### PR DESCRIPTION
## Summary

PR 1 of the retrieval-adoption sequence (#424; plan recorded in `docs/research/2026-07-retrieval-assessment.md`). Four small, non-breaking correctness fixes on the search path:

- **bge query-instruction prefix** — semantic search embeds queries via new `GenerateQueryEmbeddingAsync` with the bge-family retrieval instruction (verified against the BAAI/bge-small-en-v1.5 parent model card; bge-micro-v2 is distilled from it). Document-side and dedup paths stay unprefixed — dedup is document-vs-document (symmetric). No re-embedding needed; stored embeddings remain valid.
- **`websearch_to_tsquery` + `ts_rank_cd`** — keyword search gains phrase quoting / OR / -negation, never throws on malformed operator input, and ranks with cover-density (better on short agent queries).
- **Keyword `limit`** — previously unbounded; endpoint now exposes `limit` (clamped 1–100, default 50), additive OpenAPI change.
- **#329** — `BadHttpRequestException` (minimal-API binding failure, e.g. missing required `q`) now surfaces its own status code through `IProblemDetailsService` instead of a generic 500; the ProblemDetails customizer (traceId + non-Dev Detail scrub) still fires.

## Test evidence

- Full suite: **394/394 passing** (Testcontainers via podman).
- New tests: query-prefix pin + prefixed-vs-raw embedding (unit), missing-`q` → 400 with traceId, keyword `limit` respected, websearch syntax incl. malformed input (integration); SQL-shape pin updated (websearch_to_tsquery/ts_rank_cd/LIMIT).
- `dotnet format analyzers --verify-no-changes` clean; linter agent verdict PASS.

## Doc impact

| Surface | Classification |
|---|---|
| DESIGN.md API Surface + Known Gotchas | in-scope (updated in this PR) |
| CLAUDE.md | not-a-thing (quick-start examples unaffected) |
| ADR | not-a-thing (bug-fix tier per the recorded plan; the hybrid-endpoint ADR comes with #428) |

Closes #424. Closes #329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)