### PR TITLE
fix(migrate): per-os prefix defaults and secrets-file guards for standalone runs

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -521,7 +521,8 @@ preflight() {
 # ---------------------------------------------------------------------------
 # CRLF detector — fail fast before any publish work. Only filename and
 # line number are echoed; never the matched content (which may contain
-# secret values).
+# secret values). Kept in lockstep with the standalone copy in
+# scripts/migrate.sh (#332) — update both together.
 # ---------------------------------------------------------------------------
 check_secrets_line_endings() {
   [[ -f "${SECRETS_FILE}" ]] || return 0
@@ -921,7 +922,7 @@ run_migrate_staged() {
   fi
 
   log "running migrate against staged binaries (${STAGE_DIR})"
-  if ! "${SCRIPT_DIR}/migrate.sh" --bin-dir "${STAGE_DIR}" --secrets-file "${SECRETS_FILE}" --migrate-timeout "${MIGRATE_TIMEOUT}"; then
+  if ! "${SCRIPT_DIR}/migrate.sh" --prefix "${PREFIX}" --bin-dir "${STAGE_DIR}" --secrets-file "${SECRETS_FILE}" --migrate-timeout "${MIGRATE_TIMEOUT}"; then
     err "migrate failed — live binaries NOT swapped; service NOT restarted; prior state intact. EF migrations are transactional per-migration; retry by fixing the schema/DB issue and re-running scripts/install.sh."
   fi
 }

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -42,8 +42,19 @@ Exit codes:
 EOF
 }
 
-PREFIX="${HOME}/.local/share/expertise-api"
-SECRETS_FILE="${XDG_CONFIG_HOME:-${HOME}/.config}/expertise-api/secrets.env"
+# Per-OS user-scope defaults, mirroring install.sh's path layout (#328/#332).
+# The previous unconditional XDG layout pointed macOS runs at a nonexistent
+# PREFIX, so Onnx__ModelPath/Onnx__VocabPath resolved to missing files and
+# Program.cs silently skipped IEmbeddingGenerator registration (fatal under
+# Development's ValidateOnBuild). System-scope or custom installs pass
+# --prefix/--secrets-file explicitly — install.sh now always does.
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  PREFIX="${HOME}/Library/Application Support/expertise-api"
+  SECRETS_FILE="${PREFIX}/secrets.env"
+else
+  PREFIX="${HOME}/.local/share/expertise-api"
+  SECRETS_FILE="${XDG_CONFIG_HOME:-${HOME}/.config}/expertise-api/secrets.env"
+fi
 BIN_DIR_OVERRIDE=""
 MIGRATE_TIMEOUT=300
 
@@ -71,11 +82,28 @@ err()  { printf '[migrate] ERROR: %s\n' "$1" >&2; exit 2; }
 # Load secrets — required because the connection string is sensitive and
 # never embedded in the wrapper or service unit on the filesystem.
 if [[ -f "${SECRETS_FILE}" ]]; then
+  # #332: standalone invocations get the same secrets.env guards install.sh
+  # runs before its identical `. "${SECRETS_FILE}"`. Logic kept in lockstep
+  # with install.sh's check_secrets_line_endings / unquoted-conn heuristic
+  # (duplication-with-lockstep-comment, same pattern as the secrets-guard
+  # hooks — migrate.sh must stay standalone-runnable). Only filename and
+  # line number are echoed, never matched content.
+  if LC_ALL=C grep -l $'\r' "${SECRETS_FILE}" >/dev/null 2>&1; then
+    crlf_line=$(LC_ALL=C grep -n -m1 $'\r' "${SECRETS_FILE}" 2>/dev/null | cut -d: -f1 || echo "?")
+    err "CRLF line endings detected at ${SECRETS_FILE}:${crlf_line} — the bash sourcer would silently corrupt values. Remediate: tr -d '\\r' < ${SECRETS_FILE} > ${SECRETS_FILE}.tmp && mv ${SECRETS_FILE}.tmp ${SECRETS_FILE} && chmod 600 ${SECRETS_FILE} (or re-run scripts/install.sh --fix-line-endings)"
+  fi
   log "sourcing secrets from ${SECRETS_FILE}"
   set -a
   # shellcheck disable=SC1090
   . "${SECRETS_FILE}"
   set +a
+  # Legacy unquoted connection string: `set -a; . file` splits on `;` and
+  # keeps only the Host= segment. Same heuristic as install.sh (PR #157).
+  if [[ "${ConnectionStrings__DefaultConnection:-}" == *Host=* \
+      && "${ConnectionStrings__DefaultConnection:-}" != *\;* ]] \
+      && grep -qE '^[[:space:]]*Port=' "${SECRETS_FILE}" 2>/dev/null; then
+    err "detected legacy unquoted ConnectionStrings__DefaultConnection in ${SECRETS_FILE}: the bash sourcer split on ';' and only kept the Host= segment. Wrap the value in double quotes and re-run."
+  fi
 else
   warn "no secrets file at ${SECRETS_FILE} — relying on environment"
 fi


### PR DESCRIPTION
Closes #328. Closes items 2–3 of #332 (the non-loopback bind guard and threat-model notes land in a follow-up PR that closes #332 itself).

## What

1. **Per-OS defaults (#328 / #332-3):** `migrate.sh` hardcoded the Linux XDG layout; macOS runs resolved `Onnx__ModelPath`/`Onnx__VocabPath` under a nonexistent `PREFIX`, so `Program.cs` silently skipped `IEmbeddingGenerator` registration — fatal under Development's `ValidateOnBuild`, latent in Production (the exact failure #262's exports were meant to prevent). Now: `install.sh` always passes `--prefix "${PREFIX}"` (covers system-scope and `--prefix` overrides too), and `migrate.sh`'s own defaults branch per-OS mirroring install.sh's user-scope layout.
2. **Standalone secrets guards (#332-2):** `migrate.sh` sources `secrets.env` with the same two guards `install.sh` runs before its identical sourcing — the CRLF fail-fast and the legacy unquoted-connection-string heuristic. Duplicated with lockstep comments on both sides (migrate.sh must stay standalone-runnable; same pattern as the secrets-guard hooks, ADR-053).

## Verification

- Both guards functionally verified against synthetic tainted files (CRLF → ERROR exit 2 with remediation hint; unquoted Host-only value → ERROR naming the split).
- `shellcheck -x` clean on both scripts; `/bin/bash -n` (bash 3.2) clean; `test-migrate-timeout.sh` PASS.

## Observed in passing

`validate-pr.sh`'s title regex bans inner periods, stricter than the CI workflow it mirrors — filed #448.

🤖 Generated with [Claude Code](https://claude.com/claude-code)