### PR TITLE
chore(codeql): resolve note-level quality alerts

### DIFF
--- a/src/ExpertiseApi/Cli/BackupCommand.cs
+++ b/src/ExpertiseApi/Cli/BackupCommand.cs
@@ -26,6 +26,7 @@ internal static class BackupCommand
     public static bool IsBackupRequested(string[] args) =>
         args.Length > 0 && args[0].Equals("backup", StringComparison.OrdinalIgnoreCase);
 
+    /// <summary>Exports all entries and audit rows as NDJSON plus an RFC 6962 Merkle manifest (ADR-012).</summary>
     /// <returns>0 on success; 1 on any database or filesystem failure.</returns>
     public static async Task<int> RunAsync(WebApplication app, string[] args)
     {
@@ -41,9 +42,9 @@ internal static class BackupCommand
         try
         {
             Directory.CreateDirectory(outputDir);
-            var entriesPath = Path.Combine(outputDir, "entries.jsonl");
-            var auditPath = Path.Combine(outputDir, "audit.jsonl");
-            var manifestPath = Path.Combine(outputDir, "manifest.json");
+            var entriesPath = Path.Join(outputDir, "entries.jsonl");
+            var auditPath = Path.Join(outputDir, "audit.jsonl");
+            var manifestPath = Path.Join(outputDir, "manifest.json");
 
             foreach (var path in new[] { entriesPath, auditPath, manifestPath })
             {

--- a/src/ExpertiseApi/Cli/RestoreCommand.cs
+++ b/src/ExpertiseApi/Cli/RestoreCommand.cs
@@ -36,6 +36,7 @@ internal static class RestoreCommand
     private const int EmbeddingDimensions = 384;
     private const string QuarantinePrincipal = "restore-cli";
 
+    /// <summary>Imports a decrypted backup payload written by <see cref="BackupCommand"/>, verifying per-record hashes and Merkle roots against the manifest.</summary>
     /// <returns>0 on success; 1 on validation or import failure.</returns>
     public static async Task<int> RunAsync(WebApplication app, string[] args)
     {
@@ -63,9 +64,9 @@ internal static class RestoreCommand
 
         try
         {
-            var manifestPath = Path.Combine(inputDir, "manifest.json");
-            var entriesPath = Path.Combine(inputDir, "entries.jsonl");
-            var auditPath = Path.Combine(inputDir, "audit.jsonl");
+            var manifestPath = Path.Join(inputDir, "manifest.json");
+            var entriesPath = Path.Join(inputDir, "entries.jsonl");
+            var auditPath = Path.Join(inputDir, "audit.jsonl");
 
             foreach (var path in new[] { manifestPath, entriesPath, auditPath })
             {

--- a/src/ExpertiseApi/Services/MerkleTree.cs
+++ b/src/ExpertiseApi/Services/MerkleTree.cs
@@ -19,6 +19,7 @@ internal static class MerkleTree
     private const byte LeafPrefix = 0x00;
     private const byte NodePrefix = 0x01;
 
+    /// <summary>Computes the RFC 6962 Merkle Tree Hash over an ordered list of leaf record hashes.</summary>
     /// <param name="leafData">Ordered record hashes (lowercase hex strings), export order.</param>
     /// <returns>Lowercase hex Merkle Tree Hash.</returns>
     public static string ComputeRoot(IReadOnlyList<string> leafData)

--- a/tests/ExpertiseApi.Tests/Evaluation/EvalFactAttribute.cs
+++ b/tests/ExpertiseApi.Tests/Evaluation/EvalFactAttribute.cs
@@ -44,14 +44,14 @@ internal static class ModelFiles
     static ModelFiles()
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "ExpertiseApi.slnx")))
+        while (dir is not null && !File.Exists(Path.Join(dir.FullName, "ExpertiseApi.slnx")))
             dir = dir.Parent;
 
         if (dir is null)
             return;
 
-        var model = Path.Combine(dir.FullName, "src", "ExpertiseApi", "models", "model.onnx");
-        var vocab = Path.Combine(dir.FullName, "src", "ExpertiseApi", "models", "vocab.txt");
+        var model = Path.Join(dir.FullName, "src", "ExpertiseApi", "models", "model.onnx");
+        var vocab = Path.Join(dir.FullName, "src", "ExpertiseApi", "models", "vocab.txt");
         if (File.Exists(model) && File.Exists(vocab))
         {
             ModelPath = model;

--- a/tests/ExpertiseApi.Tests/Evaluation/RetrievalEvalTests.cs
+++ b/tests/ExpertiseApi.Tests/Evaluation/RetrievalEvalTests.cs
@@ -138,10 +138,8 @@ public sealed class RetrievalEvalTests(PostgresFixture postgres, ITestOutputHelp
             output.WriteLine($"{m.Name,-10} {m.RecallAt5,9:F3} {m.RecallAt10,10:F3} {m.Mrr,8:F3}");
         output.WriteLine("");
 
-        foreach (var m in new[] { keyword, semantic, hybrid })
+        foreach (var m in new[] { keyword, semantic, hybrid }.Where(m => m.Misses.Count > 0))
         {
-            if (m.Misses.Count == 0)
-                continue;
             output.WriteLine($"-- {m.Name}: {m.Misses.Count} miss(es) at depth {ReportDepth} --");
             foreach (var (query, kind, top) in m.Misses)
                 output.WriteLine($"  [{kind}] \"{query}\" -> top-3: {string.Join(" | ", top.Take(3))}");
@@ -162,7 +160,7 @@ public sealed class RetrievalEvalTests(PostgresFixture postgres, ITestOutputHelp
 
     private static GoldenSet LoadGoldenSet()
     {
-        var path = Path.Combine(AppContext.BaseDirectory, "Evaluation", "golden-set.json");
+        var path = Path.Join(AppContext.BaseDirectory, "Evaluation", "golden-set.json");
         var json = File.ReadAllText(path);
         var set = JsonSerializer.Deserialize<GoldenSet>(json, GoldenSetJsonOptions);
         set.Should().NotBeNull();

--- a/tests/ExpertiseApi.Tests/Integration/BackupRestoreCommandTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/BackupRestoreCommandTests.cs
@@ -104,7 +104,7 @@ public class BackupRestoreCommandTests : IAsyncLifetime
         // Tamper the CONTENT only — the stored recordHash goes stale, which is
         // exactly the per-record quarantine case (root still matches, because
         // the root covers the stored hashes).
-        var entriesPath = Path.Combine(dir, "entries.jsonl");
+        var entriesPath = Path.Join(dir, "entries.jsonl");
         var tampered = (await File.ReadAllTextAsync(entriesPath))
             .Replace("approved body", "poisoned body", StringComparison.Ordinal);
         await File.WriteAllTextAsync(entriesPath, tampered);
@@ -143,7 +143,7 @@ public class BackupRestoreCommandTests : IAsyncLifetime
         // passes, but the Merkle root no longer matches the manifest — the
         // manifest (signed in production) is the trust anchor, so this must
         // abort entirely, not quarantine.
-        var entriesPath = Path.Combine(dir, "entries.jsonl");
+        var entriesPath = Path.Join(dir, "entries.jsonl");
         var lines = await File.ReadAllLinesAsync(entriesPath);
         var record = JsonSerializer.Deserialize(lines[0], BackupJsonContext.Default.BackupEntryRecord)!;
         record = record with { Body = "silently rewritten" };

--- a/tests/ExpertiseApi.Tests/Integration/StaticIssuerCompoundRoleTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/StaticIssuerCompoundRoleTests.cs
@@ -36,7 +36,7 @@ public class StaticIssuerCompoundRoleTests : IAsyncLifetime
     public Task InitializeAsync()
     {
         // A real on-disk public JWKS for the embedded-key issuer — the production code reads it.
-        _jwksPath = Path.Combine(Path.GetTempPath(), $"adr015-jwks-{Guid.NewGuid():N}.json");
+        _jwksPath = Path.Join(Path.GetTempPath(), $"adr015-jwks-{Guid.NewGuid():N}.json");
         File.WriteAllText(_jwksPath, JwtTokenMinter.StaticJwksJson());
 
         _baseFactory = new JwtApiFactory(_postgres.ConnectionString);

--- a/tests/ExpertiseApi.Tests/Unit/AuthModeStartupGuardTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/AuthModeStartupGuardTests.cs
@@ -156,7 +156,7 @@ public class AuthModeStartupGuardTests
             Name = "LanStatic",
             Issuer = "https://static-issuer.local/",
             Audience = "expertise-api",
-            JwksPath = Path.Combine(Path.GetTempPath(), $"does-not-exist-{Guid.NewGuid():N}.json")
+            JwksPath = Path.Join(Path.GetTempPath(), $"does-not-exist-{Guid.NewGuid():N}.json")
         };
 
         var act = () => AuthExtensions.LoadStaticSigningKeys(issuer);
@@ -167,7 +167,7 @@ public class AuthModeStartupGuardTests
     [Fact]
     public void LoadStaticSigningKeys_EmptyKeySet_FailsClosed()
     {
-        var path = Path.Combine(Path.GetTempPath(), $"empty-jwks-{Guid.NewGuid():N}.json");
+        var path = Path.Join(Path.GetTempPath(), $"empty-jwks-{Guid.NewGuid():N}.json");
         File.WriteAllText(path, "{\"keys\":[]}");
         try
         {
@@ -192,7 +192,7 @@ public class AuthModeStartupGuardTests
     [Fact]
     public void LoadStaticSigningKeys_MalformedJson_FailsClosed()
     {
-        var path = Path.Combine(Path.GetTempPath(), $"bad-jwks-{Guid.NewGuid():N}.json");
+        var path = Path.Join(Path.GetTempPath(), $"bad-jwks-{Guid.NewGuid():N}.json");
         File.WriteAllText(path, "this is not json");
         try
         {
@@ -217,7 +217,7 @@ public class AuthModeStartupGuardTests
     [Fact]
     public void LoadStaticSigningKeys_ValidJwks_ReturnsKeys()
     {
-        var path = Path.Combine(Path.GetTempPath(), $"good-jwks-{Guid.NewGuid():N}.json");
+        var path = Path.Join(Path.GetTempPath(), $"good-jwks-{Guid.NewGuid():N}.json");
         File.WriteAllText(path, Infrastructure.JwtTokenMinter.StaticJwksJson());
         try
         {
@@ -244,7 +244,7 @@ public class AuthModeStartupGuardTests
     {
         // Operator footgun: JwksPath points at mint_token.py's *.priv.json (private key) instead
         // of the build-jwks public output. Must fail closed, not load a forging key into the API.
-        var path = Path.Combine(Path.GetTempPath(), $"private-jwks-{Guid.NewGuid():N}.json");
+        var path = Path.Join(Path.GetTempPath(), $"private-jwks-{Guid.NewGuid():N}.json");
         File.WriteAllText(path, Infrastructure.JwtTokenMinter.PrivateJwksJson());
         try
         {
@@ -303,7 +303,7 @@ public class AuthModeStartupGuardTests
         // Proves scripts/mint_token.py's ACTUAL `build-jwks` output shape (alg/e/kid/kty/n/use,
         // public-only) is consumable by the production loader — locking the Python-tool ↔ API
         // config contract that the C#-side StaticJwksJson() helper alone would not guarantee.
-        var path = Path.Combine(Path.GetTempPath(), $"real-jwks-{Guid.NewGuid():N}.json");
+        var path = Path.Join(Path.GetTempPath(), $"real-jwks-{Guid.NewGuid():N}.json");
         File.WriteAllText(path, RealMintTokenJwks);
         try
         {


### PR DESCRIPTION
Closes 23 of the 28 open note-level CodeQL alerts by code; the remaining 5 are dismissed via the code-scanning API with recorded rationale (see below). Triage: three-agent review (security data-flow trace, rule-semantics research, per-site fix/dismiss analysis) — no security-severity findings existed; all path-combine sites were structurally incapable of the flagged hazard.

## Changes

- **`Path.Combine` → `Path.Join`** at all 19 flagged sites (`cs/path-combine`). Zero behavior change (every non-first arg is a relative literal/GUID-templated name); matches the idiom already deliberately used in `BackupRestoreCommandTests.cs` and `AuthModeStartupGuardTests.cs:275`; future-proofs against later variable segments.
- **3 missing `<summary>` tags** (`cs/xmldoc/missing-summary`): `BackupCommand.RunAsync`, `RestoreCommand.RunAsync`, `MerkleTree.ComputeRoot`.
- **1 `.Where()` hoist** (`cs/linq/missed-where`, alert 154): pure filter loop in EXPERTISE_EVAL-gated diagnostic reporting.

## Dismissals (not code — API, after merge)

| Alert | Rule | Reason |
| --- | --- | --- |
| 56 | missed-where | won't fix — TryGetValue single-lookup hot path, already comment-documented in-code |
| 57, 58 | missed-where | false positive — abort-on-first-miss guard clauses; `.Where()` changes which path gets logged |
| 59, 60 | missed-select | false positive — ordered side-effecting async I/O loops in the Merkle-sensitive export; `Select` would misrepresent as pure projection |

Deliberately NOT adding `tests/**` to CodeQL `paths-ignore` — path exclusion is reserved for generated code and would blind security queries to future test-tree findings; per-alert dismissal is the right-sized tool.

## Gate evidence

Build 0 warnings / 0 errors; 43 tests across all touched test classes pass; `dotnet format analyzers --verify-no-changes` clean; `validate-pr.sh` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)