### PR TITLE
docs: apply doc-accuracy sweep findings across readme, runbook, and references

### DIFF
--- a/.agents/skills/expertise-api/references/DESIGN.md
+++ b/.agents/skills/expertise-api/references/DESIGN.md
@@ -112,7 +112,7 @@ Single-row `EmbeddingMetadata` table tracks model name, dimensions, and `LastRee
 | GET | `/expertise/{id}` | `expertise.read` | Single entry | |
 | POST | `/expertise` | `expertise.write.draft` | Create entry (generates embedding) | |
 | POST | `/expertise/batch` | `expertise.write.draft` | Create up to 100 entries (generates embeddings, deduplicates) | Max 100 entries per batch |
-| PATCH | `/expertise/{id}` | `expertise.write.draft` | Update entry (regenerates embedding if title/body changed). Changing `visibility` requires `expertise.write.approve`. | |
+| PATCH | `/expertise/{id}` | `expertise.write.draft` | Update entry (regenerates embedding if title/body changed). Changing `visibility` — or PATCHing a `shared` entry at all (#330) — requires `expertise.write.approve`. | Title ≤ 200 / Body ≤ 1500 chars |
 | DELETE | `/expertise/{id}` | `expertise.write.draft` | Soft delete (sets DeprecatedAt). Shared entries require `expertise.write.approve`. | |
 | GET | `/expertise/drafts` | `expertise.write.approve` | List Draft + Rejected entries in caller's tenant | |
 | POST | `/expertise/{id}/approve` | `expertise.write.approve` | Transition Draft → Approved | |
@@ -238,10 +238,10 @@ src/ExpertiseApi/
   Endpoints/               # Minimal API endpoint definitions
   Models/                  # ExpertiseEntry, EmbeddingMetadata, enums (EntryType, Severity)
   Data/                    # DbContext, IExpertiseRepository, ExpertiseRepository, DesignTimeDbContextFactory
-  Migrations/              # EF Core migrations (InitialCreate, AddSearchVector)
+  Migrations/              # EF Core migrations (nine and counting — InitialCreate through the secure-rebuild/search additions)
   Services/                # EmbeddingService, DeduplicationService
   Auth/                    # ApiKeyAuthHandler, AuthExtensions, AuthConstants
-  Cli/                     # ReembedCommand, RehashCommand
+  Cli/                     # ReembedCommand, RehashCommand, MigrateCommand, BackupCommand, RestoreCommand
   models/                  # ONNX model files (bge-micro-v2) — not committed, needed at runtime
 helm/expertise-api/        # Helm chart (shared templates, generic values)
 deploy/local/              # Docker Compose, .env.example, pgvector init script

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,7 +18,8 @@ Design document: GitHub issue #1. For architecture and implementation guidance, 
 
 ```bash
 # .NET 10 SDK, Docker + Docker Compose
-dotnet tool install --global dotnet-ef
+# dotnet-ef is version-pinned in .config/dotnet-tools.json — never install globally:
+dotnet tool restore
 ```
 
 ## Build & Run Commands
@@ -75,6 +76,7 @@ This is required before `docker build` and for local semantic search. The script
 
 - `ci.yml`: runs `dotnet build` + `dotnet test` on PRs to main and pushes to dev
 - `release.yml`: runs on merge to main — downloads models (cached), builds multi-arch Docker image (amd64 + arm64), pushes to `ghcr.io/psmfd/agent-expertise-api`
+- The full workflow roster (PR-title lint, install smokes, CodeQL/Trivy/Hadolint, Dependabot auto-merge, and more) is in CLAUDE.md's CI/CD table — treat that as the authoritative list.
 
 ## Architecture & Design
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,7 @@ curl http://localhost:5000/health
 
 # 5. Create an entry (under Hybrid mode in Development — accepts the API key from .env)
 # POSTs require an Idempotency-Key header per ADR-010 (hard-required since 2026-05-19).
+# Write guards: title max 200 chars, body max 1500 (400 beyond — embedding-window caps, #429/#436).
 curl -X POST http://localhost:5000/expertise \
   -H "Authorization: Bearer dev-api-key-change-me" \
   -H "Idempotency-Key: $(uuidgen)" \

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The three POST writes (`/expertise`, `/expertise/{id}/approve`, `/expertise/{id}
 | GET | `/expertise/drafts` | — | List Draft + Rejected entries in caller's tenant (requires `expertise.write.approve`) |
 | POST | `/expertise` | **required** | Create entry (generates embedding, writes audit row) |
 | POST | `/expertise/batch` | — | Create up to 100 entries (generates embeddings, deduplicates) |
-| PATCH | `/expertise/{id}` | — | Update entry. Approved entries regress to Draft if caller lacks `write.approve`. Changing `visibility` requires `write.approve`. |
+| PATCH | `/expertise/{id}` | — | Update entry. Approved entries regress to Draft if caller lacks `write.approve`. Changing `visibility` — or PATCHing a `shared` entry at all (#330) — requires `write.approve`. Title ≤ 200 chars, body ≤ 1500 (embedding-window guards). |
 | DELETE | `/expertise/{id}` | — | Soft delete (sets DeprecatedAt). Shared entries require `expertise.write.approve` |
 | POST | `/expertise/{id}/approve` | **required** | Transition Draft → Approved (requires `expertise.write.approve`) |
 | POST | `/expertise/{id}/reject` | **required** | Transition Draft → Rejected with required reason (requires `expertise.write.approve`) |
@@ -450,9 +450,12 @@ OIDC issuer. You do **not** need a full identity provider. See
 [`deploy/lan-static-oidc/`](deploy/lan-static-oidc/RUNBOOK.md) for the turnkey
 runbook. The short version:
 
-1. **Bind off loopback.** `scripts/install.sh --bind 0.0.0.0:8080` (or a specific
-   LAN interface IP). Remote clients target the host's **LAN IP**, not
-   `host.docker.internal`.
+1. **Bind off loopback.** `scripts/install.sh --bind 0.0.0.0:8080 --allow-plaintext-bind`
+   (or a specific LAN interface IP). The explicit flag is required (#332): this path
+   serves plaintext `http://`, so prefer keeping the default loopback bind behind a
+   co-located TLS edge (`deploy/lan-static-oidc/RUNBOOK.md`) and use a non-loopback
+   bind only when the TLS edge runs on a different host. Remote clients target the
+   host's **LAN IP**, not `host.docker.internal`.
 2. **Allow the LAN Host header.** The default `AllowedHosts`
    (`localhost;127.0.0.1;[::1]`) makes ASP.NET Core's host-filtering return **400**
    to a remote `Host:` — set `AllowedHosts=<your-lan-hostname>` in `secrets.env`,
@@ -533,8 +536,10 @@ pending EF Core migrations and is idempotent (no-op when up to date).
 
 - On a **fresh install** the secrets file has not yet been edited, so the
   install script detects the placeholder connection string and **skips**
-  migrate with a warning. After editing `~/.config/expertise-api/secrets.env`
-  (or `%ProgramData%\ExpertiseApi\config\secrets.env` on Windows), run
+  migrate with a warning. After editing the service secrets file —
+  `~/.config/expertise-api/secrets.env` on Linux/WSL,
+  `~/Library/Application Support/expertise-api/secrets.env` on macOS,
+  or `%ProgramData%\ExpertiseApi\config\secrets.env` on Windows — run
   `scripts/migrate.sh` (or `.\scripts\migrate.ps1`) manually, then start
   the service.
 - On an **upgrade** the secrets file is preserved and migrate runs
@@ -786,7 +791,9 @@ Quick start (macOS / Linux / WSL):
 ./scripts/install.sh --version vX.Y.Z             # DEFAULT (ADR-011): cosign-verify a published tarball, no SDK on host
 ./scripts/install.sh                              # DEFAULT on upgrades: fetches the latest signed release
 ./scripts/install.sh --from-source --i-accept-unverified-source  # opt-in: build from local tree (no cosign chain)
-edit ~/.config/expertise-api/secrets.env          # set ConnectionStrings__DefaultConnection
+edit the service secrets.env                      # set ConnectionStrings__DefaultConnection
+#   Linux/WSL: ~/.config/expertise-api/secrets.env
+#   macOS:     ~/Library/Application Support/expertise-api/secrets.env
 ./scripts/migrate.sh                              # apply EF Core migrations (idempotent)
 ./scripts/expertise-apictl status                 # daily-use service control
 ./scripts/expertise-apictl logs -f                # follow logs (journald / launchd)

--- a/deploy/lan-static-oidc/RUNBOOK.md
+++ b/deploy/lan-static-oidc/RUNBOOK.md
@@ -72,7 +72,8 @@ export OIDC_ISSUER="https://auth.lan.example/"   # any stable string; must byte-
 ./scripts/mint_token.py build-jwks --out oidc/jwks.json
 ```
 
-Copy `oidc/jwks.json` to the API host, e.g. `~/.config/expertise-api/jwks.json`.
+Copy `oidc/jwks.json` to the API host's config dir — `~/.config/expertise-api/jwks.json`
+on Linux, `~/Library/Application Support/expertise-api/jwks.json` on macOS.
 
 ### 6. Configure the API service
 
@@ -86,9 +87,10 @@ scripts/install.sh                       # default bind 127.0.0.1:8080 is correc
 # scripts/install.sh --bind 0.0.0.0:8080 --allow-plaintext-bind
 ```
 ```sh
-# ~/.config/expertise-api/secrets.env
+# Service secrets.env — ~/.config/expertise-api/secrets.env on Linux,
+# ~/Library/Application Support/expertise-api/secrets.env on macOS:
 Auth__Oidc__Issuers__2__Issuer=https://auth.lan.example/
-Auth__Oidc__Issuers__2__JwksPath=/home/<user>/.config/expertise-api/jwks.json
+Auth__Oidc__Issuers__2__JwksPath=<config-dir-above>/jwks.json   # absolute path, no ~ expansion
 AllowedHosts=expertise.lan.example
 ForwardedHeaders__KnownNetworks__0=<proxy-subnet-cidr>
 ```


### PR DESCRIPTION
Applies every finding from the pre-release docs-expert accuracy sweep (verdict was NEEDS_CHANGES; this PR takes it to clean).

## Critical fixes

- **README LAN recipe** showed `--bind 0.0.0.0:8080` bare — fails verbatim against the #332 guard shipped this cycle. Now shows the flag, and recommends the loopback + co-located TLS edge default first.
- **macOS service secrets path**: README quick-start/migrations and the LAN runbook pointed macOS operators at `~/.config/expertise-api/secrets.env`; the service reads `~/Library/Application Support/expertise-api/secrets.env`. All three sites now disambiguate per OS. (The client-side skill config at `~/.config` is a different file by design — untouched.)

## Warnings fixed

- README + DESIGN.md API-surface `PATCH` rows: added the #330 shared-entry gate (DELETE rows already had it) and the 200/1500 length caps; CLAUDE.md quick-start now names the caps.
- copilot-instructions: `dotnet tool restore` (pinned via `.config/dotnet-tools.json`) replaces the global `dotnet-ef` install; CI section defers to CLAUDE.md's authoritative workflow table.
- DESIGN.md structure-tree comments (Cli/, Migrations/) updated to reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)