### PR TITLE
fix(install): keep resolver stdout pure and survive bash 3.2 on --version latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,9 @@ jobs:
       - name: Run semver comparator unit tests
         run: bash tests/install/test-semver-compare.sh
 
+      - name: Run version resolver stdout-purity tests (#440)
+        run: bash tests/install/test-resolve-version.sh
+
   install-script-guards:
     name: install/uninstall script guard tests (#242)
     runs-on: ubuntu-latest

--- a/scripts/lib/release-consumer.sh
+++ b/scripts/lib/release-consumer.sh
@@ -91,6 +91,25 @@ rc_curl_https() {
 # Echos the resolved tag (without leading 'v') on stdout.
 # Args: requested_version (literal or "latest")
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# rc_assert_semver — fail closed if a resolved version string is not plain
+# semver (X.Y.Z, optional prerelease/build suffix). Guards the command-
+# substitution seam between rc_resolve_version and its callers: any stray
+# stdout (a mis-redirected log line, curl noise) becomes a clear one-line
+# diagnosis instead of a corrupted release-tag URL downstream (#440).
+# Args: candidate version string (no leading v)
+# ---------------------------------------------------------------------------
+rc_assert_semver() {
+  # Reject embedded newlines first: grep matches per-line, so a log-polluted
+  # multi-line value with a valid semver on its last line would slip through.
+  local nl; nl=$(printf '\nx'); nl=${nl%x}
+  case "$1" in
+    *"$nl"*) err "resolved version contains a newline — resolver stdout is polluted (#440)" ;;
+  esac
+  printf '%s\n' "$1" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.+-]+)?$' \
+    || err "resolved version '$1' is not a semver string — resolver stdout may be polluted (#440)"
+}
+
 rc_resolve_version() {
   local requested=$1
   if [ "$requested" != "latest" ]; then
@@ -100,7 +119,10 @@ rc_resolve_version() {
     return 0
   fi
   command -v jq >/dev/null 2>&1 || err "jq required to resolve --version latest"
-  log "resolving --version latest via GitHub Releases API"
+  # stdout of this function IS its return value (command substitution at the
+  # call site) — log lines must go to stderr or they corrupt the resolved
+  # version string (#440).
+  log "resolving --version latest via GitHub Releases API" >&2
   local api_url="https://api.github.com/repos/${RELEASE_REPO}/releases/latest"
   # D3 pre-PR (shell-expert LOW): use the unambiguous `mktemp TEMPLATE`
   # form instead of `mktemp -t prefix` (BSD treats -t as prefix-only,
@@ -120,7 +142,7 @@ rc_resolve_version() {
   if ! curl --proto '=https' --tlsv1.2 --fail --location --max-redirs 5 \
        --connect-timeout 10 --max-time 30 --silent --show-error \
        -H 'Accept: application/vnd.github+json' \
-       "${auth_header[@]}" \
+       ${auth_header[@]+"${auth_header[@]}"} \
        -o "$tmp" \
        "$api_url"; then
     rm -f -- "$tmp"
@@ -164,7 +186,7 @@ rc_crosscheck_release_api() {
   if ! curl --proto '=https' --tlsv1.2 --fail --location --max-redirs 5 \
        --connect-timeout 10 --max-time 30 --silent --show-error \
        -H 'Accept: application/vnd.github+json' \
-       "${auth_header[@]}" \
+       ${auth_header[@]+"${auth_header[@]}"} \
        -o "$tmp" \
        "$api_url"; then
     rm -f -- "$tmp"
@@ -692,6 +714,7 @@ rc_publish_from_release() {
 
   local version
   version=$(rc_resolve_version "$1")
+  rc_assert_semver "$version"
   log "release: requested version=${version}"
 
   # First-install policy: latest is only acceptable when a prior semver

--- a/tests/install/test-resolve-version.sh
+++ b/tests/install/test-resolve-version.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# tests/install/test-resolve-version.sh — regression tests for #440:
+# rc_resolve_version's stdout IS its return value (command substitution at
+# the call site), so an stdout-printing log() — exactly what install.sh
+# defines — must never leak into the resolved version string.
+#
+# Covers:
+#   1. explicit-version passthrough (v-prefix stripped, stdout pure)
+#   2. --version latest path with a stubbed curl: stdout carries ONLY the
+#      resolved version even when log() writes to stdout (the #440 bug shape)
+#   3. rc_assert_semver accepts valid semver (incl. prerelease/build)
+#   4. rc_assert_semver rejects a log-polluted string and plain garbage
+#
+# Runs under bash 3.2 (macOS /bin/bash) and newer bash.
+# Follows script-output conventions (OK/ERROR labels, PASS/FAIL summary).
+#
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+LIB="${SCRIPT_DIR}/scripts/lib/release-consumer.sh"
+
+# Reproduce install.sh's REAL log() (stdout, not a silent stub) — the whole
+# point of this suite is proving resolver stdout stays pure despite it.
+log()  { printf '[install] %s\n' "$1"; }
+warn() { printf 'WARN  [test-stub] %s\n' "$*" >&2; }
+# err in the library aborts; for assert_semver rejection tests we need it
+# non-fatal, so record and return via a flag file (subshell-safe).
+ERR_FLAG=""
+err()  { ERR_FLAG="yes"; printf 'ERROR [test-stub] %s\n' "$*" >&2; return 1; }
+
+# shellcheck source=../../scripts/lib/release-consumer.sh
+. "$LIB" 2>/dev/null || { echo "ERROR [test-resolve-version] cannot source ${LIB}" >&2; exit 2; }
+
+for fn in rc_resolve_version rc_assert_semver; do
+  if ! type "$fn" >/dev/null 2>&1; then
+    echo "ERROR [test-resolve-version] ${fn} not defined after sourcing ${LIB}" >&2
+    exit 2
+  fi
+done
+
+PASS=0
+FAIL=0
+ok()   { PASS=$((PASS+1)); printf 'OK    %s\n' "$1"; }
+fail() { FAIL=$((FAIL+1)); printf 'ERROR %s\n' "$1" >&2; }
+
+# --- 1. explicit version passthrough ---------------------------------------
+v=$(rc_resolve_version "v1.2.3")
+[ "$v" = "1.2.3" ] && ok "explicit v-prefixed version resolves to bare semver" \
+                   || fail "explicit version: expected '1.2.3', got '$v'"
+
+v=$(rc_resolve_version "1.2.3")
+[ "$v" = "1.2.3" ] && ok "explicit bare version passes through" \
+                   || fail "explicit bare version: expected '1.2.3', got '$v'"
+
+# --- 2. latest path: stdout purity under an stdout log() --------------------
+# Stub curl to write a canned Releases API response to the -o target; jq is
+# real (required by the code path and present in CI/dev environments).
+curl() {
+  local out=""
+  while [ $# -gt 0 ]; do
+    if [ "$1" = "-o" ]; then out="$2"; shift; fi
+    shift
+  done
+  [ -n "$out" ] || return 1
+  printf '{"tag_name":"v9.9.9"}' > "$out"
+}
+
+v=$(rc_resolve_version "latest")
+if [ "$v" = "9.9.9" ]; then
+  ok "latest path returns pure version on stdout (log line did not leak)"
+else
+  fail "latest path stdout polluted or wrong: expected '9.9.9', got '$v'"
+fi
+unset -f curl
+
+# --- 3. rc_assert_semver accepts -------------------------------------------
+for good in "1.5.0" "0.1.0" "10.20.30" "1.0.0-rc.1" "1.0.0+build.7"; do
+  ERR_FLAG=""
+  if rc_assert_semver "$good" 2>/dev/null && [ -z "$ERR_FLAG" ]; then
+    ok "assert_semver accepts '$good'"
+  else
+    fail "assert_semver rejected valid '$good'"
+  fi
+done
+
+# --- 4. rc_assert_semver rejects --------------------------------------------
+polluted="$(printf '[install] resolving --version latest via GitHub Releases API\n1.5.0')"
+for bad in "$polluted" "latest" "" "1.5" "v1.5.0" "1.5.0; rm -rf /"; do
+  ERR_FLAG=""
+  if rc_assert_semver "$bad" 2>/dev/null && [ -z "$ERR_FLAG" ]; then
+    fail "assert_semver accepted invalid '$(printf '%s' "$bad" | head -1)'"
+  else
+    ok "assert_semver rejects '$(printf '%s' "$bad" | head -1 | cut -c1-50)'"
+  fi
+done
+
+printf 'PASS %d FAIL %d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes #440. Hit live during the v1.5.0 upgrade.

## Two defects, one code path

1. **stdout pollution (the #440 symptom):** `rc_resolve_version` logged to stdout inside a command substitution; the captured "version" became `[install] resolving...\n1.5.0`, corrupting the release-tag URL. Fixed by sending that log to stderr (ADR-051: stdout is the return channel) plus a new `rc_assert_semver` fail-closed guard at the call seam — it also rejects multi-line values, which plain `grep -Eq` would pass (caught by the new test during development).
2. **bash 3.2 unbound-variable abort (found by the new test):** both Releases-API curl calls splice `"${auth_header[@]}"` with a possibly-empty array under `set -u` — fatal on macOS system bash when no `GH_TOKEN`/`GITHUB_TOKEN` is set. Fixed with the `${arr[@]+"${arr[@]}"}` idiom. (This is verbatim the bash-3.2 gotcha captured as an expertise entry yesterday — the corpus earning its keep.)

## Tests

`tests/install/test-resolve-version.sh` — 14 cases: explicit-version passthrough, latest-path stdout purity under a stdout-printing `log()` (stubbed curl), semver guard accept/reject incl. log-polluted multi-line input. Passes under `/bin/bash` 3.2 and modern bash; shellcheck clean; wired into the ci.yml unit-test job.

## Observed in passing

`test-release-tarball-flow.sh` case 23 fails on clean dev and isn't in CI — filed #445, not touched here.

## Docs

No doc surface changes: the `--version latest` behavior now matches what the README/CLAUDE.md already describe. The #440 workaround note in the host-local MINTING.md becomes obsolete on next release and will be cleaned up in the release verification pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)