### PR TITLE
feat(embeddings): swap to jina-embeddings-v2-small-en with 6144-token ceiling

### DIFF
--- a/.agents/skills/expertise-api/SKILL.md
+++ b/.agents/skills/expertise-api/SKILL.md
@@ -83,7 +83,7 @@ cat > /tmp/entry.json <<'EOF'
 }
 EOF
 ./scripts/create.sh --file /tmp/entry.json
-# NOTE: title is capped at 200 characters and body at 1500 (HTTP 400 beyond).
+# NOTE: title is capped at 200 characters and body at 16000 (HTTP 400 beyond).
 # The embedding model sees at most ~510 tokens of "title + body"; longer text
 # would be silently invisible to semantic search, so keep titles concise and
 # bodies focused — split large topics into multiple entries.

--- a/.agents/skills/expertise-api/references/DESIGN.md
+++ b/.agents/skills/expertise-api/references/DESIGN.md
@@ -17,10 +17,10 @@ curl toolkit and when to invoke it — lives in `SKILL.md`.
 | Database | PostgreSQL 17 (single backend, no MongoDB) |
 | PostgreSQL image | `pgvector/pgvector:pg17` |
 | Connection pooling | PgBouncer 1.21+ sidecar (`edoburu/pgbouncer`, transaction mode) |
-| Vector search | pgvector extension — `vector(384)` column with HNSW index (`vector_cosine_ops`) |
+| Vector search | pgvector extension — `vector(512)` column with HNSW index (`vector_cosine_ops`) |
 | Keyword search | PostgreSQL stored generated `tsvector` column with GIN index |
 | Embeddings | In-process ONNX via `Microsoft.SemanticKernel.Connectors.Onnx` |
-| Embedding model | `bge-micro-v2` (22.9MB, 384-dim, bundled in Docker image) |
+| Embedding model | `jina-embeddings-v2-small-en` (~130MB FP32, 512-dim, 6144-token ceiling, bundled in Docker image — ADR-017) |
 | Embedding abstraction | `IEmbeddingGenerator<string, Embedding<float>>` (Microsoft.Extensions.AI) |
 | Embedding input | `EmbeddingService.BuildInputText(title, body)` — single source of truth |
 | Auth | Multi-issuer OIDC (Entra + Authentik) via `JwtBearer` per issuer behind a `Bearer` policy scheme; `ApiKey`/`LocalDev`/`Hybrid` modes for Development only |
@@ -50,7 +50,7 @@ public class ExpertiseEntry
     public Severity Severity { get; set; }
     public required string Source { get; set; }      // self-reported — informational only post-rebuild
     public string? SourceVersion { get; set; }       // e.g. "EF Core 10.0.1" — staleness signal
-    public Vector? Embedding { get; set; }           // pgvector vector(384), nullable until embedded
+    public Vector? Embedding { get; set; }           // pgvector vector(512), nullable until embedded
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
     public DateTime? DeprecatedAt { get; set; }      // soft delete
@@ -242,7 +242,7 @@ src/ExpertiseApi/
   Services/                # EmbeddingService, DeduplicationService
   Auth/                    # ApiKeyAuthHandler, AuthExtensions, AuthConstants
   Cli/                     # ReembedCommand, RehashCommand, MigrateCommand, BackupCommand, RestoreCommand
-  models/                  # ONNX model files (bge-micro-v2) — not committed, needed at runtime
+  models/                  # ONNX model files (jina-v2-small) — not committed, needed at runtime
 helm/expertise-api/        # Helm chart (shared templates, generic values)
 deploy/local/              # Docker Compose, .env.example, pgvector init script
 scripts/                   # download-models.sh
@@ -265,8 +265,8 @@ scripts/                   # download-models.sh
 - **`reembed` CLI:** Run as a one-off k8s Job, not from a running API replica, to avoid concurrent row writes.
 - **Keyword search uses raw SQL:** The stored `SearchVector` column cannot be queried via LINQ — `KeywordSearchAsync` uses `FromSqlInterpolated` (`websearch_to_tsquery` + `ts_rank_cd` + `LIMIT`; all filtering and ordering must stay inside the SQL string — composing LINQ on top wraps it in a subquery and can drop the inner ORDER BY).
 - **Search `score` field semantics:** search responses carry a server-computed `score` per hit (#427) — keyword: raw `ts_rank_cd` (unbounded, comparable only within one response); semantic: cosine similarity (`1 - distance`, higher is closer); hybrid: the fused RRF sum (`Σ 1/(60+rank)` across arms, ADR-016). Never compare scores across modes; every score is comparable only within one response. Non-search reads emit no score.
-- **bge query-instruction prefix:** bge-family embedding models are trained asymmetrically — QUERY-side text must be prefixed with `Represent this sentence for searching relevant passages:` plus a trailing space (see `EmbeddingService.QueryInstruction`); document-side text is embedded unprefixed. Semantic search uses `GenerateQueryEmbeddingAsync`; create/reembed/dedup paths use the unprefixed document path. A model swap must re-verify the instruction wording against the new model's card.
-- **512-token embedding ceiling / `MaxBodyLength`:** bge-micro-v2 embeds at most 512 wordpiece tokens (510 content + `[CLS]`/`[SEP]`); the ONNX connector **silently truncates** anything longer — no exception, no log, confirmed empirically to the exact token (#429, 2026-07-22). `BuildInputText` embeds `"{title} {body}"` in one pass, so Title and Body share the budget. Writes enforce `MaxBodyLength = 1500` chars (hard 400; derivation: ~470 body tokens × ~3 chars/token measured on real entries). Entries created before the guard may exceed the cap: they are grandfathered (readable, non-Body PATCHes fine) but their embeddings only reflect the first ~510 tokens, and a Body PATCH must come in under the cap. `MaxTitleLength = 200` guards the Title share of the same budget (#436). Re-derive both constants on any model swap (#437).
+- **No query-instruction prefix (ADR-017):** jina-embeddings-v2-small-en embeds queries and documents symmetrically — NO instruction prefix on either side. The bge-era query prefix (PR #431) was model-specific and was removed with the swap; `EmbeddingServiceTests` pins the no-prefix contract. Any future model swap must re-verify prefix requirements against the new model’s card (bge-family needs one, jina forbids the asymmetry).
+- **6144-token embedding ceiling / `MaxBodyLength` (ADR-017):** the generator is wired with `MaximumTokens = 6144` (`EmbeddingModelInfo`) — the measured coverage plateau for this corpus (99.71%, identical to 8192, at 65% less peak RSS). The ONNX connector **silently truncates** beyond the ceiling — no exception, no log (#429). `BuildInputText` embeds `"{title} {body}"` in one pass, so Title and Body share the window. Writes enforce `MaxBodyLength = 16000` chars (hard 400; ≈5,390 worst-case body tokens at the measured 2.97 chars/token minimum density) and `MaxTitleLength = 200` (#436). Entries created before the model swap have NULL embeddings until `reembed` runs (invisible to semantic/hybrid search, still in keyword results). Ceiling-filling embeds transiently peak ~12 GB RSS — relevant to A2 host sizing, prohibitive for the current Helm limits (#458). Re-derive all constants on any model or ceiling change; ground-truth tables live on issue #437.
 - **A2 binds are plaintext http; non-loopback requires an explicit override:** `install.sh` hardcodes `ASPNETCORE_URLS=http://…` (no TLS on this path), so `preflight` refuses a non-loopback `--bind` unless `--allow-plaintext-bind` is passed (#332). Keep the API on loopback behind a co-located TLS edge (the LAN runbook topology); the override exists only for a remote TLS edge where cleartext on that segment is accepted. `AllowedHosts` is not a mitigation — HostFiltering checks only the client-controlled Host header.
 - **`secrets.env` is sourced, not parsed:** the wrapper, `migrate.sh`, and install flow all `set -a; . secrets.env` (deliberate — quoted `;`-bearing values survive). Consequence: write access to `secrets.env` is code-execution-equivalent in the service context at every start/restart/migrate, not merely config injection. It is the one 600-mode, owner-guarded object in the tree; treat it accordingly (#332, full deployment threat model tracked in #226).
 - **launchd services lack systemd-grade sandboxing:** the systemd unit ships `ProtectSystem`/`ProtectHome`/`RestrictAddressFamilies` etc.; the launchd plists have no first-class equivalent without code-signing/entitlements. Accepted platform-parity gap on macOS A2 installs (#332/#226).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,10 +7,10 @@ Design document: GitHub issue #1. For architecture and implementation guidance, 
 ## Tech Stack
 
 - .NET 10 (LTS) with ASP.NET Core Minimal APIs
-- PostgreSQL 17 with pgvector extension (vector(384)) and tsvector full-text search
+- PostgreSQL 17 with pgvector extension (vector(512)) and tsvector full-text search
 - EF Core with repository pattern (`IExpertiseRepository`)
 - PgBouncer 1.21+ sidecar (transaction mode)
-- In-process ONNX embeddings: bge-micro-v2, 384-dim, via `Microsoft.SemanticKernel.Connectors.Onnx`
+- In-process ONNX embeddings: jina-embeddings-v2-small-en, 512-dim, 6144-token ceiling (ADR-017), via `Microsoft.SemanticKernel.Connectors.Onnx`
 - OpenAPI via Scalar (`Scalar.AspNetCore`)
 - Docker Compose for local dev; Helm chart for k3s deployment
 
@@ -64,7 +64,7 @@ All endpoints require a Bearer token in the Authorization header except the anon
 
 ## Model Files
 
-The bge-micro-v2 ONNX model files (`model.onnx`, `vocab.txt`) are not tracked in git. Download them with:
+The jina-embeddings-v2-small-en ONNX model files (`model.onnx`, `vocab.txt`) are not tracked in git. Download them with:
 
 ```bash
 ./scripts/download-models.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: src/ExpertiseApi/models
-          key: onnx-bge-micro-v2-quantized-${{ hashFiles('scripts/download-models.sh') }}
+          key: onnx-models-${{ hashFiles('scripts/download-models.sh') }}
 
       - name: Download ONNX model files
         if: steps.model-cache.outputs.cache-hit != 'true'
@@ -361,7 +361,7 @@ jobs:
           # existence alone is insufficient — a csproj that lists an RID
           # but produces an empty native dir would crash at runtime on
           # that host. If this fails, the csproj property was reverted or
-          # the bge-micro-v2 model dir lacks its native sidecar.
+          # the ONNX runtime dir lacks its native sidecar.
           for rid in linux-x64 linux-arm64 osx-arm64 osx-x64 win-x64; do
             native_dir="$out_pub/runtimes/$rid/native"
             if [ ! -d "$native_dir" ] || [ -z "$(ls -A "$native_dir" 2>/dev/null)" ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Self-hosted .NET 10 REST API for storing and serving expertise entries consumed 
 - **PostgreSQL 17** with **pgvector** extension for semantic search
 - **EF Core** for data access (repository pattern via `IExpertiseRepository`)
 - **PgBouncer 1.21+** sidecar for connection pooling (transaction mode)
-- **In-process ONNX** embeddings via `Microsoft.SemanticKernel.Connectors.Onnx` (bge-micro-v2, 384-dim)
+- **In-process ONNX** embeddings via `Microsoft.SemanticKernel.Connectors.Onnx` (jina-embeddings-v2-small-en, 512-dim, 6144-token ceiling — ADR-017)
 - **Serilog** for structured logging (`Serilog.AspNetCore`)
 - **prometheus-net** for Prometheus metrics endpoint (`/metrics`)
 - **OpenAPI** docs via Scalar (`Scalar.AspNetCore`)
@@ -83,7 +83,7 @@ see [`docs/operations/backup-restore-runbook.md`](docs/operations/backup-restore
 The ONNX model files are not tracked in git. Download them before running locally or building Docker images:
 
 ```bash
-# Download bge-micro-v2 quantized model (~17.4 MB) and vocab.txt
+# Download jina-embeddings-v2-small-en model (~130 MB) and vocab.txt
 ./scripts/download-models.sh
 
 # Force re-download (e.g., after model version bump)
@@ -114,7 +114,7 @@ curl http://localhost:5000/health
 
 # 5. Create an entry (under Hybrid mode in Development — accepts the API key from .env)
 # POSTs require an Idempotency-Key header per ADR-010 (hard-required since 2026-05-19).
-# Write guards: title max 200 chars, body max 1500 (400 beyond — embedding-window caps, #429/#436).
+# Write guards: title max 200 chars, body max 16000 (400 beyond — embedding-window caps, #429/#436/ADR-017).
 curl -X POST http://localhost:5000/expertise \
   -H "Authorization: Bearer dev-api-key-change-me" \
   -H "Idempotency-Key: $(uuidgen)" \
@@ -147,7 +147,7 @@ curl "http://localhost:5000/expertise/search/semantic?q=test&limit=5" \
 # Browse to http://localhost:5000/query
 ```
 
-**Note:** Semantic search and embedding generation require the bge-micro-v2 ONNX model files (`model.onnx` and `vocab.txt`) in `src/ExpertiseApi/models/`. Without them, the API will start but POST/PATCH and semantic search will fail. CRUD and keyword search work without the model.
+**Note:** Semantic search and embedding generation require the jina-embeddings-v2-small-en ONNX model files (`model.onnx` and `vocab.txt`) in `src/ExpertiseApi/models/`. Without them, the API will start but POST/PATCH and semantic search will fail. CRUD and keyword search work without the model.
 
 ## Agent Integration
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ flowchart LR
     api["expertise-api\n(ASP.NET Core)"]
     pgbouncer["PgBouncer\n(connection pooling)"]
     postgres["PostgreSQL 17\n(pgvector + tsvector)"]
-    onnx["ONNX Runtime\n(bge-micro-v2, 384-dim)"]
+    onnx["ONNX Runtime\n(jina-v2-small, 512-dim)"]
 
     agents -->|"HTTP + Bearer token"| api
     api --> pgbouncer --> postgres
@@ -28,7 +28,7 @@ flowchart LR
 | Framework | ASP.NET Core Minimal APIs |
 | Database | PostgreSQL 17 + pgvector + tsvector |
 | Connection pooling | PgBouncer 1.21+ (transaction mode) |
-| Embeddings | In-process ONNX (bge-micro-v2, 384-dim) |
+| Embeddings | In-process ONNX (jina-embeddings-v2-small-en, 512-dim, 6144-token ceiling — ADR-017) |
 | Data access | EF Core (repository pattern) |
 | API docs | Scalar (OpenAPI) |
 | Local dev | Docker Compose |
@@ -45,7 +45,7 @@ The three POST writes (`/expertise`, `/expertise/{id}/approve`, `/expertise/{id}
 | GET | `/expertise/drafts` | — | List Draft + Rejected entries in caller's tenant (requires `expertise.write.approve`) |
 | POST | `/expertise` | **required** | Create entry (generates embedding, writes audit row) |
 | POST | `/expertise/batch` | — | Create up to 100 entries (generates embeddings, deduplicates) |
-| PATCH | `/expertise/{id}` | — | Update entry. Approved entries regress to Draft if caller lacks `write.approve`. Changing `visibility` — or PATCHing a `shared` entry at all (#330) — requires `write.approve`. Title ≤ 200 chars, body ≤ 1500 (embedding-window guards). |
+| PATCH | `/expertise/{id}` | — | Update entry. Approved entries regress to Draft if caller lacks `write.approve`. Changing `visibility` — or PATCHing a `shared` entry at all (#330) — requires `write.approve`. Title ≤ 200 chars, body ≤ 16000 (embedding-window guards, ADR-017). |
 | DELETE | `/expertise/{id}` | — | Soft delete (sets DeprecatedAt). Shared entries require `expertise.write.approve` |
 | POST | `/expertise/{id}/approve` | **required** | Transition Draft → Approved (requires `expertise.write.approve`) |
 | POST | `/expertise/{id}/reject` | **required** | Transition Draft → Rejected with required reason (requires `expertise.write.approve`) |

--- a/adrs/012-backup-artifact-format.md
+++ b/adrs/012-backup-artifact-format.md
@@ -67,7 +67,7 @@ Manifest schema (v1):
   "entriesMerkleRoot": "…",      // RFC 6962 over per-entry BackupRecordHash leaves
   "auditMerkleRoot": "…",        // RFC 6962 over per-audit-row leaves
   "dbSchemaVersion": "…",        // last applied EF migration id at export time
-  "embeddingModel": { "name": "bge-micro-v2", "dims": 384 },
+  "embeddingModel": { "name": "jina-embeddings-v2-small-en", "dims": 512 },
   "payloadSha256": "…"           // SHA-256 of payload.tar.gz.age as stored
 }
 ```

--- a/adrs/017-embedding-model-swap.md
+++ b/adrs/017-embedding-model-swap.md
@@ -1,0 +1,146 @@
+# 017 — Embedding model swap: jina-embeddings-v2-small-en at a 6144-token ceiling
+
+## Status
+
+Accepted (2026-07-23)
+
+## Context and Problem Statement
+
+The API embeds entries with bge-micro-v2 (384-dim, 512-token architectural window)
+via `Microsoft.SemanticKernel.Connectors.Onnx`. The connector silently truncates
+input beyond `MaximumTokens` (#429), which forced hard write caps of
+`MaxBodyLength = 1500` / `MaxTitleLength = 200` characters. Those caps are the
+binding constraint on entry authoring: real agent-generated fix/caveat entries
+routinely want more than 1500 characters of body. Issue #437 asked whether a
+long-context embedding model could raise the ceiling — and by how much —
+without changing the embedding architecture (in-process ONNX, WordPiece
+vocab.txt, the existing SK connector).
+
+## Decision Drivers
+
+- Must run **unmodified** through the existing connector: WordPiece `vocab.txt`
+  tokenizer, ONNX graph accepting `{input_ids, attention_mask, token_type_ids}`,
+  pooling limited to the connector's Mean/Max/MeanSqrt (no CLS).
+- Retrieval quality on the real corpus must not regress (golden-set harness,
+  #432) and should improve on long documents (needle-in-document test).
+- A2 single-host deployment: embedding is in-process; peak RSS during a
+  ceiling-filling embed is a real host constraint (O(n²) attention memory).
+- The ceiling should be a **compile-time constant**, chosen once from ground
+  truth, not a tunable that invites drift.
+
+## Considered Options
+
+### Model
+
+1. **jina-embeddings-v2-small-en** (33M params, 512-dim, ALiBi positions to
+   8192, mean pooling, no query prefixes) — **chosen**
+2. nomic-embed-text-v1.5 (137M, 768-dim, rotary, 4-way task prefixes)
+3. gte-base-en-v1.5 (rejected: ONNX graph lacks `token_type_ids`; CLS pooling —
+   connector hardcodes both)
+4. granite-embedding-r2 (rejected: BPE tokenizer; connector is WordPiece-only)
+5. Keep bge-micro-v2 (status quo)
+
+### Ceiling (`MaximumTokens`)
+
+4096 vs 6144 vs 8192, measured empirically (all tables in the #437 issue
+comments, 2026-07-23).
+
+## Decision Outcome
+
+**jina-embeddings-v2-small-en, `MaximumTokens = 6144`, derived caps
+`MaxBodyLength = 16000` / `MaxTitleLength = 200`.**
+
+### Why jina-v2-small over nomic (the a-priori favorite)
+
+Empirical, on this repo's corpus and harnesses:
+
+- Golden set (30 queries): jina semantic recall@10 **1.000** / MRR **0.925** vs
+  bge 1.000/0.894 — no regression, slight MRR gain.
+- Needle-in-document (8 docs, needles at 400–8000 chars): jina avg rank **1.5**
+  (5/8 rank-1) vs nomic 3.0 and truncated bge 3.38. Nomic runs safely at a true
+  8k window (verified 8190 encoded tokens, no degenerate vectors) but its
+  needle precision was no better than truncated bge — long window without
+  long-window retrieval value.
+- jina runs through the connector unmodified (model.onnx + vocab.txt +
+  `MaximumTokens`); mean pooling is the connector default. The root
+  `model.onnx` (token-level outputs, 129,809,014 bytes) is required — the
+  sibling `model-w-mean-pooling.onnx` bakes pooling into the graph and would
+  be pooled twice by the connector.
+- FP32 (~130 MB) vs bge's quantized 17.4 MB: accepted. The spike measured
+  quality and cost on this exact artifact; a quantized variant would be an
+  unverified substitution.
+
+**Liveliness:** Maintenance-only (upstream focus moved to jina-v3+), single
+vendor. Risk Medium, accepted: the artifact is pinned by SHA-256, fully
+self-hosted, and the fallback path (ML.Tokenizers + OnnxRuntime behind the
+existing `IEmbeddingGenerator` seam, ~120–190 LoC) is documented in #437.
+
+### Why 6144 — the ground-truth ceiling
+
+Measured on the live corpus (n=692 entries) and a token-calibrated needle
+matrix (#437 second findings comment):
+
+| Ceiling | Corpus coverage | Ceiling-filling embed cost | In-window needle precision |
+| --- | --- | --- | --- |
+| 4096 | 98.7% — **below p99 (4,347 tokens)** | 575 ms / 5.4 GB RSS | loses 6k/7.5k depths |
+| **6144** | **99.71% — the plateau** | **1.16 s / 12.1 GB RSS** | **matches 8192** |
+| 8192 | 99.71% — identical to 6144 | 1.86 s / 19.9 GB RSS | one measured mean-pooling dilution regression |
+
+8192 buys zero coverage (the only two entries beyond 6144 tokens exceed 8192
+too), costs 65% more peak RSS, and measurably *hurt* one always-in-window
+needle via mean-pooling dilution. 4096 sits below the corpus p99. 6144 is the
+smallest ceiling that captures everything capturable — a durable constant, not
+a tunable.
+
+### Derived caps
+
+Same method as #429, re-based on the 6144 window: reserve ~70 worst-case tokens
+for a 200-char title plus specials; body budget ≈ 6,000 tokens; at the measured
+worst-case density of 2.97 chars/token, `MaxBodyLength = 16000` chars lands at
+≈ 5,390 worst-case body tokens — comfortable headroom inside the window.
+`MaxTitleLength` stays 200 (#436 rationale unchanged).
+
+### Migration (two-phase, forward-only)
+
+1. **One atomic release** (this ADR's PR set): EF migration — drop the HNSW
+   index, `UPDATE ... SET "Embedding" = NULL` (pgvector's typmod cast rejects
+   `ALTER COLUMN TYPE` over live 384-dim values), retype to `vector(512)`,
+   recreate the HNSW index (NULLs are not indexed; it fills incrementally as
+   embeddings return) — plus model files, `MaximumTokens`, cap raise, and
+   removal of the bge query-instruction prefix (jina uses none; PR #431's
+   prefix was bge-specific).
+2. **Operator reembed** (`expertise-apictl reembed` / `dotnet run -- reembed`)
+   immediately after install. During the window, every read path already
+   filters `Embedding != null`: keyword search is unaffected; semantic/hybrid
+   gracefully surface only reembedded rows; embed-on-write uses the new model
+   from the first request. Dedup can only under-fire (miss), never misfire.
+   Measured wall-clock for ~700 entries: single-digit minutes (≤15 min bound);
+   the host needs RSS headroom for the ~12 GB p99 transient.
+
+**Rollback is NOT `install.sh`'s binary swap.** Once the migration commits,
+embeddings are nulled and the column is `vector(512)`; the previous binary's EF
+model does not match. Recovery from a bad rollout is roll-forward (fix and
+reembed — embeddings are regenerable, content is the source of truth) or full
+`backup`/`restore` from a pre-upgrade backup. Take a backup before upgrading.
+
+### Consequences
+
+- `Deduplication:SemanticThreshold = 0.10` was calibrated to bge's distance
+  geometry; it is re-derived against the jina space after the production
+  reembed (#457). Until then dedup under-fires only.
+- The eval gates (`RetrievalEvalTests`, window-aware `NeedleEvalTests`, #437
+  PR-B) are the merge gate for this and any future retrieval change; they are
+  `EXPERTISE_EVAL=1` opt-in, so running them is a release-checklist step, not
+  CI-automatic.
+- CI model downloads grow ~17 MB → ~130 MB; mitigated by the `actions/cache`
+  keyed on `download-models.sh` (added with #456's fix).
+- Helm/k8s resource sizing is NOT covered — tracked in #458; A2 native service
+  remains the hosting model of record.
+
+## Related
+
+- #437 (spike + ground-truth sweeps — both findings comments), #429 (silent
+  truncation + original cap derivation), #455/#456 (prerequisites), #457
+  (threshold retune), #458 (Helm sizing), #345 (reembed vintage detection)
+- ADR-016 (hybrid RRF search — the eval-gated precedent)
+- PR #431 (bge query prefix — reverted by this swap for the new model)

--- a/docs/operations/backup-restore-runbook.md
+++ b/docs/operations/backup-restore-runbook.md
@@ -111,7 +111,7 @@ Idempotent; only touches rows where `IntegrityHash IS NULL`. Costs nothing on a 
 SELECT "ModelName", "Dimensions", "LastReembedAt" FROM "EmbeddingMetadata";
 ```
 
-If that row is absent, or disagrees with the deployed model files (`./scripts/download-models.sh` fetches bge-micro-v2, 384-dim), regenerate:
+If that row is absent, or disagrees with the deployed model files (`./scripts/download-models.sh` fetches jina-embeddings-v2-small-en, 512-dim — ADR-017), regenerate:
 
 ```bash
 dotnet run --project src/ExpertiseApi -- reembed

--- a/docs/testing-and-coverage.md
+++ b/docs/testing-and-coverage.md
@@ -120,8 +120,8 @@ the csproj makes them reachable. Prefer this over re-deriving the logic in the t
 
 Correctness tests use the content-derived mock embeddings above; retrieval *quality*
 cannot be measured that way. `tests/ExpertiseApi.Tests/Evaluation/` holds an opt-in
-harness (#425) that seeds the corpus in `golden-set.json` with **real** bge-micro-v2
-embeddings (via `AddBertOnnxEmbeddingGenerator`), runs every golden query through
+harness (#425) that seeds the corpus in `golden-set.json` with **real** embeddings
+from the pinned ONNX model (jina-embeddings-v2-small-en, ADR-017) (via `AddBertOnnxEmbeddingGenerator`), runs every golden query through
 keyword and semantic search, and reports recall@5 / recall@10 / MRR@10 per mode plus
 every miss:
 

--- a/scripts/download-models.sh
+++ b/scripts/download-models.sh
@@ -116,7 +116,11 @@ download_file() {
 
 mkdir -p "${DEST_DIR}"
 
-download_file "${DEST_DIR}/model.onnx" "${HF_BASE}/model.onnx" 104857600 \
+# min_bytes is a coarse error-page detector only (an HTML 404/consent page is
+# far under 1 MiB) — the SHA-256 pin below is the actual integrity gate, so the
+# floor deliberately does NOT track the model size (tests/install/ fixtures
+# depend on it staying small).
+download_file "${DEST_DIR}/model.onnx" "${HF_BASE}/model.onnx" 1048576 \
   "model.onnx (jina-embeddings-v2-small-en FP32, ~130 MB)" "${SHA256_MODEL_ONNX}"
 
 download_file "${DEST_DIR}/vocab.txt" "${HF_BASE}/vocab.txt" 1024 \

--- a/scripts/download-models.sh
+++ b/scripts/download-models.sh
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
-# download-models.sh — Download bge-micro-v2 ONNX model files
+# download-models.sh — Download jina-embeddings-v2-small-en ONNX model files
 #
 # Usage:
 #   ./scripts/download-models.sh                          # default: src/ExpertiseApi/models/
 #   DEST_DIR=/custom/path ./scripts/download-models.sh    # custom destination
 #   FORCE=1 ./scripts/download-models.sh                  # re-download even if files exist
 #
-# Downloads the quantized bge-micro-v2 model (~17.4 MB) and vocab.txt (~232 KB)
-# from the SmartComponents Hugging Face mirror (canonical source for .NET/SK).
+# Downloads the jina-embeddings-v2-small-en model (~130 MB, FP32) and
+# vocab.txt (~232 KB) from the upstream jinaai Hugging Face repo (ADR-017).
+# The root model.onnx (token-level outputs; the SK connector applies mean
+# pooling) is REQUIRED — model-w-mean-pooling.onnx bakes pooling into the
+# graph and would be pooled twice.
 #
-# Idempotent: skips files that already exist and pass size + checksum validation.
-# The model file is saved as model.onnx (not model_quantized.onnx) to match
-# the default path expected by Program.cs and the Dockerfile.
+# Idempotent: skips files that already exist and pass size + checksum
+# validation; re-downloads stale/corrupt files (#456).
 #
 # To update checksums after a model version bump:
 #   FORCE=1 ./scripts/download-models.sh
@@ -28,14 +30,14 @@ FORCE="${FORCE:-0}"
 # Bump MODEL_VERSION when model files change. This string is embedded in the
 # script, so any change here automatically busts the CI cache (keyed on
 # hashFiles('scripts/download-models.sh')).
-MODEL_VERSION="1"
+MODEL_VERSION="2"
 
-HF_BASE="https://huggingface.co/SmartComponents/bge-micro-v2/resolve/main"
+HF_BASE="https://huggingface.co/jinaai/jina-embeddings-v2-small-en/resolve/main"
 
 # SHA-256 checksums for model version ${MODEL_VERSION}.
 # Computed from: sha256sum model.onnx vocab.txt
-SHA256_MODEL_ONNX="ed65e36025aa94cb74207dab863c85452919ec0ab7df3512092932aa22c9a33a"
-SHA256_VOCAB_TXT="07eced375cec144d27c900241f3e339478dec958f92fddbc551f295c992038a3"
+SHA256_MODEL_ONNX="974fdefe71fc9889258f569132b35acae6278874c8d09dbdf7806d23ad0b4497"
+SHA256_VOCAB_TXT="109753d618dbb576a35112f9c20ef35cf3517d46106175bcf010c986a4bef1df"
 
 log() { printf '[download-models] %s\n' "$1"; }
 err() { printf '[download-models] ERROR: %s\n' "$1" >&2; exit 1; }
@@ -114,8 +116,8 @@ download_file() {
 
 mkdir -p "${DEST_DIR}"
 
-download_file "${DEST_DIR}/model.onnx" "${HF_BASE}/onnx/model_quantized.onnx" 1048576 \
-  "model.onnx (quantized bge-micro-v2, ~17.4 MB)" "${SHA256_MODEL_ONNX}"
+download_file "${DEST_DIR}/model.onnx" "${HF_BASE}/model.onnx" 104857600 \
+  "model.onnx (jina-embeddings-v2-small-en FP32, ~130 MB)" "${SHA256_MODEL_ONNX}"
 
 download_file "${DEST_DIR}/vocab.txt" "${HF_BASE}/vocab.txt" 1024 \
   "vocab.txt" "${SHA256_VOCAB_TXT}"

--- a/scripts/expertise-apictl
+++ b/scripts/expertise-apictl
@@ -10,6 +10,7 @@
 #   expertise-apictl start|stop|restart|status
 #   expertise-apictl logs [-f] [-n LINES]
 #   expertise-apictl health
+#   expertise-apictl reembed [--batch-size N]
 #   expertise-apictl backup-init [--install-deps]
 #   expertise-apictl backup [--output DIR] [--instance-id ID]
 #   expertise-apictl restore ARTIFACT [--force-draft] [--i-accept-unsigned-backup]
@@ -34,7 +35,7 @@ READY_TIMEOUT="${EXPERTISE_API_READY_TIMEOUT:-30}"
 log() { printf '[expertise-apictl] %s\n' "$1"; }
 err() { printf '[expertise-apictl] ERROR: %s\n' "$1" >&2; exit 1; }
 
-usage() { sed -n '2,24p' "$0" | sed 's/^# \{0,1\}//'; }
+usage() { sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'; }
 
 detect_os() {
   case "$(uname -s)" in
@@ -72,10 +73,10 @@ _detect_install_scope() {
 }
 
 # The system-scope guard applies to service-LIFECYCLE subcommands only —
-# backup-init/backup/restore talk to the database and filesystem, never to
-# launchd, so they work fine against a --system install.
+# backup-init/backup/restore/reembed talk to the database and filesystem,
+# never to launchd, so they work fine against a --system install.
 case "${1:-}" in
-  backup-init|backup|restore) _lifecycle_cmd=0 ;;
+  backup-init|backup|restore|reembed) _lifecycle_cmd=0 ;;
   *)                          _lifecycle_cmd=1 ;;
 esac
 
@@ -574,6 +575,16 @@ cmd_backup() {
   log "backup: OK — ${artifact}"
 }
 
+cmd_reembed() {
+  # Pass-through to the ExpertiseApi reembed verb: regenerate every stored
+  # embedding with the currently installed model. Idempotent and safe while
+  # the service is running (per-batch row saves; reads tolerate NULL/stale
+  # embeddings). REQUIRED once after a model-swap release (ADR-017) — until it
+  # completes, pre-existing entries are invisible to semantic/hybrid search.
+  _run_api_verb reembed "$@" || err "reembed verb failed — see log output above"
+  log "reembed: OK"
+}
+
 cmd_restore() {
   local artifact="" force_draft=0 accept_unsigned=0
   while [[ $# -gt 0 ]]; do
@@ -644,6 +655,7 @@ case "${1:-}" in
   backup-init) shift; cmd_backup_init "$@" ;;
   backup)     shift; cmd_backup "$@" ;;
   restore)    shift; cmd_restore "$@" ;;
+  reembed)    shift; cmd_reembed "$@" ;;
   ''|-h|--help) usage ;;
   *) err "unknown subcommand: $1 (try --help)" ;;
 esac

--- a/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
@@ -198,14 +198,16 @@ internal static class ExpertiseEndpoints
         !string.IsNullOrWhiteSpace(request.Body) &&
         !string.IsNullOrWhiteSpace(request.Source);
 
-    // MaxBodyLength derivation (#429): bge-micro-v2 embeds at most 512 wordpiece tokens
-    // (510 content + [CLS]/[SEP]) and the ONNX connector silently truncates beyond that
-    // with no signal. BuildInputText embeds "{title} {body}" in one pass; reserving
-    // ~40 tokens for Title leaves ~470 for Body. Measured density across the 60 longest
-    // real entries is 2.97–4.24 chars/token (median 3.46), so 1500 chars keeps a
-    // median-density Body fully embedded (~476/512 tokens); only the densest tail loses
-    // a few trailing tokens. Re-derive this constant if the embedding model changes (#437).
-    private const int MaxBodyLength = 1500;
+    // MaxBodyLength derivation (#429 method, re-based by ADR-017): the embedding
+    // window is EmbeddingModelInfo.MaximumTokens (6144) and the ONNX connector
+    // silently truncates beyond it with no signal. BuildInputText embeds
+    // "{title} {body}" in one pass; reserving ~70 worst-case tokens for a
+    // 200-char Title plus specials leaves ~6,000 for Body. Measured density
+    // across the 60 longest real entries is 2.97–4.24 chars/token, so 16,000
+    // chars lands at ≈5,390 worst-case Body tokens — fully embedded with
+    // headroom even at maximum density. Re-derive if the model or ceiling
+    // changes (ADR-017 ground-truth tables are on issue #437).
+    private const int MaxBodyLength = 16_000;
 
     private static string? BodyLengthError(string? body) =>
         body is { Length: > MaxBodyLength }
@@ -213,10 +215,11 @@ internal static class ExpertiseEndpoints
               "Content past the embedding window is invisible to semantic search; shorten the body or split the entry."
             : null;
 
-    // MaxTitleLength (#436): Title shares the 512-token embedding budget with Body
-    // (BuildInputText embeds "{title} {body}"); the MaxBodyLength derivation reserves
-    // ~40 tokens for Title, which 200 chars comfortably respects (observed corpus max
-    // is 142). Same guard shape as MaxBodyLength/MaxRejectionReasonLength.
+    // MaxTitleLength (#436): Title shares the embedding window with Body
+    // (BuildInputText embeds "{title} {body}"); the MaxBodyLength derivation
+    // reserves ~70 worst-case tokens for Title, which 200 chars comfortably
+    // respects (observed corpus max is 142). Unchanged by the ADR-017 ceiling
+    // raise — titles are a display/scan surface, not a content dump.
     private const int MaxTitleLength = 200;
 
     private static string? TitleLengthError(string? title) =>

--- a/src/ExpertiseApi/Migrations/20260723141427_SwapEmbeddingModelTo512Dim.Designer.cs
+++ b/src/ExpertiseApi/Migrations/20260723141427_SwapEmbeddingModelTo512Dim.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using ExpertiseApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -14,9 +15,11 @@ using Pgvector;
 namespace ExpertiseApi.Migrations
 {
     [DbContext(typeof(ExpertiseDbContext))]
-    partial class ExpertiseDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260723141427_SwapEmbeddingModelTo512Dim")]
+    partial class SwapEmbeddingModelTo512Dim
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ExpertiseApi/Migrations/20260723141427_SwapEmbeddingModelTo512Dim.cs
+++ b/src/ExpertiseApi/Migrations/20260723141427_SwapEmbeddingModelTo512Dim.cs
@@ -1,0 +1,79 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using Pgvector;
+
+#nullable disable
+
+namespace ExpertiseApi.Migrations
+{
+    /// <summary>
+    /// ADR-017 model swap: bge-micro-v2 (384-dim) → jina-embeddings-v2-small-en
+    /// (512-dim). pgvector's typmod cast rejects ALTER COLUMN TYPE over live
+    /// vectors of a different dimension, and the old vectors are garbage in the
+    /// new space anyway, so the migration nulls them first. Every read path
+    /// filters Embedding != null, so the window until `reembed` repopulates is
+    /// a soft degradation of semantic search, not an outage. The HNSW index is
+    /// dropped before the retype and recreated after — NULLs are not indexed,
+    /// so the recreate is instant and fills incrementally as reembed writes.
+    ///
+    /// FORWARD-ONLY in practice: Down() restores the column type but cannot
+    /// restore the destroyed 384-dim vectors (regenerable via the old model's
+    /// `reembed` only). See ADR-017's rollback section.
+    /// </summary>
+    public partial class SwapEmbeddingModelTo512Dim : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ExpertiseEntries_Embedding",
+                table: "ExpertiseEntries");
+
+            migrationBuilder.Sql(
+                """UPDATE "ExpertiseEntries" SET "Embedding" = NULL;""");
+
+            migrationBuilder.AlterColumn<Vector>(
+                name: "Embedding",
+                table: "ExpertiseEntries",
+                type: "vector(512)",
+                nullable: true,
+                oldClrType: typeof(Vector),
+                oldType: "vector(384)",
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExpertiseEntries_Embedding",
+                table: "ExpertiseEntries",
+                column: "Embedding")
+                .Annotation("Npgsql:IndexMethod", "hnsw")
+                .Annotation("Npgsql:IndexOperators", new[] { "vector_cosine_ops" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ExpertiseEntries_Embedding",
+                table: "ExpertiseEntries");
+
+            // 512-dim vectors cannot survive a retype to vector(384) either.
+            migrationBuilder.Sql(
+                """UPDATE "ExpertiseEntries" SET "Embedding" = NULL;""");
+
+            migrationBuilder.AlterColumn<Vector>(
+                name: "Embedding",
+                table: "ExpertiseEntries",
+                type: "vector(384)",
+                nullable: true,
+                oldClrType: typeof(Vector),
+                oldType: "vector(512)",
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExpertiseEntries_Embedding",
+                table: "ExpertiseEntries",
+                column: "Embedding")
+                .Annotation("Npgsql:IndexMethod", "hnsw")
+                .Annotation("Npgsql:IndexOperators", new[] { "vector_cosine_ops" });
+        }
+    }
+}

--- a/src/ExpertiseApi/Models/ExpertiseEntry.cs
+++ b/src/ExpertiseApi/Models/ExpertiseEntry.cs
@@ -25,7 +25,7 @@ internal class ExpertiseEntry
 
     public string? SourceVersion { get; set; }
 
-    [Column(TypeName = "vector(384)")]
+    [Column(TypeName = "vector(512)")]
     public Vector? Embedding { get; set; }
 
     public DateTime CreatedAt { get; set; }

--- a/src/ExpertiseApi/Services/EmbeddingModelInfo.cs
+++ b/src/ExpertiseApi/Services/EmbeddingModelInfo.cs
@@ -2,25 +2,27 @@ namespace ExpertiseApi.Services;
 
 /// <summary>
 /// Single source of truth for the identity of the embedding model the API is
-/// built against. Every consumer that stamps, compares, or gates on the model
-/// name or vector dimensionality (reembed metadata upsert, restore
-/// compatibility gate) reads these constants — a model swap changes them in
-/// exactly one place (#455, #437).
+/// built against (ADR-017). Every consumer that stamps, compares, or gates on
+/// the model name, vector dimensionality, or token ceiling (reembed metadata
+/// upsert, restore compatibility gate, ONNX generator wiring, eval harness
+/// window math) reads these constants — a model swap changes them in exactly
+/// one place (#455, #437).
 /// </summary>
 internal static class EmbeddingModelInfo
 {
-    public const string Name = "bge-micro-v2";
+    public const string Name = "jina-embeddings-v2-small-en";
 
-    /// <summary>Must match the pgvector column type on ExpertiseEntries.Embedding (vector(384)).</summary>
-    public const int Dimensions = 384;
+    /// <summary>Must match the pgvector column type on ExpertiseEntries.Embedding (vector(512)).</summary>
+    public const int Dimensions = 512;
 
     /// <summary>
-    /// Token ceiling passed to the ONNX embedding generator. 512 is
-    /// bge-micro-v2's architectural window (and the connector's implicit
-    /// default — made explicit here so the ceiling is a visible, single-point
-    /// decision). Input beyond the ceiling is silently truncated by the
+    /// Token ceiling passed to the ONNX embedding generator. 6144 is the
+    /// ground-truth plateau for this corpus (ADR-017): coverage at 6144 equals
+    /// 8192 (99.71%, corpus p99 = 4,347 tokens), at 65% less peak RSS, and
+    /// 8192 measurably degraded one in-window needle via mean-pooling
+    /// dilution. Input beyond the ceiling is silently truncated by the
     /// connector (#429); the MaxBodyLength/MaxTitleLength write guards are
-    /// derived from this value. The #437 model swap raises it.
+    /// derived from this value.
     /// </summary>
-    public const int MaximumTokens = 512;
+    public const int MaximumTokens = 6144;
 }

--- a/src/ExpertiseApi/Services/EmbeddingService.cs
+++ b/src/ExpertiseApi/Services/EmbeddingService.cs
@@ -5,21 +5,15 @@ namespace ExpertiseApi.Services;
 
 internal class EmbeddingService(IEmbeddingGenerator<string, Embedding<float>> generator)
 {
-    // bge-family models are trained asymmetrically for retrieval: the QUERY side carries
-    // this instruction, the document side never does. bge-micro-v2's own card omits it,
-    // but the model is distilled from BAAI/bge-small-en-v1.5, whose card specifies it
-    // (optional in v1.5 — "slight degradation" without — and most beneficial for short
-    // queries, which is exactly this API's agent query profile). Documents embedded via
-    // BuildInputText and the dedup path stay unprefixed: dedup compares document-vs-
-    // document, which is symmetric (#424).
-    internal const string QueryInstruction = "Represent this sentence for searching relevant passages: ";
-
+    // jina-embeddings-v2-small-en is trained symmetrically: queries and documents
+    // embed identically, with NO instruction prefix (ADR-017). The bge-family
+    // query instruction PR #431 added was model-specific and was removed with the
+    // swap — a model change must re-verify prefix requirements against the new
+    // model's card (bge needs one, jina forbids none-vs-some asymmetry).
     public static string BuildInputText(string title, string body) => $"{title} {body}";
 
-    public static string BuildQueryInputText(string query) => $"{QueryInstruction}{query}";
-
     public Task<Vector> GenerateQueryEmbeddingAsync(string query, CancellationToken ct = default)
-        => GenerateEmbeddingAsync(BuildQueryInputText(query), ct);
+        => GenerateEmbeddingAsync(query, ct);
 
     public async Task<Vector> GenerateEmbeddingAsync(string text, CancellationToken ct = default)
     {

--- a/tests/ExpertiseApi.Tests/Evaluation/EvalFactAttribute.cs
+++ b/tests/ExpertiseApi.Tests/Evaluation/EvalFactAttribute.cs
@@ -1,7 +1,7 @@
 namespace ExpertiseApi.Tests.Evaluation;
 
 /// <summary>
-/// Marks a retrieval-evaluation test that runs the REAL bge-micro-v2 ONNX model
+/// Marks a retrieval-evaluation test that runs the REAL pinned ONNX model (ADR-017)
 /// against a real PostgreSQL container — deliberately excluded from normal
 /// <c>dotnet test</c> runs (and CI) because it measures retrieval quality, not
 /// correctness, and its metrics are for human comparison across revisions (#425).

--- a/tests/ExpertiseApi.Tests/Evaluation/RetrievalEvalTests.cs
+++ b/tests/ExpertiseApi.Tests/Evaluation/RetrievalEvalTests.cs
@@ -18,7 +18,7 @@ namespace ExpertiseApi.Tests.Evaluation;
 /// Golden-query retrieval evaluation harness (#425, recommendation 5 of
 /// docs/research/2026-07-retrieval-assessment.md).
 ///
-/// Seeds the corpus from <c>golden-set.json</c> with REAL bge-micro-v2 embeddings
+/// Seeds the corpus from <c>golden-set.json</c> with REAL embeddings from the pinned ONNX model (ADR-017: jina-embeddings-v2-small-en)
 /// (the normal test suite's content-derived mock cannot measure retrieval quality),
 /// runs every golden query through keyword and semantic search, and reports
 /// recall@5 / recall@10 / MRR@10 per mode plus every miss. Run with:

--- a/tests/ExpertiseApi.Tests/Evaluation/golden-set.json
+++ b/tests/ExpertiseApi.Tests/Evaluation/golden-set.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Golden retrieval-evaluation set (#425). Corpus entries are seeded with REAL bge-micro-v2 embeddings; queries score keyword and semantic retrieval via recall@5/@10 and MRR. Expected titles must match corpus titles exactly. Grow this set when a real agent query misses — add the query with its expected entry.",
+  "$comment": "Golden retrieval-evaluation set (#425). Corpus entries are seeded with REAL embeddings from the pinned ONNX model (ADR-017); queries score keyword and semantic retrieval via recall@5/@10 and MRR. Expected titles must match corpus titles exactly. Grow this set when a real agent query misses — add the query with its expected entry.",
   "corpus": [
     { "domain": "dotnet", "title": "CS8618 non-nullable property warning on EF Core entities", "body": "EF Core entity classes with required string properties raise CS8618 nullable warnings. Use the required modifier or initialize with null! when the ORM guarantees materialization.", "entryType": "Caveat", "severity": "Info" },
     { "domain": "dotnet", "title": "EF Core migration conflict after parallel feature branches", "body": "Two branches each adding a migration produce a model snapshot conflict. Re-scaffold the later migration after rebase: remove it, then run dotnet ef migrations add again.", "entryType": "IssueFix", "severity": "Warning" },

--- a/tests/ExpertiseApi.Tests/Infrastructure/ApiFactory.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/ApiFactory.cs
@@ -53,7 +53,7 @@ public class ApiFactory : WebApplicationFactory<Program>
             services.AddDbContext<ExpertiseDbContext>(options =>
                 options.UseNpgsql(_connectionString, o => o.UseVector()));
 
-            // Replace ONNX embedding generator with a mock that returns 384-dim vectors.
+            // Replace ONNX embedding generator with a mock that returns 512-dim vectors.
             // AddBertOnnxEmbeddingGenerator opens the model file at registration time,
             // so we must remove the existing registration and substitute it.
             var embeddingDescriptor = services.SingleOrDefault(

--- a/tests/ExpertiseApi.Tests/Infrastructure/TestHelpers.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/TestHelpers.cs
@@ -101,7 +101,7 @@ internal static class TestHelpers
     }
 
     /// <summary>Content-independent fixed vector (query vectors / unit-test stubs that don't care).</summary>
-    internal static Vector CreateTestVector(int dimensions = 384)
+    internal static Vector CreateTestVector(int dimensions = 512)
     {
         var values = new float[dimensions];
         var rng = new Random(42);
@@ -118,7 +118,7 @@ internal static class TestHelpers
     /// vector for every input — which made semantic-dedup behaviour structurally unobservable
     /// and forced two integration tests into per-test workarounds.
     /// </summary>
-    internal static float[] CreateContentEmbedding(string content, int dimensions = 384)
+    internal static float[] CreateContentEmbedding(string content, int dimensions = 512)
     {
         var rng = new Random(StableSeed(content));
         var values = new float[dimensions];
@@ -127,7 +127,7 @@ internal static class TestHelpers
         return values;
     }
 
-    internal static Vector CreateContentVector(string content, int dimensions = 384)
+    internal static Vector CreateContentVector(string content, int dimensions = 512)
         => new(CreateContentEmbedding(content, dimensions));
 
     // FNV-1a over UTF-16 code units. Stable across processes, unlike string.GetHashCode

--- a/tests/ExpertiseApi.Tests/Integration/BackupRestoreCommandTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/BackupRestoreCommandTests.cs
@@ -87,8 +87,8 @@ public class BackupRestoreCommandTests : IAsyncLifetime
         audit.Should().HaveCount(seeded.Count, "the audit log is restored verbatim, no new rows for a clean restore");
 
         var metadata = await db.EmbeddingMetadata.SingleAsync();
-        metadata.ModelName.Should().Be("bge-micro-v2");
-        metadata.Dimensions.Should().Be(384);
+        metadata.ModelName.Should().Be("jina-embeddings-v2-small-en");
+        metadata.Dimensions.Should().Be(512);
     }
 
     [Fact]
@@ -236,7 +236,7 @@ public class BackupRestoreCommandTests : IAsyncLifetime
             ReviewState = ReviewState.Approved,
             ReviewedBy = "reviewer@example.com",
             ReviewedAt = new DateTime(2026, 7, 1, 9, 0, 0, DateTimeKind.Utc),
-            Embedding = new Vector(Enumerable.Repeat(0.5f, 384).ToArray()),
+            Embedding = new Vector(Enumerable.Repeat(0.5f, 512).ToArray()),
         };
         var deprecated = new ExpertiseEntry
         {
@@ -262,8 +262,8 @@ public class BackupRestoreCommandTests : IAsyncLifetime
 
         db.EmbeddingMetadata.Add(new EmbeddingMetadata
         {
-            ModelName = "bge-micro-v2",
-            Dimensions = 384,
+            ModelName = "jina-embeddings-v2-small-en",
+            Dimensions = 512,
             LastReembedAt = DateTime.UtcNow,
         });
         await db.SaveChangesAsync();

--- a/tests/ExpertiseApi.Tests/Integration/BatchEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/BatchEndpointTests.cs
@@ -143,14 +143,14 @@ public class BatchEndpointTests : IAsyncLifetime
         var response = await client.PostAsJsonAsync("/expertise/batch", new[]
         {
             Item(freshDomain, "within cap", "a normal-sized body"),
-            Item(freshDomain, "over cap", new string('a', 1501)), // #429 MaxBodyLength = 1500
+            Item(freshDomain, "over cap", new string('a', 16001)), // #429 MaxBodyLength = 16000 (ADR-017)
         });
 
         response.StatusCode.Should().Be(HttpStatusCode.MultiStatus);
         var results = (await response.Content.ReadFromJsonAsync<List<BatchResult>>())!;
         results[0].Status.Should().Be("Created");
         results[1].Status.Should().Be("Rejected");
-        results[1].Error.Should().Contain("maximum length of 1500");
+        results[1].Error.Should().Contain("maximum length of 16000");
     }
 
     [Fact]

--- a/tests/ExpertiseApi.Tests/Integration/CliMaintenanceCommandTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/CliMaintenanceCommandTests.cs
@@ -52,7 +52,7 @@ public class CliMaintenanceCommandTests : IAsyncLifetime
             var entry = TestHelpers.SeedEntry(
                 domain: "reembed", title: $"entry {i}", body: $"body {i}",
                 tenant: i % 2 == 0 ? "team-a" : "team-b");
-            entry.Embedding = new Vector(new float[384]);
+            entry.Embedding = new Vector(new float[512]);
             db.ExpertiseEntries.Add(entry);
             await db.SaveChangesAsync();
             seeded.Add(entry);
@@ -72,8 +72,8 @@ public class CliMaintenanceCommandTests : IAsyncLifetime
         }
 
         var metadata = await verify.EmbeddingMetadata.SingleAsync();
-        metadata.ModelName.Should().Be("bge-micro-v2");
-        metadata.Dimensions.Should().Be(384);
+        metadata.ModelName.Should().Be("jina-embeddings-v2-small-en");
+        metadata.Dimensions.Should().Be(512);
         metadata.LastReembedAt.Should().NotBe(default);
     }
 
@@ -100,8 +100,8 @@ public class CliMaintenanceCommandTests : IAsyncLifetime
 
         await using var verify = NewContext();
         var metadata = await verify.EmbeddingMetadata.SingleAsync();
-        metadata.ModelName.Should().Be("bge-micro-v2");
-        metadata.Dimensions.Should().Be(384);
+        metadata.ModelName.Should().Be("jina-embeddings-v2-small-en");
+        metadata.Dimensions.Should().Be(512);
         metadata.LastReembedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(1));
     }
 

--- a/tests/ExpertiseApi.Tests/Integration/ExpertiseEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/ExpertiseEndpointTests.cs
@@ -186,19 +186,19 @@ public class ExpertiseEndpointTests : IAsyncLifetime
     [Fact]
     public async Task CreateEntry_WithOverlongBody_Returns400()
     {
-        // 1500 is the #429 embedding-window cap (MaxBodyLength in ExpertiseEndpoints).
-        var payload = new { domain = "shared", title = "Overlong", body = new string('a', 1501), entryType = "Pattern", severity = "Info", source = "test" };
+        // 16000 is the embedding-window cap (#429 method, re-based by ADR-017).
+        var payload = new { domain = "shared", title = "Overlong", body = new string('a', 16001), entryType = "Pattern", severity = "Info", source = "test" };
         var response = await _client.PostAsJsonAsync("/expertise", payload);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var problem = await response.Content.ReadAsStringAsync();
-        problem.Should().Contain("maximum length of 1500");
+        problem.Should().Contain("maximum length of 16000");
     }
 
     [Fact]
     public async Task CreateEntry_WithBodyAtLimit_Returns201()
     {
-        var payload = new { domain = "shared", title = "At limit", body = new string('a', 1500), entryType = "Pattern", severity = "Info", source = "test" };
+        var payload = new { domain = "shared", title = "At limit", body = new string('a', 16000), entryType = "Pattern", severity = "Info", source = "test" };
         var response = await _client.PostAsJsonAsync("/expertise", payload);
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -242,11 +242,11 @@ public class ExpertiseEndpointTests : IAsyncLifetime
     {
         var entry = await SeedEntryViaRepo("shared", "Patch target");
 
-        var response = await _client.PatchAsJsonAsync($"/expertise/{entry.Id}", new { body = new string('b', 1501) });
+        var response = await _client.PatchAsJsonAsync($"/expertise/{entry.Id}", new { body = new string('b', 16001) });
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var problem = await response.Content.ReadAsStringAsync();
-        problem.Should().Contain("maximum length of 1500");
+        problem.Should().Contain("maximum length of 16000");
     }
 
     private async Task<ExpertiseEntry> SeedEntryViaRepo(

--- a/tests/ExpertiseApi.Tests/Integration/MigrationReversibilityTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/MigrationReversibilityTests.cs
@@ -84,6 +84,75 @@ public class MigrationReversibilityTests : IAsyncLifetime
         await AssertActorClassColumnsExist(db, expected: false);
     }
 
+    [Fact]
+    public async Task SwapEmbeddingModelTo512Dim_NullsPopulated384DimData_AndRetypes()
+    {
+        // ADR-017. The empty-DB apply path is exercised by every PostgresFixture
+        // test for free; THIS test covers the only path where the migration's
+        // internal ordering matters — an UPGRADE over populated 384-dim rows.
+        // pgvector's typmod cast rejects a naive ALTER COLUMN TYPE over live
+        // vectors, so a migration that "works" on fresh CI databases would break
+        // the first real production upgrade. Seeding uses raw SQL because the
+        // current EF model already reflects vector(512).
+        await using var db = NewContext();
+        var migrator = db.GetInfrastructure().GetRequiredService<IMigrator>();
+
+        await migrator.MigrateAsync(SwapBaselineMigration);
+
+        var conn = db.Database.GetDbConnection();
+        if (conn.State != System.Data.ConnectionState.Open)
+            await conn.OpenAsync();
+        await using (var insert = conn.CreateCommand())
+        {
+            insert.CommandText = """
+                INSERT INTO "ExpertiseEntries"
+                    ("Domain","Tags","Title","Body","EntryType","Severity","Source",
+                     "Tenant","Visibility","AuthorPrincipal","ReviewState","Embedding")
+                VALUES ('mig','{}','migration seed','populated 384-dim row','Pattern','Info','human',
+                        'legacy','Private','test','Approved',
+                        (SELECT array_agg(0.5)::vector(384) FROM generate_series(1,384)));
+                """;
+            await insert.ExecuteNonQueryAsync();
+        }
+
+        await migrator.MigrateAsync(SwapMigration);
+
+        (await ScalarLong(db, """
+            SELECT COUNT(*) FROM information_schema.columns
+            WHERE table_name = 'ExpertiseEntries' AND column_name = 'Embedding'
+              AND udt_name = 'vector';
+            """)).Should().Be(1);
+        (await ScalarLong(db, """SELECT atttypmod FROM pg_attribute WHERE attrelid = '"ExpertiseEntries"'::regclass AND attname = 'Embedding';"""))
+            .Should().Be(512, "the column typmod must carry the new dimension");
+        (await ScalarLong(db, """SELECT COUNT(*) FROM "ExpertiseEntries" WHERE "Embedding" IS NOT NULL;"""))
+            .Should().Be(0, "old-model vectors are garbage in the new space and must be nulled");
+        (await ScalarLong(db, """SELECT COUNT(*) FROM "ExpertiseEntries";"""))
+            .Should().Be(1, "the row itself must survive — only its embedding is invalidated");
+        (await ScalarLong(db, """SELECT COUNT(*) FROM pg_indexes WHERE tablename = 'ExpertiseEntries' AND indexname = 'IX_ExpertiseEntries_Embedding' AND indexdef LIKE '%hnsw%';"""))
+            .Should().Be(1, "the HNSW index must be recreated after the retype");
+
+        // Down(): the column type reverts; the destroyed vectors do NOT come
+        // back (forward-only in practice — ADR-017 rollback section).
+        await migrator.MigrateAsync(SwapBaselineMigration);
+        (await ScalarLong(db, """SELECT atttypmod FROM pg_attribute WHERE attrelid = '"ExpertiseEntries"'::regclass AND attname = 'Embedding';"""))
+            .Should().Be(384);
+        (await ScalarLong(db, """SELECT COUNT(*) FROM "ExpertiseEntries" WHERE "Embedding" IS NOT NULL;"""))
+            .Should().Be(0, "Down() cannot restore destroyed vectors — documented, deliberate");
+    }
+
+    private const string SwapBaselineMigration = "20260723135538_EmbeddingMetadataSingletonGuard";
+    private const string SwapMigration = "20260723141427_SwapEmbeddingModelTo512Dim";
+
+    private static async Task<long> ScalarLong(ExpertiseDbContext db, string sql)
+    {
+        var conn = db.Database.GetDbConnection();
+        if (conn.State != System.Data.ConnectionState.Open)
+            await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        return Convert.ToInt64(await cmd.ExecuteScalarAsync());
+    }
+
     private static async Task AssertActorClassColumnsExist(ExpertiseDbContext db, bool expected)
     {
         foreach (var column in new[] { "ActorClass", "AuthMethod", "ActorClassHeader" })

--- a/tests/ExpertiseApi.Tests/Integration/SyncWorkerTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/SyncWorkerTests.cs
@@ -200,7 +200,7 @@ public class SyncWorkerTests : IAsyncLifetime
             ReviewedBy = state == ReviewState.Approved ? "reviewer@spoke.local" : null,
             ReviewedAt = state == ReviewState.Approved ? DateTime.UtcNow : null,
             DeprecatedAt = deprecatedAt,
-            Embedding = new Vector(new float[384]),
+            Embedding = new Vector(new float[512]),
         };
 
         var hidden = new List<ExpertiseEntry>

--- a/tests/ExpertiseApi.Tests/Unit/CosineDistanceTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/CosineDistanceTests.cs
@@ -65,12 +65,12 @@ public class CosineDistanceTests
     }
 
     [Fact]
-    public void MatchingDimensions_384dim_ShouldReturnValidDistance()
+    public void MatchingDimensions_512dim_ShouldReturnValidDistance()
     {
-        var a = new float[384];
-        var b = new float[384];
+        var a = new float[512];
+        var b = new float[512];
         var rng = new Random(42);
-        for (var i = 0; i < 384; i++)
+        for (var i = 0; i < 512; i++)
         {
             a[i] = (float)(rng.NextDouble() * 2 - 1);
             b[i] = (float)(rng.NextDouble() * 2 - 1);

--- a/tests/ExpertiseApi.Tests/Unit/DeduplicationServiceTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/DeduplicationServiceTests.cs
@@ -206,7 +206,7 @@ public class DeduplicationServiceTests
         var requests = new List<CreateExpertiseRequest> { CreateRequest(title: "Unique Title") };
 
         // Build a vector that is orthogonal to _testVector (cosine distance == 1)
-        var orthogonalValues = new float[384];
+        var orthogonalValues = new float[512];
         orthogonalValues[0] = 1.0f; // all other dims zero — orthogonal to random _testVector
         var farVector = new Vector(orthogonalValues);
 

--- a/tests/ExpertiseApi.Tests/Unit/EmbeddingServiceTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/EmbeddingServiceTests.cs
@@ -43,21 +43,18 @@ public class EmbeddingServiceTests
     }
 
     [Fact]
-    public void BuildQueryInputText_PrefixesBgeQueryInstruction()
+    public void BuildInputText_RemainsUnprefixed()
     {
-        // bge-family asymmetric retrieval: the query side carries the instruction, the
-        // document side (BuildInputText) never does (#424). If the instruction wording
-        // ever changes (model swap), stored document embeddings stay valid — only
-        // query-side embedding changes — but this pin forces the change to be deliberate.
-        EmbeddingService.BuildQueryInputText("pgvector index tuning")
-            .Should().Be("Represent this sentence for searching relevant passages: pgvector index tuning");
-
+        // jina-v2-small embeds queries and documents symmetrically with NO
+        // instruction prefix (ADR-017). This pin forces any future prefix
+        // reintroduction (another model swap) to be deliberate — bge needed
+        // one (PR #431), jina must not have one.
         EmbeddingService.BuildInputText("title", "body")
             .Should().Be("title body", "document-side input must remain unprefixed");
     }
 
     [Fact]
-    public async Task GenerateQueryEmbeddingAsync_EmbedsPrefixedQuery_NotRawQuery()
+    public async Task GenerateQueryEmbeddingAsync_EmbedsRawQuery_NoInstructionPrefix()
     {
         var generator = Substitute.For<IEmbeddingGenerator<string, Embedding<float>>>();
         generator.GenerateAsync(
@@ -78,10 +75,8 @@ public class EmbeddingServiceTests
         var queryVector = await service.GenerateQueryEmbeddingAsync("kafka rebalance");
 
         queryVector.ToArray().Should().Equal(
-            TestHelpers.CreateContentEmbedding(EmbeddingService.BuildQueryInputText("kafka rebalance")),
-            "the query embedding must be generated from the instruction-prefixed text");
-        queryVector.ToArray().Should().NotEqual(
             TestHelpers.CreateContentEmbedding("kafka rebalance"),
-            "embedding the raw query would silently drop the bge query instruction");
+            "ADR-017: jina embeds the raw query — a leftover bge-style instruction prefix " +
+            "would silently degrade every semantic search against the new model");
     }
 }

--- a/tests/ExpertiseApi.Tests/Unit/RepositoryQueryTranslationTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/RepositoryQueryTranslationTests.cs
@@ -121,7 +121,7 @@ public class RepositoryQueryTranslationTests
     public void SemanticSearch_CosineDistanceOrdering_Translates()
     {
         using var db = NewContext();
-        var vector = new Vector(new float[384]);
+        var vector = new Vector(new float[512]);
         var query = ExpertiseRepository.ApplyApprovedReviewFilter(
                 ExpertiseRepository.ApplyTenantFilter(db.ExpertiseEntries, Ctx()))
             .Where(e => e.Embedding != null)
@@ -136,7 +136,7 @@ public class RepositoryQueryTranslationTests
     public void FindNearestInDomain_CosineDistanceOrdering_Translates()
     {
         using var db = NewContext();
-        var vector = new Vector(new float[384]);
+        var vector = new Vector(new float[512]);
         var query = ExpertiseRepository.ApplyTenantFilter(db.ExpertiseEntries, Ctx())
             .Where(e => e.DeprecatedAt == null)
             .Where(e => e.ReviewState != ReviewState.Rejected)
@@ -253,7 +253,7 @@ public class RepositoryQueryTranslationTests
     {
         using var db = NewContext();
         var tags = new List<string> { "postgres", "ef-core" };
-        var queryVector = new Vector(new float[384]);
+        var queryVector = new Vector(new float[512]);
 
         // Mirrors the production SemanticSearchAsync composition: shared tenant+approved
         // seam -> ApplyMetadataFilters (shared with BuildListQuery, #426) -> pgvector


### PR DESCRIPTION
Closes #437. PR-C of the approved plan — the atomic swap release (ADR-017), after prerequisites #459 and eval hardening #460.

## What ships together (and must)

| Piece | Why atomic |
| --- | --- |
| EF migration `SwapEmbeddingModelTo512Dim` (drop HNSW → NULL embeddings → retype `vector(512)` → recreate HNSW) | pgvector's typmod cast rejects a retype over live 384-dim vectors |
| `download-models.sh` → jinaai HF source, new SHA-256 pins, `MODEL_VERSION=2` | new binaries embedding 512-dim into a `vector(512)` column |
| `EmbeddingModelInfo`: Name/Dimensions/`MaximumTokens = 6144` | single-point flip (wired by #459/#460) |
| bge query-prefix removal (`EmbeddingService`) | jina embeds symmetrically; a leftover prefix silently degrades every query |
| Caps: `MaxBodyLength` 1500 → **16000**, title stays 200 | re-derived from the 6144 window (#429 method) |

Plus: `expertise-apictl reembed` passthrough, populated-upgrade migration test (the empty-DB CI path cannot catch the retype failure mode), ADR-017, and the doc sweep (README, CLAUDE.md, DESIGN.md, SKILL.md, copilot-instructions, runbook, testing guide, ADR-012 example manifest).

## Eval gates (run locally, real model, pre-merge — EXPERTISE_EVAL is opt-in by design)

- **Golden set (jina@6144):** semantic recall@5 **1.000** / recall@10 1.000 / MRR **0.925** (bge baseline: 0.967/1.000/0.894); hybrid MRR **0.942** (was 0.923). Keyword arm unchanged (0.367 — model-independent).
- **Needle set (jina@6144):** 8/8 needles in-window, avg semantic rank **1.6**, worst 4; both 8000-char-deep needles rank **1**. Under bge@512 the same suite showed out-of-window decay (ranks up to 8) — the gap this swap closes, now pinned in CI-committed tests.
- Full suite 424/424; `dotnet format analyzers`, shellcheck/yamllint/actionlint/markdownlint clean.

## Deploy notes (ADR-017)

Two-phase: this release migrates schema + model atomically; the operator runs `expertise-apictl reembed` once after install (~700 entries, single-digit minutes; ~12 GB transient peak RSS on ceiling-filling embeds). During the window keyword search is unaffected; semantic/hybrid surface only reembedded rows (every read path already filters `Embedding != null`); dedup can only under-fire. **Take a backup first** — there is no binary rollback once the migration commits (Down() cannot restore destroyed vectors); recovery is roll-forward or restore.

Follow-ups tracked: #457 (SemanticThreshold retune post-reembed), #458 (Helm sizing), #345 (reembed vintage detection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)