### PR TITLE
fix(security): require write.approve to patch shared entries

### DIFF
--- a/.agents/skills/expertise-api/references/DESIGN.md
+++ b/.agents/skills/expertise-api/references/DESIGN.md
@@ -207,7 +207,7 @@ PATCH state regression (ADR-003): a `write.draft`-only caller editing an `Approv
 
 Dedup queries (exact-match and semantic) exclude `Rejected` entries — otherwise a Rejected entry would permanently block resubmission of identical content. Drafts and Approved entries still dedup as before.
 
-Soft-deleting a `Tenant = "shared"` entry requires `expertise.write.approve` (returns 403 otherwise — 404 would mislead since the caller can read the entry). Changing `Visibility` on PATCH (Private ↔ Shared, either direction) is the symmetric inverse of `/approve`'s Visibility selection and also requires `expertise.write.approve`; the check is value-based, so a no-op PATCH that supplies the current Visibility does not escalate.
+Mutating a `Tenant = "shared"` entry — content PATCH or soft-delete — requires `expertise.write.approve` (returns 403 otherwise — 404 would mislead since the caller can read the entry). The PATCH gate (#330) prevents a `write.draft` caller in any tenant from editing a shared Approved entry, which would regress it to `Draft + Tenant="shared"` — a state no tenant's draft queue surfaces, stranding the entry. Changing `Visibility` on PATCH (Private ↔ Shared, either direction) is the symmetric inverse of `/approve`'s Visibility selection and also requires `expertise.write.approve`; the check is value-based, so a no-op PATCH that supplies the current Visibility does not escalate.
 
 ### Audit log
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,7 +236,7 @@ Four scopes drive the four authorization policies. The hierarchy is `admin ⊇ a
 | --- | --- | --- |
 | `expertise.read` | `ReadAccess` | All `GET` endpoints |
 | `expertise.write.draft` | `WriteAccess` | `POST`, `PATCH`, `DELETE` (drafts in caller's own tenant; **changing `Visibility` via PATCH escalates to `expertise.write.approve`** — see ADR-003) |
-| `expertise.write.approve` | `WriteApproveAccess` | `/approve`, `/reject`, `PATCH` when `Visibility` changes, soft-delete on `shared` |
+| `expertise.write.approve` | `WriteApproveAccess` | `/approve`, `/reject`, `PATCH` when `Visibility` changes, any PATCH or soft-delete on `shared` entries |
 | `expertise.admin` | `AdminAccess` | `/audit`, cross-tenant ops |
 
 The legacy `expertise.write` scope is normalized to `expertise.write.draft` during one transition cycle.
@@ -269,7 +269,7 @@ PATCH state regression (per ADR-003): when a `write.draft`-only caller PATCHes a
 
 Dedup queries (exact-match and semantic) exclude `Rejected` entries so a Rejected entry does not permanently block resubmission of identical content. Drafts and Approved entries still dedup as before.
 
-Soft-deleting a `Tenant = "shared"` entry requires `expertise.write.approve`. A `write.draft` caller attempting to delete a shared entry receives 403.
+Mutating a `Tenant = "shared"` entry — PATCH or soft-delete — requires `expertise.write.approve`; a `write.draft` caller receives 403 (#330). Without the PATCH gate, a draft-only caller in any tenant could edit a shared Approved entry and the ADR-003 regression would strand it as a `Draft` visible in no tenant's review queue.
 
 ### Audit log
 

--- a/src/ExpertiseApi/Data/ExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/ExpertiseRepository.cs
@@ -216,6 +216,17 @@ internal class ExpertiseRepository(
         if (entry is null)
             return (WriteOutcome.NotFound, null);
 
+        // #330: mutating a shared entry requires write.approve — the same gate
+        // SoftDeleteAsync applies. Without it, a write.draft caller in ANY tenant can
+        // reach a shared Approved entry (ApplyTenantFilter admits Tenant="shared"),
+        // and the ADR-003 regression below would demote it to Draft. A Draft with
+        // Tenant="shared" appears in no tenant's draft queue (ListDraftsAsync filters
+        // on the caller's literal tenant), stranding the entry outside every read and
+        // review surface. 403 (not 404) is correct: the caller can read the entry
+        // under the same TenantContext, so existence is already known.
+        if (entry.Tenant == "shared" && !ctx.Scopes.Contains(AuthConstants.WriteApproveScope))
+            return (WriteOutcome.InsufficientScope, null);
+
         var beforeHash = entry.IntegrityHash ?? IntegrityHashService.Compute(entry);
         var beforeVisibility = entry.Visibility;
 

--- a/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
@@ -298,7 +298,7 @@ internal static class ExpertiseEndpoints
             WriteOutcome.NotFound => Results.NotFound(),
             WriteOutcome.InsufficientScope => Results.Problem(
                 title: "Insufficient scope",
-                detail: "Changing Visibility requires expertise.write.approve.",
+                detail: "Changing Visibility or modifying a shared entry requires expertise.write.approve.",
                 statusCode: StatusCodes.Status403Forbidden),
             WriteOutcome.ConcurrentConflict => Results.Problem(
                 title: "Concurrent modification",

--- a/tests/ExpertiseApi.Tests/Integration/ApprovalWorkflowTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/ApprovalWorkflowTests.cs
@@ -278,6 +278,61 @@ public class ApprovalWorkflowTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Patch_SharedEntryByWriteDraftCaller_Returns403_AndEntryNotStranded()
+    {
+        // #330: content-editing a shared entry requires write.approve, mirroring the
+        // soft-delete gate. Without it, the ADR-003 regression demotes the entry to
+        // Draft + Tenant="shared", which no tenant's draft queue can see — stranded.
+        ExpertiseEntry seeded;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+            seeded = TestHelpers.SeedEntry(
+                tenant: "shared", title: "shared-knowledge-patch-target", reviewState: ReviewState.Approved);
+            db.ExpertiseEntries.Add(seeded);
+            await db.SaveChangesAsync();
+        }
+
+        using var writer = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);
+        var response = await writer.PatchAsJsonAsync(
+            $"/expertise/{seeded.Id}",
+            new { title = "cross-tenant vandalism attempt" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+
+        // The entry must be untouched: still Approved, still readable, original title.
+        using var verifyScope = _factory.Services.CreateScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+        var after = await verifyDb.ExpertiseEntries.IgnoreQueryFilters().SingleAsync(e => e.Id == seeded.Id);
+        after.ReviewState.Should().Be(ReviewState.Approved);
+        after.Title.Should().Be("shared-knowledge-patch-target");
+    }
+
+    [Fact]
+    public async Task Patch_SharedEntryByApproveCaller_Succeeds()
+    {
+        ExpertiseEntry seeded;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+            seeded = TestHelpers.SeedEntry(
+                tenant: "shared", title: "shared-approver-editable", reviewState: ReviewState.Approved);
+            db.ExpertiseEntries.Add(seeded);
+            await db.SaveChangesAsync();
+        }
+
+        using var approver = ClientWithScopes(
+            AuthConstants.ReadScope, AuthConstants.WriteDraftScope, AuthConstants.WriteApproveScope);
+        var response = await approver.PatchAsJsonAsync(
+            $"/expertise/{seeded.Id}",
+            new { body = "curator edit — permitted and stays Approved" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await response.Content.ReadJsonElementAsync();
+        json.GetProperty("reviewState").GetString().Should().Be("Approved");
+    }
+
+    [Fact]
     public async Task Delete_SharedEntryByWriteDraftCaller_Returns403()
     {
         // Soft-delete on shared entries requires write.approve per ADR-003.


### PR DESCRIPTION
Closes #330 (priority/high).

## What

`UpdateAsync` now applies the same shared-entry gate `SoftDeleteAsync` has: mutating a `Tenant="shared"` entry requires `expertise.write.approve`, returning 403 before any mutation runs.

## Why (the stranding chain from the issue, verified)

1. `ApplyTenantFilter` admits `shared` entries to every tenant's write path.
2. A content-only PATCH by a `write.draft` caller had no scope check (only Visibility changes were gated).
3. The ADR-003 regression demotes the Approved entry to `Draft`.
4. `ListDraftsAsync` filters on the caller's literal tenant — `Tenant="shared"` matches none, so the regressed entry vanishes from every read AND every review queue with no in-band recovery.

## Tests

- New: `write.draft` PATCH on shared Approved → 403 **and** entry verified untouched (still Approved, original title).
- New: `write.approve` PATCH on shared Approved → 200, stays Approved (curator path unaffected).
- 46 tests in the touched classes pass; format gate clean.

## Doc impact

CLAUDE.md scope table + approval-workflow paragraph and DESIGN.md scope semantics updated in-PR (doc-accuracy requirement for v1.5.1). Up-sync (ADR-013) unaffected — the spoke pushes via batch CREATE, never PATCH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)