### PR TITLE
feat(search): metadata filters on keyword and semantic search

### DIFF
--- a/.agents/skills/expertise-api/references/DESIGN.md
+++ b/.agents/skills/expertise-api/references/DESIGN.md
@@ -117,8 +117,8 @@ Single-row `EmbeddingMetadata` table tracks model name, dimensions, and `LastRee
 | GET | `/expertise/drafts` | `expertise.write.approve` | List Draft + Rejected entries in caller's tenant | |
 | POST | `/expertise/{id}/approve` | `expertise.write.approve` | Transition Draft → Approved | |
 | POST | `/expertise/{id}/reject` | `expertise.write.approve` | Transition Draft → Rejected (requires reason) | |
-| GET | `/expertise/search?q=` | `expertise.read` | Keyword full-text search (`websearch_to_tsquery` over tsvector, `ts_rank_cd` ranked; supports quoted phrases, OR, `-negation`) | `limit` (1-100, default 50), `includeDeprecated` |
-| GET | `/expertise/search/semantic?q=` | `expertise.read` | Semantic vector search (pgvector) | `limit` (1-100, default 10), `includeDeprecated` |
+| GET | `/expertise/search?q=` | `expertise.read` | Keyword full-text search (`websearch_to_tsquery` over tsvector, `ts_rank_cd` ranked; supports quoted phrases, OR, `-negation`) | `domain`, `tags` (comma-separated, all must match), `entryType`, `severity`, `limit` (1-100, default 50), `includeDeprecated` |
+| GET | `/expertise/search/semantic?q=` | `expertise.read` | Semantic vector search (pgvector) | `domain`, `tags` (comma-separated, all must match), `entryType`, `severity`, `limit` (1-100, default 10), `includeDeprecated` |
 | GET | `/audit` | `expertise.admin` | Cross-tenant audit log | `entryId`, `principal`, `action`, `from`, `to`, `limit` (1-200, default 50), cursor (`afterTimestamp` + `afterId`) |
 | GET | `/health` | none | Liveness probe | |
 | GET | `/metrics` | none | Prometheus scrape endpoint | |

--- a/src/ExpertiseApi/Data/ExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/ExpertiseRepository.cs
@@ -1,8 +1,10 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using ExpertiseApi.Auth;
 using ExpertiseApi.Models;
 using ExpertiseApi.Services;
 using Microsoft.EntityFrameworkCore;
+using Npgsql;
 using Pgvector;
 using Pgvector.EntityFrameworkCore;
 
@@ -128,6 +130,23 @@ internal class ExpertiseRepository(
         if (!includeDeprecated)
             query = query.Where(e => e.DeprecatedAt == null);
 
+        return ApplyMetadataFilters(query, domain, tags, entryType, severity)
+            .OrderByDescending(e => e.UpdatedAt);
+    }
+
+    /// <summary>
+    /// Optional structured-metadata predicates shared by <see cref="BuildListQuery"/> and
+    /// <see cref="SemanticSearchAsync"/> (#426) — one translation-tested seam instead of
+    /// two drift-prone copies. The keyword path applies the same semantics in raw SQL via
+    /// <see cref="BuildKeywordSearchQuery"/>.
+    /// </summary>
+    internal static IQueryable<ExpertiseEntry> ApplyMetadataFilters(
+        IQueryable<ExpertiseEntry> query,
+        string? domain,
+        List<string>? tags,
+        EntryType? entryType,
+        Severity? severity)
+    {
         if (domain is not null)
             query = query.Where(e => e.Domain == domain);
 
@@ -140,7 +159,7 @@ internal class ExpertiseRepository(
         if (tags is { Count: > 0 })
             query = query.Where(e => tags.All(t => e.Tags.Contains(t)));
 
-        return query.OrderByDescending(e => e.UpdatedAt);
+        return query;
     }
 
     public async Task<List<ExpertiseEntry>> ListDraftsAsync(TenantContext ctx, CancellationToken ct)
@@ -394,42 +413,84 @@ internal class ExpertiseRepository(
             .FirstOrDefaultAsync(ct);
     }
 
-    public async Task<List<ExpertiseEntry>> KeywordSearchAsync(string query, TenantContext ctx, bool includeDeprecated, int limit, CancellationToken ct)
+    public async Task<List<ExpertiseEntry>> KeywordSearchAsync(string query, TenantContext ctx, bool includeDeprecated, int limit, string? domain, List<string>? tags, EntryType? entryType, Severity? severity, CancellationToken ct)
     {
-        // Tenant + ReviewState + DeprecatedAt filters live inside the raw SQL alongside
-        // ORDER BY because composing LINQ Where on top of FromSqlInterpolated wraps the
-        // original query in a subquery — the planner may then drop the inner ORDER BY
-        // since the subquery has no LIMIT, leaving result order undefined.
-        //
-        // websearch_to_tsquery over plainto_tsquery: adds phrase quoting, OR, and
-        // -negation while never throwing on malformed input. ts_rank_cd over ts_rank:
-        // cover-density ranking rewards term proximity, which performs better on the
-        // short few-word queries agent callers issue (#424).
-        var tenant = RequireTenant(ctx);
-        var approvedState = nameof(ReviewState.Approved);
-
-        if (includeDeprecated)
-            return await db.ExpertiseEntries.FromSqlInterpolated($"""
-                SELECT *, xmin FROM "ExpertiseEntries"
-                WHERE "SearchVector" @@ websearch_to_tsquery('english', {query})
-                  AND ("Tenant" = {tenant} OR "Tenant" = 'shared')
-                  AND "ReviewState" = {approvedState}
-                ORDER BY ts_rank_cd("SearchVector", websearch_to_tsquery('english', {query})) DESC
-                LIMIT {limit}
-                """).ToListAsync(ct);
-
-        return await db.ExpertiseEntries.FromSqlInterpolated($"""
-            SELECT *, xmin FROM "ExpertiseEntries"
-            WHERE "SearchVector" @@ websearch_to_tsquery('english', {query})
-              AND ("Tenant" = {tenant} OR "Tenant" = 'shared')
-              AND "ReviewState" = {approvedState}
-              AND "DeprecatedAt" IS NULL
-            ORDER BY ts_rank_cd("SearchVector", websearch_to_tsquery('english', {query})) DESC
-            LIMIT {limit}
-            """).ToListAsync(ct);
+        return await BuildKeywordSearchQuery(query, ctx, includeDeprecated, limit, domain, tags, entryType, severity)
+            .ToListAsync(ct);
     }
 
-    public async Task<List<ExpertiseEntry>> SemanticSearchAsync(Vector queryVector, TenantContext ctx, int limit, bool includeDeprecated, CancellationToken ct)
+    /// <summary>
+    /// Composes the keyword-search raw SQL. Extracted as an <c>internal</c> seam so the
+    /// query-translation test suite can render every filter combination via
+    /// <c>ToQueryString()</c> against the exact production SQL builder.
+    ///
+    /// Tenant + ReviewState + DeprecatedAt + metadata predicates all live inside the raw
+    /// SQL alongside ORDER BY and LIMIT because composing LINQ Where on top of a FromSql
+    /// query wraps it in a subquery — the planner may then drop the inner ORDER BY,
+    /// leaving result order undefined. Only fixed SQL fragments are appended; every value
+    /// travels as an <see cref="NpgsqlParameter"/> (the EF global query filter does not
+    /// apply to FromSql queries, so the in-SQL tenant predicate is the safeguard per
+    /// ADR-001).
+    ///
+    /// websearch_to_tsquery over plainto_tsquery: adds phrase quoting, OR, and -negation
+    /// while never throwing on malformed input. ts_rank_cd over ts_rank: cover-density
+    /// ranking rewards term proximity, which performs better on the short few-word
+    /// queries agent callers issue (#424). Metadata predicates mirror
+    /// <see cref="ApplyMetadataFilters"/> (#426): <c>"Tags" @&gt; @tags</c> is the raw-SQL
+    /// form of <c>tags.All(t =&gt; e.Tags.Contains(t))</c>.
+    /// </summary>
+    internal IQueryable<ExpertiseEntry> BuildKeywordSearchQuery(string query, TenantContext ctx, bool includeDeprecated, int limit, string? domain, List<string>? tags, EntryType? entryType, Severity? severity)
+    {
+        var tenant = RequireTenant(ctx);
+
+        var sql = new StringBuilder("""
+            SELECT *, xmin FROM "ExpertiseEntries"
+            WHERE "SearchVector" @@ websearch_to_tsquery('english', @query)
+              AND ("Tenant" = @tenant OR "Tenant" = 'shared')
+              AND "ReviewState" = @approvedState
+            """);
+        var parameters = new List<NpgsqlParameter>
+        {
+            new("query", query),
+            new("tenant", tenant),
+            new("approvedState", nameof(ReviewState.Approved)),
+        };
+
+        if (!includeDeprecated)
+            sql.Append("\n  AND \"DeprecatedAt\" IS NULL");
+
+        if (domain is not null)
+        {
+            sql.Append("\n  AND \"Domain\" = @domain");
+            parameters.Add(new NpgsqlParameter("domain", domain));
+        }
+
+        if (entryType is not null)
+        {
+            sql.Append("\n  AND \"EntryType\" = @entryType");
+            parameters.Add(new NpgsqlParameter("entryType", entryType.Value.ToString()));
+        }
+
+        if (severity is not null)
+        {
+            sql.Append("\n  AND \"Severity\" = @severity");
+            parameters.Add(new NpgsqlParameter("severity", severity.Value.ToString()));
+        }
+
+        if (tags is { Count: > 0 })
+        {
+            sql.Append("\n  AND \"Tags\" @> @tags");
+            parameters.Add(new NpgsqlParameter("tags", tags.ToArray()));
+        }
+
+        sql.Append("\nORDER BY ts_rank_cd(\"SearchVector\", websearch_to_tsquery('english', @query)) DESC");
+        sql.Append("\nLIMIT @limit");
+        parameters.Add(new NpgsqlParameter("limit", limit));
+
+        return db.ExpertiseEntries.FromSqlRaw(sql.ToString(), parameters.ToArray<object>());
+    }
+
+    public async Task<List<ExpertiseEntry>> SemanticSearchAsync(Vector queryVector, TenantContext ctx, int limit, bool includeDeprecated, string? domain, List<string>? tags, EntryType? entryType, Severity? severity, CancellationToken ct)
     {
         var query = ApplyApprovedReviewFilter(ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx))
             .Where(e => e.Embedding != null);
@@ -437,7 +498,7 @@ internal class ExpertiseRepository(
         if (!includeDeprecated)
             query = query.Where(e => e.DeprecatedAt == null);
 
-        return await query
+        return await ApplyMetadataFilters(query, domain, tags, entryType, severity)
             .OrderBy(e => e.Embedding!.CosineDistance(queryVector))
             .Take(limit)
             .ToListAsync(ct);

--- a/src/ExpertiseApi/Data/IExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/IExpertiseRepository.cs
@@ -81,9 +81,9 @@ internal interface IExpertiseRepository
     /// </summary>
     Task<ExpertiseAuditLog?> GetAuditByIdAsync(Guid id, CancellationToken ct = default);
 
-    Task<List<ExpertiseEntry>> KeywordSearchAsync(string query, TenantContext ctx, bool includeDeprecated = false, int limit = 50, CancellationToken ct = default);
+    Task<List<ExpertiseEntry>> KeywordSearchAsync(string query, TenantContext ctx, bool includeDeprecated = false, int limit = 50, string? domain = null, List<string>? tags = null, EntryType? entryType = null, Severity? severity = null, CancellationToken ct = default);
 
-    Task<List<ExpertiseEntry>> SemanticSearchAsync(Vector queryVector, TenantContext ctx, int limit = 10, bool includeDeprecated = false, CancellationToken ct = default);
+    Task<List<ExpertiseEntry>> SemanticSearchAsync(Vector queryVector, TenantContext ctx, int limit = 10, bool includeDeprecated = false, string? domain = null, List<string>? tags = null, EntryType? entryType = null, Severity? severity = null, CancellationToken ct = default);
 
     Task<ExpertiseEntry?> FindExactMatchAsync(string domain, string title, TenantContext ctx, CancellationToken ct = default);
 

--- a/src/ExpertiseApi/Endpoints/SearchEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/SearchEndpoints.cs
@@ -21,7 +21,8 @@ internal static class SearchEndpoints
             .WithDescription("PostgreSQL full-text search (`websearch_to_tsquery`, cover-density ranked) over Approved entries " +
                              "visible to the caller's tenant. Query string `q` is required and supports web-search syntax " +
                              "(quoted phrases, OR, -negation). Returns the top `limit` (clamped 1–100, default 50) matches. " +
-                             "Set `includeDeprecated=true` to surface soft-deleted entries.")
+                             "Optional structured filters: `domain`, `tags` (comma-separated, all must match), `entryType`, " +
+                             "`severity`. Set `includeDeprecated=true` to surface soft-deleted entries.")
             .Produces<List<ExpertiseEntryResponse>>(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
@@ -36,6 +37,10 @@ internal static class SearchEndpoints
         IExpertiseRepository repo,
         IResponseHygiene hygiene,
         [FromQuery] string q,
+        [FromQuery] string? domain = null,
+        [FromQuery] string? tags = null,
+        [FromQuery] EntryType? entryType = null,
+        [FromQuery] Severity? severity = null,
         [FromQuery] bool includeDeprecated = false,
         [FromQuery] int limit = 50,
         CancellationToken ct = default)
@@ -45,7 +50,8 @@ internal static class SearchEndpoints
 
         var tenantContext = httpContext.RequireTenantContext();
         var clampedLimit = Math.Clamp(limit, 1, 100);
-        var results = await repo.KeywordSearchAsync(q, tenantContext, includeDeprecated, clampedLimit, ct);
+        var tagList = tags?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
+        var results = await repo.KeywordSearchAsync(q, tenantContext, includeDeprecated, clampedLimit, domain, tagList, entryType, severity, ct);
         return Results.Ok(ExpertiseEntryResponse.FromMany(results, hygiene));
     }
 }

--- a/src/ExpertiseApi/Endpoints/SemanticSearchEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/SemanticSearchEndpoints.cs
@@ -20,8 +20,9 @@ internal static class SemanticSearchEndpoints
         group.MapGet("/", SemanticSearch)
             .WithSummary("Vector similarity search using cosine distance over title+body embeddings")
             .WithDescription("Generates an embedding for `q` via the configured ONNX/SBERT model and returns the top `limit` (clamped 1\u2013100) " +
-                             "Approved entries by cosine similarity. Tenant-scoped (own tenant + shared). Subject to the `semantic-search` " +
-                             "rate-limit policy (token bucket, 10/min) because each call runs ONNX inference.")
+                             "Approved entries by cosine similarity. Optional structured filters: `domain`, `tags` (comma-separated, all must " +
+                             "match), `entryType`, `severity` \u2014 applied before ranking. Tenant-scoped (own tenant + shared). Subject to the " +
+                             "`semantic-search` rate-limit policy (token bucket, 10/min) because each call runs ONNX inference.")
             .Produces<List<ExpertiseEntryResponse>>(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
@@ -37,6 +38,10 @@ internal static class SemanticSearchEndpoints
         EmbeddingService embeddingService,
         IResponseHygiene hygiene,
         [FromQuery] string q,
+        [FromQuery] string? domain = null,
+        [FromQuery] string? tags = null,
+        [FromQuery] EntryType? entryType = null,
+        [FromQuery] Severity? severity = null,
         [FromQuery] int limit = 10,
         [FromQuery] bool includeDeprecated = false,
         CancellationToken ct = default)
@@ -46,8 +51,9 @@ internal static class SemanticSearchEndpoints
 
         var tenantContext = httpContext.RequireTenantContext();
         var clampedLimit = Math.Clamp(limit, 1, 100);
+        var tagList = tags?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
         var queryVector = await embeddingService.GenerateQueryEmbeddingAsync(q, ct);
-        var results = await repo.SemanticSearchAsync(queryVector, tenantContext, clampedLimit, includeDeprecated, ct);
+        var results = await repo.SemanticSearchAsync(queryVector, tenantContext, clampedLimit, includeDeprecated, domain, tagList, entryType, severity, ct);
         return Results.Ok(ExpertiseEntryResponse.FromMany(results, hygiene));
     }
 }

--- a/tests/ExpertiseApi.Tests/Evaluation/RetrievalEvalTests.cs
+++ b/tests/ExpertiseApi.Tests/Evaluation/RetrievalEvalTests.cs
@@ -111,11 +111,13 @@ public sealed class RetrievalEvalTests(PostgresFixture postgres, ITestOutputHelp
 
         foreach (var q in golden.Queries)
         {
-            var keywordResults = await _repo.KeywordSearchAsync(q.Query, ctx, includeDeprecated: false, limit: ReportDepth, CancellationToken.None);
+            var keywordResults = await _repo.KeywordSearchAsync(q.Query, ctx, includeDeprecated: false, limit: ReportDepth,
+                domain: null, tags: null, entryType: null, severity: null, CancellationToken.None);
             keyword.Score(q, keywordResults.Select(e => e.Title).ToList());
 
             var queryVector = await _embedding.GenerateQueryEmbeddingAsync(q.Query);
-            var semanticResults = await _repo.SemanticSearchAsync(queryVector, ctx, limit: ReportDepth, includeDeprecated: false, CancellationToken.None);
+            var semanticResults = await _repo.SemanticSearchAsync(queryVector, ctx, limit: ReportDepth, includeDeprecated: false,
+                domain: null, tags: null, entryType: null, severity: null, CancellationToken.None);
             semantic.Score(q, semanticResults.Select(e => e.Title).ToList());
         }
 

--- a/tests/ExpertiseApi.Tests/Integration/SearchEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/SearchEndpointTests.cs
@@ -164,16 +164,70 @@ public class SearchEndpointTests : IAsyncLifetime
         json.GetArrayLength().Should().Be(0);
     }
 
+    [Fact]
+    public async Task KeywordSearch_FiltersByDomain()
+    {
+        await SeedEntryViaRepo("dotnet", "Caching strategy for dotnet services",
+            "Response caching guidance for dotnet minimal APIs.");
+        await SeedEntryViaRepo("kubernetes", "Caching strategy for cluster workloads",
+            "Response caching guidance for kubernetes ingress layers.");
+
+        var response = await _client.GetAsync("/expertise/search?q=caching&domain=dotnet");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetArrayLength().Should().Be(1);
+        json[0].GetProperty("domain").GetString().Should().Be("dotnet");
+    }
+
+    [Fact]
+    public async Task KeywordSearch_FiltersByTagsEntryTypeAndSeverity()
+    {
+        await SeedEntryViaRepo("dotnet", "Caching pitfall with stale keys",
+            "Stale cache keys cause subtle caching bugs.",
+            entryType: EntryType.Caveat, severity: Severity.Warning, tags: ["cache", "redis"]);
+        await SeedEntryViaRepo("dotnet", "Caching pattern for hot paths",
+            "Memoize hot-path caching lookups.",
+            entryType: EntryType.Pattern, severity: Severity.Info, tags: ["cache"]);
+
+        var byTags = await _client.GetAsync("/expertise/search?q=caching&tags=cache,redis");
+        byTags.StatusCode.Should().Be(HttpStatusCode.OK);
+        var tagsJson = await byTags.Content.ReadJsonElementAsync();
+        tagsJson.GetArrayLength().Should().Be(1, "both requested tags must match (AND semantics)");
+        tagsJson[0].GetProperty("title").GetProperty("value").GetString().Should().Contain("Caching pitfall with stale keys");
+
+        var byTypeAndSeverity = await _client.GetAsync("/expertise/search?q=caching&entryType=Pattern&severity=Info");
+        byTypeAndSeverity.StatusCode.Should().Be(HttpStatusCode.OK);
+        var typeJson = await byTypeAndSeverity.Content.ReadJsonElementAsync();
+        typeJson.GetArrayLength().Should().Be(1);
+        typeJson[0].GetProperty("title").GetProperty("value").GetString().Should().Contain("Caching pattern for hot paths");
+    }
+
+    [Fact]
+    public async Task KeywordSearch_InvalidEnumFilter_Returns400()
+    {
+        var response = await _client.GetAsync("/expertise/search?q=caching&entryType=NotAType");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
+            "an unparseable enum filter is a binding failure surfaced as 400, not a 500");
+    }
+
     private async Task<ExpertiseEntry> SeedEntryViaRepo(
         string domain,
         string title,
         string body = "Default test body content",
-        string tenant = TestHelpers.TestTenant)
+        string tenant = TestHelpers.TestTenant,
+        EntryType entryType = EntryType.Pattern,
+        Severity severity = Severity.Info,
+        string[]? tags = null)
     {
         using var scope = _factory.Services.CreateScope();
         var repo = scope.ServiceProvider.GetRequiredService<IExpertiseRepository>();
-        return await repo.CreateAsync(
-            TestHelpers.SeedEntry(domain: domain, title: title, body: body, tenant: tenant),
-            TestHelpers.CreateTenantContext(tenant));
+        var entry = TestHelpers.SeedEntry(
+            domain: domain, title: title, body: body,
+            entryType: entryType, severity: severity, tenant: tenant);
+        if (tags is not null)
+            entry.Tags = [.. tags];
+        return await repo.CreateAsync(entry, TestHelpers.CreateTenantContext(tenant));
     }
 }

--- a/tests/ExpertiseApi.Tests/Integration/SemanticSearchEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/SemanticSearchEndpointTests.cs
@@ -69,6 +69,34 @@ public class SemanticSearchEndpointTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Semantic_FiltersByDomain()
+    {
+        await SeedApproved(3, "filter-alpha");
+        await SeedApproved(2, "filter-beta");
+
+        var response = await ReadClient().GetAsync("/expertise/search/semantic?q=anything&domain=filter-alpha&limit=50");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var results = await response.Content.ReadFromJsonAsync<JsonElement>();
+        results.GetArrayLength().Should().Be(3, "the domain filter applies before ranking");
+        foreach (var entry in results.EnumerateArray())
+            entry.GetProperty("domain").GetString().Should().Be("filter-alpha");
+    }
+
+    [Fact]
+    public async Task Semantic_FiltersByEntryType()
+    {
+        await SeedApproved(2, "type-domain");
+
+        var none = await ReadClient().GetAsync("/expertise/search/semantic?q=anything&domain=type-domain&entryType=Requirement&limit=50");
+        (await none.Content.ReadFromJsonAsync<JsonElement>()).GetArrayLength()
+            .Should().Be(0, "seeded entries are Pattern, not Requirement");
+
+        var all = await ReadClient().GetAsync("/expertise/search/semantic?q=anything&domain=type-domain&entryType=Pattern&limit=50");
+        (await all.Content.ReadFromJsonAsync<JsonElement>()).GetArrayLength().Should().Be(2);
+    }
+
+    [Fact]
     public async Task Semantic_LimitAboveMax_IsClampedTo100()
     {
         await SeedApproved(105, "clamp-domain");

--- a/tests/ExpertiseApi.Tests/Unit/RepositoryQueryTranslationTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/RepositoryQueryTranslationTests.cs
@@ -216,30 +216,62 @@ public class RepositoryQueryTranslationTests
         AssertTranslates(query, "the shared tenant+approved read seam must translate");
     }
 
-    // ---- Raw FromSqlInterpolated (keyword search) -------------------------
+    // ---- Raw keyword-search SQL builder (production seam) -----------------
 
     [Fact]
-    public void KeywordSearch_FromSqlInterpolated_Parameterizes()
+    public void KeywordSearchQuery_EveryFilterCombination_Renders()
     {
         using var db = NewContext();
-        var q = "postgres pgvector";
-        var tenant = "team-alpha";
-        var approvedState = nameof(ReviewState.Approved);
+        var repo = NewRepository(db);
+        var tags = new List<string> { "postgres", "ef-core" };
 
-        // ToQueryString on FromSql renders the raw SQL with its parameters — this pins the
-        // interpolation/parameterization (it does not validate the tsquery against a live
-        // server; SearchEndpointTests covers execution correctness).
-        var limit = 50;
-        var query = db.ExpertiseEntries.FromSqlInterpolated($"""
-            SELECT *, xmin FROM "ExpertiseEntries"
-            WHERE "SearchVector" @@ websearch_to_tsquery('english', {q})
-              AND ("Tenant" = {tenant} OR "Tenant" = 'shared')
-              AND "ReviewState" = {approvedState}
-              AND "DeprecatedAt" IS NULL
-            ORDER BY ts_rank_cd("SearchVector", websearch_to_tsquery('english', {q})) DESC
-            LIMIT {limit}
-            """);
+        // ToQueryString on FromSqlRaw renders the raw SQL with its parameters — this
+        // exercises the REAL BuildKeywordSearchQuery seam across all 32 combinations of
+        // the 5 conditional dimensions (#426), so the conditional SQL assembly and its
+        // NpgsqlParameter set can never drift from production. (It does not validate the
+        // tsquery against a live server; SearchEndpointTests covers execution.)
+        for (var mask = 0; mask < 32; mask++)
+        {
+            var query = repo.BuildKeywordSearchQuery(
+                "postgres pgvector",
+                Ctx(),
+                includeDeprecated: (mask & 16) != 0,
+                limit: 50,
+                domain: (mask & 1) != 0 ? "dotnet" : null,
+                tags: (mask & 2) != 0 ? tags : null,
+                entryType: (mask & 4) != 0 ? EntryType.Pattern : null,
+                severity: (mask & 8) != 0 ? Severity.Warning : null);
 
-        AssertTranslates(query, "keyword-search raw SQL must parameterize without throwing");
+            AssertTranslates(query, $"keyword-search SQL for filter mask {mask} must render without throwing");
+        }
+    }
+
+    // ---- SemanticSearchAsync — metadata filters + CosineDistance ----------
+
+    [Fact]
+    public void SemanticSearchFilters_EveryCombination_Translates()
+    {
+        using var db = NewContext();
+        var tags = new List<string> { "postgres", "ef-core" };
+        var queryVector = new Vector(new float[384]);
+
+        // Mirrors the production SemanticSearchAsync composition: shared tenant+approved
+        // seam -> ApplyMetadataFilters (shared with BuildListQuery, #426) -> pgvector
+        // CosineDistance ordering. 16 combinations of the 4 metadata dimensions.
+        for (var mask = 0; mask < 16; mask++)
+        {
+            var query = ExpertiseRepository.ApplyMetadataFilters(
+                    ExpertiseRepository.ApplyApprovedReviewFilter(
+                        ExpertiseRepository.ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), Ctx()))
+                        .Where(e => e.Embedding != null),
+                    domain: (mask & 1) != 0 ? "dotnet" : null,
+                    tags: (mask & 2) != 0 ? tags : null,
+                    entryType: (mask & 4) != 0 ? EntryType.Pattern : null,
+                    severity: (mask & 8) != 0 ? Severity.Warning : null)
+                .OrderBy(e => e.Embedding!.CosineDistance(queryVector))
+                .Take(10);
+
+            AssertTranslates(query, $"semantic-search filter mask {mask} must translate to SQL");
+        }
     }
 }


### PR DESCRIPTION
## Summary

PR 3 of the retrieval-adoption sequence (#426; plan in `docs/research/2026-07-retrieval-assessment.md`, recommendation 2). Search and structured filtering are no longer mutually exclusive: both search endpoints accept optional `domain`, `tags` (comma-separated, all-must-match), `entryType`, and `severity` filters, mirroring `GET /expertise` semantics, applied before ranking. Additive OpenAPI change — agent callers (which know the taxonomy from the skill docs) can now scope searches directly.

Implementation notes:
- Semantic: new `ApplyMetadataFilters` internal seam shared with `BuildListQuery` — single translation-tested filter composition.
- Keyword: raw SQL moved to an internal `BuildKeywordSearchQuery` seam (conditional `StringBuilder` fragments + `NpgsqlParameter`s via `FromSqlRaw`) — every value parameterized, all predicates/ORDER BY/LIMIT inside the SQL (the EF global filter does not apply to FromSql; in-SQL tenant predicate remains the ADR-001 safeguard). `"Tags" @> @tags` is the raw-SQL mirror of `tags.All(...)`.

## Gate evidence

- Full suite: **400 passed + 1 skipped** (env-gated eval); eval harness re-run passes with baseline metrics unchanged.
- Translation tests: all 32 keyword-builder and 16 semantic filter combinations against the production seams (testing-guide same-PR convention).
- `dotnet format analyzers --verify-no-changes` clean; linter verdict PASS (one pre-existing Info markdownlint false-positive on a load-bearing trailing space, not in this diff).

## Doc impact

| Surface | Classification |
|---|---|
| DESIGN.md API Surface (both search rows) | in-scope (updated) |
| CLAUDE.md | not-a-thing (no quick-start impact) |
| ADR | not-a-thing (additive params following list-endpoint pattern; hybrid ADR comes with #428) |

Closes #426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)