### PR TITLE
fix: embedding metadata upsert, db singleton guard, and stale model refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,15 @@ jobs:
       - name: Format gate (analyzers must be clean)
         run: dotnet format analyzers ExpertiseApi.slnx --verify-no-changes
 
+      - name: Cache ONNX model files
+        id: model-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: src/ExpertiseApi/models
+          key: onnx-models-${{ hashFiles('scripts/download-models.sh') }}
+
       - name: Download ONNX model files
+        if: steps.model-cache.outputs.cache-hit != 'true'
         run: bash scripts/download-models.sh
 
       - name: Test
@@ -176,6 +184,9 @@ jobs:
 
       - name: Run version resolver stdout-purity tests (#440)
         run: bash tests/install/test-resolve-version.sh
+
+      - name: Run model-download staleness tests (#456)
+        run: bash tests/install/test-download-models.sh
 
   install-script-guards:
     name: install/uninstall script guard tests (#242)

--- a/scripts/download-models.sh
+++ b/scripts/download-models.sh
@@ -75,10 +75,20 @@ download_file() {
     existing_size=$(wc -c < "${dest}")
     if (( existing_size >= min_bytes )); then
       log "${filename} already present — verifying checksum"
-      verify_checksum "${dest}" "${expected_sha256}"
-      return 0
+      local existing_sha
+      existing_sha=$(sha256_of "${dest}")
+      if [[ "${existing_sha}" == "${expected_sha256}" ]]; then
+        log "  ${filename}: checksum OK"
+        return 0
+      fi
+      # A mismatching existing file is stale (model version bump) or corrupt —
+      # re-download instead of aborting, so upgrade installs pick up new model
+      # files automatically (#456). verify_checksum after the download is still
+      # the hard gate: a bad upstream file aborts as before.
+      log "  ${filename} checksum mismatch (expected ${expected_sha256}, got ${existing_sha}) — stale or corrupt; re-downloading"
+    else
+      log "  ${filename} exists but is suspiciously small (${existing_size} bytes) — re-downloading"
     fi
-    log "  ${filename} exists but is suspiciously small (${existing_size} bytes) — re-downloading"
   fi
 
   log "Downloading ${display_name}..."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -725,11 +725,11 @@ publish_app_staged() {
 # ---------------------------------------------------------------------------
 ensure_models() {
   STAGE="models"
-  if [[ -f "${MODEL_DIR}/model.onnx" && -f "${MODEL_DIR}/vocab.txt" ]]; then
-    log "ONNX models present at ${MODEL_DIR}"
-    return
-  fi
-  log "downloading ONNX models to ${MODEL_DIR}"
+  # Always delegate to download-models.sh — it skips files whose checksum
+  # matches the pinned SHA-256 and re-downloads stale ones, so upgrade
+  # installs pick up a model version bump. Gating on file existence here
+  # (the pre-#456 behavior) silently kept an outdated model on upgrades.
+  log "ensuring ONNX models at ${MODEL_DIR}"
   mkdir -p "${MODEL_DIR}"
   DEST_DIR="${MODEL_DIR}" "${REPO_ROOT}/scripts/download-models.sh"
 }

--- a/src/ExpertiseApi/Cli/ReembedCommand.cs
+++ b/src/ExpertiseApi/Cli/ReembedCommand.cs
@@ -52,10 +52,15 @@ internal static class ReembedCommand
         var metadata = await db.EmbeddingMetadata.FirstOrDefaultAsync()
             ?? db.EmbeddingMetadata.Add(new EmbeddingMetadata
             {
-                ModelName = "bge-micro-v2",
-                Dimensions = 384
+                ModelName = EmbeddingModelInfo.Name,
+                Dimensions = EmbeddingModelInfo.Dimensions
             }).Entity;
 
+        // Always overwrite — a pre-existing row may describe a previous model
+        // (#455); after a full reembed the stored vectors are, by construction,
+        // the current model's.
+        metadata.ModelName = EmbeddingModelInfo.Name;
+        metadata.Dimensions = EmbeddingModelInfo.Dimensions;
         metadata.LastReembedAt = DateTime.UtcNow;
         await db.SaveChangesAsync();
 

--- a/src/ExpertiseApi/Cli/RestoreCommand.cs
+++ b/src/ExpertiseApi/Cli/RestoreCommand.cs
@@ -33,7 +33,6 @@ internal static class RestoreCommand
     public static bool IsRestoreRequested(string[] args) =>
         args.Length > 0 && args[0].Equals("restore", StringComparison.OrdinalIgnoreCase);
 
-    private const int EmbeddingDimensions = 384;
     private const string QuarantinePrincipal = "restore-cli";
 
     /// <summary>Imports a decrypted backup payload written by <see cref="BackupCommand"/>, verifying per-record hashes and Merkle roots against the manifest.</summary>
@@ -118,12 +117,12 @@ internal static class RestoreCommand
                 return 1;
             }
 
-            var importEmbeddings = manifest.EmbeddingModel is { Dims: EmbeddingDimensions };
+            var importEmbeddings = manifest.EmbeddingModel is { Dims: EmbeddingModelInfo.Dimensions };
             if (!importEmbeddings && manifest.EmbeddingModel is not null)
             {
                 logger.LogWarning(
                     "Restore: manifest embedding model {Model}/{Dims} does not fit the vector({Expected}) column — embeddings will be skipped; run `reembed` after restore.",
-                    manifest.EmbeddingModel.Name, manifest.EmbeddingModel.Dims, EmbeddingDimensions);
+                    manifest.EmbeddingModel.Name, manifest.EmbeddingModel.Dims, EmbeddingModelInfo.Dimensions);
             }
 
             // ---- Phase 1: parse + verify everything BEFORE writing anything. ----
@@ -209,7 +208,7 @@ internal static class RestoreCommand
                         Severity = ParseEnum<Severity>(record.Severity, record.Id),
                         Source = record.Source,
                         SourceVersion = record.SourceVersion,
-                        Embedding = importEmbeddings && record.Embedding is { Count: EmbeddingDimensions }
+                        Embedding = importEmbeddings && record.Embedding is { Count: EmbeddingModelInfo.Dimensions }
                             ? new Vector(record.Embedding.ToArray())
                             : null,
                         CreatedAt = record.CreatedAt,

--- a/src/ExpertiseApi/Data/ExpertiseDbContext.cs
+++ b/src/ExpertiseApi/Data/ExpertiseDbContext.cs
@@ -97,10 +97,14 @@ internal class ExpertiseDbContext(
         {
             entity.HasKey(e => e.Id);
             entity.Property(e => e.ModelName).IsRequired();
+            // Singleton-row invariant is enforced by a raw-SQL unique index over a
+            // constant expression (UX_EmbeddingMetadata_Singleton, #455) — EF's
+            // fluent API cannot express it, so it lives only in the migration.
         });
 
         // Spoke-side up-sync cursor (ADR-013). Singleton-row semantics are enforced at
-        // the call site (get-or-create), matching EmbeddingMetadata — no unique guard.
+        // the call site (get-or-create) — sole writer is the sync worker, so the
+        // EmbeddingMetadata-style DB guard (#455) is not replicated here.
         modelBuilder.Entity<SyncState>(entity =>
         {
             entity.HasKey(e => e.Id);

--- a/src/ExpertiseApi/Migrations/20260723135538_EmbeddingMetadataSingletonGuard.Designer.cs
+++ b/src/ExpertiseApi/Migrations/20260723135538_EmbeddingMetadataSingletonGuard.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using ExpertiseApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -14,9 +15,11 @@ using Pgvector;
 namespace ExpertiseApi.Migrations
 {
     [DbContext(typeof(ExpertiseDbContext))]
-    partial class ExpertiseDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260723135538_EmbeddingMetadataSingletonGuard")]
+    partial class EmbeddingMetadataSingletonGuard
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ExpertiseApi/Migrations/20260723135538_EmbeddingMetadataSingletonGuard.cs
+++ b/src/ExpertiseApi/Migrations/20260723135538_EmbeddingMetadataSingletonGuard.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ExpertiseApi.Migrations
+{
+    /// <summary>
+    /// Enforces the EmbeddingMetadata singleton-row invariant at the database
+    /// level (#455). The get-or-create call sites (ReembedCommand,
+    /// RestoreCommand) are not atomic — two concurrent callers could both pass
+    /// the null check and insert two rows. A unique index over a constant
+    /// expression makes the second insert fail loudly instead. Raw SQL because
+    /// EF's fluent index API cannot express a constant-expression index.
+    /// </summary>
+    public partial class EmbeddingMetadataSingletonGuard : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """CREATE UNIQUE INDEX "UX_EmbeddingMetadata_Singleton" ON "EmbeddingMetadata" ((TRUE));""");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """DROP INDEX "UX_EmbeddingMetadata_Singleton";""");
+        }
+    }
+}

--- a/src/ExpertiseApi/Services/EmbeddingModelInfo.cs
+++ b/src/ExpertiseApi/Services/EmbeddingModelInfo.cs
@@ -1,0 +1,16 @@
+namespace ExpertiseApi.Services;
+
+/// <summary>
+/// Single source of truth for the identity of the embedding model the API is
+/// built against. Every consumer that stamps, compares, or gates on the model
+/// name or vector dimensionality (reembed metadata upsert, restore
+/// compatibility gate) reads these constants — a model swap changes them in
+/// exactly one place (#455, #437).
+/// </summary>
+internal static class EmbeddingModelInfo
+{
+    public const string Name = "bge-micro-v2";
+
+    /// <summary>Must match the pgvector column type on ExpertiseEntries.Embedding (vector(384)).</summary>
+    public const int Dimensions = 384;
+}

--- a/tests/ExpertiseApi.Tests/Integration/CliMaintenanceCommandTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/CliMaintenanceCommandTests.cs
@@ -78,6 +78,53 @@ public class CliMaintenanceCommandTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Reembed_OverwritesStaleEmbeddingMetadata()
+    {
+        // #455: a pre-existing metadata row describing a PREVIOUS model must be
+        // corrected by reembed — after a full reembed the stored vectors are, by
+        // construction, the current model's. The pre-fix get-or-create only
+        // stamped LastReembedAt and left the stale identity in place.
+        await using (var db = NewContext())
+        {
+            db.EmbeddingMetadata.Add(new EmbeddingMetadata
+            {
+                ModelName = "previous-model",
+                Dimensions = 999,
+                LastReembedAt = DateTime.UtcNow.AddDays(-30)
+            });
+            await db.SaveChangesAsync();
+        }
+
+        await using (var app = BuildApp())
+            await ReembedCommand.RunAsync(app, ["reembed"]);
+
+        await using var verify = NewContext();
+        var metadata = await verify.EmbeddingMetadata.SingleAsync();
+        metadata.ModelName.Should().Be("bge-micro-v2");
+        metadata.Dimensions.Should().Be(384);
+        metadata.LastReembedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(1));
+    }
+
+    [Fact]
+    public async Task EmbeddingMetadata_SecondRow_IsRejectedByDbSingletonGuard()
+    {
+        // #455: the singleton invariant is enforced at the DB level
+        // (UX_EmbeddingMetadata_Singleton) so a get-or-create race duplicates
+        // loudly instead of silently.
+        await using (var db = NewContext())
+        {
+            db.EmbeddingMetadata.Add(new EmbeddingMetadata { ModelName = "m1", Dimensions = 1 });
+            await db.SaveChangesAsync();
+        }
+
+        await using var second = NewContext();
+        second.EmbeddingMetadata.Add(new EmbeddingMetadata { ModelName = "m2", Dimensions = 2 });
+        var act = () => second.SaveChangesAsync();
+        await act.Should().ThrowAsync<DbUpdateException>(
+            "the unique constant-expression index must reject a second metadata row");
+    }
+
+    [Fact]
     public async Task Rehash_BackfillsNullHashes_AndIsIdempotent()
     {
         var ids = new List<Guid>();

--- a/tests/install/test-download-models.sh
+++ b/tests/install/test-download-models.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# tests/install/test-download-models.sh — regression tests for #456:
+# download-models.sh must RE-DOWNLOAD an existing file whose checksum does not
+# match the pinned SHA-256 (stale model after a version bump, or corruption)
+# instead of hard-erroring, so install.sh's ensure_models can unconditionally
+# delegate to it on upgrade installs. The post-download checksum verification
+# must remain a hard gate.
+#
+# Covers:
+#   1. stale oversized file → "re-downloading" path taken (not the old
+#      "Delete the file and re-run" abort), and a bad downloaded payload still
+#      aborts via the post-download checksum gate
+#   2. missing file + failing network → clean download-failure abort
+#   3. undersized file → existing "suspiciously small" re-download path intact
+#
+# Runs under bash 3.2 (macOS /bin/bash) and newer bash.
+# Follows script-output conventions (OK/ERROR labels, PASS/FAIL summary).
+#
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+TARGET="${SCRIPT_DIR}/scripts/download-models.sh"
+
+[ -f "$TARGET" ] || { echo "ERROR [test-download-models] ${TARGET} not found" >&2; exit 2; }
+
+PASS=0
+FAIL=0
+ok()   { PASS=$((PASS+1)); printf 'OK    %s\n' "$1"; }
+fail() { FAIL=$((FAIL+1)); printf 'ERROR %s\n' "$1" >&2; }
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# Stub curl on PATH. Behavior is selected via CURL_STUB_MODE:
+#   fail    → exit 1 (network down)
+#   garbage → write >=1MB of junk to the -o target, exit 0
+STUB_BIN="${TMP_ROOT}/bin"
+mkdir -p "$STUB_BIN"
+cat > "${STUB_BIN}/curl" <<'EOF'
+#!/usr/bin/env bash
+out=""
+prev=""
+for a in "$@"; do
+  [ "$prev" = "-o" ] && out="$a"
+  prev="$a"
+done
+case "${CURL_STUB_MODE:-fail}" in
+  garbage)
+    [ -n "$out" ] || exit 1
+    dd if=/dev/zero bs=1024 count=2048 2>/dev/null | tr '\0' 'x' > "$out"
+    exit 0
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${STUB_BIN}/curl"
+
+run_script() {
+  # Args: <dest_dir> <curl_mode>. Prints combined output; returns script's exit.
+  DEST_DIR="$1" CURL_STUB_MODE="$2" PATH="${STUB_BIN}:${PATH}" \
+    bash "$TARGET" 2>&1
+}
+
+# --- 1. stale oversized file: re-download path + post-download hard gate ----
+DEST1="${TMP_ROOT}/case1"
+mkdir -p "$DEST1"
+# >= 1 MiB so it passes the size check and reaches the checksum comparison,
+# but with content that cannot match the pinned SHA-256.
+dd if=/dev/zero of="${DEST1}/model.onnx" bs=1024 count=2048 2>/dev/null
+printf 'stale' >> "${DEST1}/model.onnx"
+
+out1="$(run_script "$DEST1" garbage)"
+rc1=$?
+
+if printf '%s' "$out1" | grep -q "stale or corrupt; re-downloading"; then
+  ok "stale file takes the re-download path"
+else
+  fail "stale file: expected 're-downloading' in output, got: $out1"
+fi
+
+if printf '%s' "$out1" | grep -q "checksum mismatch" && [ "$rc1" -ne 0 ]; then
+  ok "bad downloaded payload still aborts via post-download checksum gate (rc=$rc1)"
+else
+  fail "post-download gate: expected checksum-mismatch abort, rc=$rc1, output: $out1"
+fi
+
+# The stale file must have been REPLACED by the downloaded payload (all-x),
+# proving the download actually ran rather than the old abort-in-place.
+if grep -q 'xxxx' "${DEST1}/model.onnx" 2>/dev/null; then
+  ok "stale file was replaced by the re-downloaded payload"
+else
+  fail "stale file content unchanged — re-download never wrote the destination"
+fi
+
+# --- 2. missing file + network failure --------------------------------------
+DEST2="${TMP_ROOT}/case2"
+mkdir -p "$DEST2"
+out2="$(run_script "$DEST2" fail)"
+rc2=$?
+if [ "$rc2" -ne 0 ] && printf '%s' "$out2" | grep -q "Failed to download"; then
+  ok "missing file with failing network aborts cleanly (rc=$rc2)"
+else
+  fail "missing-file case: expected download-failure abort, rc=$rc2, output: $out2"
+fi
+
+# --- 3. undersized existing file keeps the re-download path -----------------
+DEST3="${TMP_ROOT}/case3"
+mkdir -p "$DEST3"
+printf 'tiny' > "${DEST3}/model.onnx"
+out3="$(run_script "$DEST3" fail)"
+rc3=$?
+if printf '%s' "$out3" | grep -q "suspiciously small" && [ "$rc3" -ne 0 ]; then
+  ok "undersized file still routes to re-download ('suspiciously small')"
+else
+  fail "undersized case: expected 'suspiciously small' path, rc=$rc3, output: $out3"
+fi
+
+# --- summary ----------------------------------------------------------------
+echo "=================================="
+if [ "$FAIL" -eq 0 ]; then
+  echo "PASS — 0 errors ($PASS checks)"
+  exit 0
+else
+  echo "FAIL — $FAIL errors, $PASS passed"
+  exit 1
+fi


### PR DESCRIPTION
Closes #455. Closes #456.

Prerequisites PR for the #437 model swap (PR-A of the approved plan).

## Changes

- **#455 — EmbeddingMetadata always-upsert:** `ReembedCommand` now overwrites `ModelName`/`Dimensions` unconditionally after a full reembed; the pre-fix get-or-create left a stale row describing a previous model untouched. Both CLI consumers now read a single `EmbeddingModelInfo` constant (the second hardcoded 384 in `RestoreCommand.cs` silently dropped embeddings when restoring a post-swap backup).
- **#455 — DB singleton guard:** `UX_EmbeddingMetadata_Singleton` unique constant-expression index (raw-SQL migration) makes a get-or-create race fail loudly instead of duplicating the metadata row.
- **#456 — stale model refresh on upgrade:** `install.sh ensure_models` no longer short-circuits on file existence; it always delegates to `download-models.sh`, which now re-downloads an existing file whose checksum mismatches the pinned SHA-256 (stale after a model version bump, or corrupt) instead of aborting. The post-download checksum verification remains the hard gate.
- **CI:** `ci.yml` gains the ONNX model `actions/cache` step `release.yml` already had (key: `onnx-models-${{ hashFiles('scripts/download-models.sh') }}`), making the CLAUDE.md cache claim accurate; new `tests/install/test-download-models.sh` (5 checks) wired as a CI step.

## Tests

- `Reembed_OverwritesStaleEmbeddingMetadata` — fails pre-fix
- `EmbeddingMetadata_SecondRow_IsRejectedByDbSingletonGuard` — proves the constant-expression index applies and enforces on PG17
- `tests/install/test-download-models.sh` — stale-file re-download path, post-download hard gate retained, undersized-file path retained
- Affected integration suites (CliMaintenance, BackupRestore, MigrationReversibility): 12/12 pass locally via podman Testcontainers; `dotnet format analyzers` clean; shellcheck/yamllint/actionlint clean

## Doc impact

No doc-sync pairs touched. The CLAUDE.md "cached in CI" sentence becomes true rather than needing an edit. ADR: not-a-thing (pattern-following fixes; no convention change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)