### PR TITLE
fix: apply model-swap review findings across embed path, install, and docs

### DIFF
--- a/.agents/skills/expertise-api/SKILL.md
+++ b/.agents/skills/expertise-api/SKILL.md
@@ -84,8 +84,9 @@ cat > /tmp/entry.json <<'EOF'
 EOF
 ./scripts/create.sh --file /tmp/entry.json
 # NOTE: title is capped at 200 characters and body at 16000 (HTTP 400 beyond).
-# The embedding model sees at most ~510 tokens of "title + body"; longer text
-# would be silently invisible to semantic search, so keep titles concise and
+# The embedding model sees at most ~6144 tokens of "title + body" (silently
+# truncated beyond that, ADR-017); text past the truncation point would be
+# invisible to semantic search, so keep titles concise and
 # bodies focused — split large topics into multiple entries.
 
 # Approve / reject (requires expertise.write.approve)

--- a/.agents/skills/expertise-api/references/DESIGN.md
+++ b/.agents/skills/expertise-api/references/DESIGN.md
@@ -112,7 +112,7 @@ Single-row `EmbeddingMetadata` table tracks model name, dimensions, and `LastRee
 | GET | `/expertise/{id}` | `expertise.read` | Single entry | |
 | POST | `/expertise` | `expertise.write.draft` | Create entry (generates embedding) | |
 | POST | `/expertise/batch` | `expertise.write.draft` | Create up to 100 entries (generates embeddings, deduplicates) | Max 100 entries per batch |
-| PATCH | `/expertise/{id}` | `expertise.write.draft` | Update entry (regenerates embedding if title/body changed). Changing `visibility` — or PATCHing a `shared` entry at all (#330) — requires `expertise.write.approve`. | Title ≤ 200 / Body ≤ 1500 chars |
+| PATCH | `/expertise/{id}` | `expertise.write.draft` | Update entry (regenerates embedding if title/body changed). Changing `visibility` — or PATCHing a `shared` entry at all (#330) — requires `expertise.write.approve`. | Title ≤ 200 / Body ≤ 16000 chars |
 | DELETE | `/expertise/{id}` | `expertise.write.draft` | Soft delete (sets DeprecatedAt). Shared entries require `expertise.write.approve`. | |
 | GET | `/expertise/drafts` | `expertise.write.approve` | List Draft + Rejected entries in caller's tenant | |
 | POST | `/expertise/{id}/approve` | `expertise.write.approve` | Transition Draft → Approved | |

--- a/.pi/extensions/expertise-api/index.ts
+++ b/.pi/extensions/expertise-api/index.ts
@@ -393,7 +393,7 @@ export default function (pi: ExtensionAPI): void {
 		name: "expertise_search_semantic",
 		label: "Expertise Search (Semantic)",
 		description:
-			"Semantic vector search via /expertise/search/semantic?q=. The server embeds the query in-process (bge-micro-v2, 384-dim) and ranks by cosine similarity. Use for conceptual or paraphrased queries.",
+			"Semantic vector search via /expertise/search/semantic?q=. The server embeds the query in-process with its configured embedding model and ranks by cosine similarity. Use for conceptual or paraphrased queries.",
 		promptSnippet:
 			"Semantic (vector) search over expertise — use for conceptual queries.",
 		promptGuidelines: [

--- a/docs/research/2026-07-retrieval-assessment.md
+++ b/docs/research/2026-07-retrieval-assessment.md
@@ -1,6 +1,10 @@
 # Retrieval Improvements Assessment — 2026-07-22
 
-**Status:** Assessment only — no decisions made, nothing implemented. Each adopted
+**Status (updated 2026-07-23):** Recommendations 1–5 shipped as PRs #431–#435 (ADR-016
+records the hybrid-RRF decision). Recommendation 1's bge-specific query-instruction prefix
+was subsequently REMOVED by ADR-017 — the jina-embeddings-v2-small-en swap embeds queries
+and documents symmetrically with no prefix, so do not re-apply it. The analysis below is
+retained as written (2026-07); the bge-specific reasoning is historical context. Each adopted
 recommendation requires its own plan and (where it changes retrieval architecture)
 an ADR before implementation.
 

--- a/scripts/download-models.sh
+++ b/scripts/download-models.sh
@@ -53,19 +53,6 @@ sha256_of() {
   fi
 }
 
-# Verify SHA-256 checksum of a file.
-# Args: <file> <expected_sha256>
-verify_checksum() {
-  local file="$1" expected="$2"
-  local filename="${file##*/}"
-  local actual
-  actual=$(sha256_of "${file}")
-  if [[ "${actual}" != "${expected}" ]]; then
-    err "${filename} checksum mismatch (expected ${expected}, got ${actual}). Delete the file and re-run, or check if the upstream model changed."
-  fi
-  log "  ${filename}: checksum OK"
-}
-
 # Download a single file if missing or suspiciously small.
 # Args: <dest_file> <url> <min_bytes> <display_name> <expected_sha256>
 download_file() {
@@ -85,8 +72,8 @@ download_file() {
       fi
       # A mismatching existing file is stale (model version bump) or corrupt —
       # re-download instead of aborting, so upgrade installs pick up new model
-      # files automatically (#456). verify_checksum after the download is still
-      # the hard gate: a bad upstream file aborts as before.
+      # files automatically (#456). The temp-file checksum below is still the
+      # hard gate: a bad upstream file aborts as before.
       log "  ${filename} checksum mismatch (expected ${expected_sha256}, got ${existing_sha}) — stale or corrupt; re-downloading"
     else
       log "  ${filename} exists but is suspiciously small (${existing_size} bytes) — re-downloading"
@@ -104,14 +91,24 @@ download_file() {
   # hard outage cannot stall the install indefinitely.
   curl -fsSL --retry 8 --retry-max-time 300 --retry-all-errors "${url}" -o "${tmpfile}" \
     || { rm -f "${tmpfile}"; err "Failed to download ${filename} from ${url}"; }
-  mv "${tmpfile}" "${dest}"
 
+  # Size + checksum are verified on the TEMP file, and the destination is only
+  # replaced after both pass (atomic-on-success). Moving before verifying let a
+  # failed re-download overwrite the existing file with unverified bytes
+  # (review finding, 2026-07-23).
   local size
-  size=$(wc -c < "${dest}")
-  (( size < min_bytes )) && err "${filename} is suspiciously small (${size} bytes). Check the URL."
-  log "  ${filename}: ${size} bytes"
+  size=$(wc -c < "${tmpfile}")
+  (( size < min_bytes )) && { rm -f "${tmpfile}"; err "${filename} is suspiciously small (${size} bytes). Check the URL."; }
 
-  verify_checksum "${dest}" "${expected_sha256}"
+  local actual
+  actual=$(sha256_of "${tmpfile}")
+  if [[ "${actual}" != "${expected_sha256}" ]]; then
+    rm -f "${tmpfile}"
+    err "${filename} downloaded file failed checksum (expected ${expected_sha256}, got ${actual}). Upstream may have changed — verify HF_BASE and the pinned SHA-256; any pre-existing ${filename} was left untouched."
+  fi
+
+  mv "${tmpfile}" "${dest}"
+  log "  ${filename}: ${size} bytes, checksum OK"
 }
 
 mkdir -p "${DEST_DIR}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -725,6 +725,11 @@ publish_app_staged() {
 # ---------------------------------------------------------------------------
 ensure_models() {
   STAGE="models"
+  # Same symlink-TOCTOU refusal as every other mutated path in this script
+  # (STAGE_DIR/OLD_DIR/VERSION_MARKER/install.env) — a pre-planted symlink
+  # here would redirect the model download outside the prefix (review
+  # finding, 2026-07-23).
+  if [[ -L "${MODEL_DIR}" ]]; then err "${MODEL_DIR} exists as a symlink — refusing to overwrite (potential TOCTOU)"; fi
   # Always delegate to download-models.sh — it skips files whose checksum
   # matches the pinned SHA-256 and re-downloads stale ones, so upgrade
   # installs pick up a model version bump. Gating on file existence here

--- a/src/ExpertiseApi/Cli/ReembedCommand.cs
+++ b/src/ExpertiseApi/Cli/ReembedCommand.cs
@@ -44,6 +44,11 @@ internal static class ReembedCommand
             }
 
             await db.SaveChangesAsync();
+            // Bound the tracker to one batch — without this the context tracks
+            // every processed entity for the whole run, and DetectChanges cost
+            // grows with corpus size while the host is also absorbing the
+            // model's inference transients (review finding, 2026-07-23).
+            db.ChangeTracker.Clear();
             lastId = entries[^1].Id;
             processed += entries.Count;
             logger.LogInformation("Reembedded {Processed} entries", processed);

--- a/src/ExpertiseApi/Cli/RehashCommand.cs
+++ b/src/ExpertiseApi/Cli/RehashCommand.cs
@@ -44,6 +44,8 @@ internal static class RehashCommand
             }
 
             await db.SaveChangesAsync();
+            // Same tracker-bounding as ReembedCommand (review finding, 2026-07-23).
+            db.ChangeTracker.Clear();
             lastId = entries[^1].Id;
             processed += entries.Count;
             logger.LogInformation("Rehashed {Processed} entries", processed);

--- a/src/ExpertiseApi/Cli/RestoreCommand.cs
+++ b/src/ExpertiseApi/Cli/RestoreCommand.cs
@@ -25,8 +25,9 @@ namespace ExpertiseApi.Cli;
 ///   * v1 is <c>--mode replace</c> only: target tables must be empty.
 ///   * Pending EF migrations → abort (MigrateCommand idiom).
 ///   * Manifest embedding model vs live EmbeddingMetadata mismatch → abort loudly,
-///     directing to <c>reembed</c>. Embeddings whose dimensions don't fit the
-///     vector(384) column are skipped (regenerable), never a reason to abort.
+///     directing to <c>reembed</c>. Embeddings whose dimensions don't fit the live
+///     vector(N) column (N = <see cref="EmbeddingModelInfo.Dimensions"/>) are
+///     skipped (regenerable), never a reason to abort.
 /// </summary>
 internal static class RestoreCommand
 {

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -419,10 +419,7 @@ var vocabPath = builder.Configuration["Onnx:VocabPath"] ?? Path.Combine(baseDir,
 if (File.Exists(modelPath) && File.Exists(vocabPath))
 {
     builder.Services.AddBertOnnxEmbeddingGenerator(modelPath, vocabPath,
-        new Microsoft.SemanticKernel.Connectors.Onnx.BertOnnxOptions
-        {
-            MaximumTokens = EmbeddingModelInfo.MaximumTokens
-        });
+        EmbeddingModelInfo.CreateOnnxOptions());
 }
 builder.Services.AddScoped<EmbeddingService>();
 

--- a/src/ExpertiseApi/Services/EmbeddingModelInfo.cs
+++ b/src/ExpertiseApi/Services/EmbeddingModelInfo.cs
@@ -25,4 +25,13 @@ internal static class EmbeddingModelInfo
     /// derived from this value.
     /// </summary>
     public const int MaximumTokens = 6144;
+
+    /// <summary>
+    /// The one way to build the connector options — Program.cs and both eval
+    /// suites use this instead of hand-rolling an options object per call site
+    /// (review finding, 2026-07-23), so a future knob (pooling, casing) is a
+    /// one-place change.
+    /// </summary>
+    public static Microsoft.SemanticKernel.Connectors.Onnx.BertOnnxOptions CreateOnnxOptions() =>
+        new() { MaximumTokens = MaximumTokens };
 }

--- a/src/ExpertiseApi/Services/EmbeddingService.cs
+++ b/src/ExpertiseApi/Services/EmbeddingService.cs
@@ -5,6 +5,17 @@ namespace ExpertiseApi.Services;
 
 internal class EmbeddingService(IEmbeddingGenerator<string, Embedding<float>> generator)
 {
+    // Bounds in-flight ONNX inference process-wide (static: the service is
+    // scoped, the memory is not). A ceiling-filling embed transiently peaks
+    // ~12 GB RSS at MaximumTokens = 6144 (ADR-017 ground truth); without this
+    // gate, concurrent max-length writes stack those transients — an
+    // authenticated memory-exhaustion path on the single-host A2 target
+    // (review finding, 2026-07-23). The per-minute rate limiter bounds request
+    // RATE, not overlap; this bounds overlap. Serialized embeds cost ~1s of
+    // queueing only under exactly the burst that would otherwise exhaust the
+    // host.
+    private static readonly SemaphoreSlim InferenceGate = new(1, 1);
+
     // jina-embeddings-v2-small-en is trained symmetrically: queries and documents
     // embed identically, with NO instruction prefix (ADR-017). The bge-family
     // query instruction PR #431 added was model-specific and was removed with the
@@ -17,14 +28,30 @@ internal class EmbeddingService(IEmbeddingGenerator<string, Embedding<float>> ge
 
     public async Task<Vector> GenerateEmbeddingAsync(string text, CancellationToken ct = default)
     {
-        var result = await generator.GenerateAsync([text], cancellationToken: ct);
-        return new Vector(result[0].Vector.ToArray());
+        await InferenceGate.WaitAsync(ct);
+        try
+        {
+            var result = await generator.GenerateAsync([text], cancellationToken: ct);
+            return new Vector(result[0].Vector.ToArray());
+        }
+        finally
+        {
+            InferenceGate.Release();
+        }
     }
 
     public async Task<IReadOnlyList<Vector>> GenerateBatchAsync(IEnumerable<string> texts, CancellationToken ct = default)
     {
         var list = texts.ToList();
-        var results = await generator.GenerateAsync(list, cancellationToken: ct);
-        return results.Select(r => new Vector(r.Vector.ToArray())).ToList();
+        await InferenceGate.WaitAsync(ct);
+        try
+        {
+            var results = await generator.GenerateAsync(list, cancellationToken: ct);
+            return results.Select(r => new Vector(r.Vector.ToArray())).ToList();
+        }
+        finally
+        {
+            InferenceGate.Release();
+        }
     }
 }

--- a/tests/ExpertiseApi.Tests/Architecture/EmbeddingDimensionConsistencyTests.cs
+++ b/tests/ExpertiseApi.Tests/Architecture/EmbeddingDimensionConsistencyTests.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Reflection;
+using ExpertiseApi.Models;
+using ExpertiseApi.Services;
+
+namespace ExpertiseApi.Tests.Architecture;
+
+/// <summary>
+/// Ties the two declarations of the vector dimension together (review finding,
+/// 2026-07-23): <c>EmbeddingModelInfo.Dimensions</c> is documented as the single
+/// source of truth, but the pgvector column width lives in a data-annotation
+/// string on <c>ExpertiseEntry.Embedding</c> that nothing else enforces. A model
+/// swap that bumps the constant without the attribute (or vice versa) compiles
+/// cleanly and only fails at INSERT time in production — this test makes that
+/// drift a CI failure instead.
+/// </summary>
+public class EmbeddingDimensionConsistencyTests
+{
+    [Fact]
+    public void EmbeddingColumnType_MatchesEmbeddingModelInfoDimensions()
+    {
+        var column = typeof(ExpertiseEntry)
+            .GetProperty(nameof(ExpertiseEntry.Embedding), BindingFlags.Public | BindingFlags.Instance)!
+            .GetCustomAttribute<ColumnAttribute>();
+
+        column.Should().NotBeNull("ExpertiseEntry.Embedding must declare its pgvector column type");
+        column!.TypeName.Should().Be($"vector({EmbeddingModelInfo.Dimensions})",
+            "the column attribute and EmbeddingModelInfo.Dimensions must move together — " +
+            "a mismatch surfaces as a runtime INSERT failure, not a compile error");
+    }
+}

--- a/tests/ExpertiseApi.Tests/Evaluation/NeedleEvalTests.cs
+++ b/tests/ExpertiseApi.Tests/Evaluation/NeedleEvalTests.cs
@@ -72,7 +72,7 @@ public sealed class NeedleEvalTests(PostgresFixture postgres, ITestOutputHelper 
 
         var services = new ServiceCollection();
         services.AddBertOnnxEmbeddingGenerator(ModelFiles.ModelPath!, ModelFiles.VocabPath!,
-            new BertOnnxOptions { MaximumTokens = EmbeddingModelInfo.MaximumTokens });
+            EmbeddingModelInfo.CreateOnnxOptions());
         _onnxProvider = services.BuildServiceProvider();
         _embedding = new EmbeddingService(
             _onnxProvider.GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>());

--- a/tests/ExpertiseApi.Tests/Evaluation/RetrievalEvalTests.cs
+++ b/tests/ExpertiseApi.Tests/Evaluation/RetrievalEvalTests.cs
@@ -62,7 +62,7 @@ public sealed class RetrievalEvalTests(PostgresFixture postgres, ITestOutputHelp
 
         var services = new ServiceCollection();
         services.AddBertOnnxEmbeddingGenerator(ModelFiles.ModelPath!, ModelFiles.VocabPath!,
-            new BertOnnxOptions { MaximumTokens = EmbeddingModelInfo.MaximumTokens });
+            EmbeddingModelInfo.CreateOnnxOptions());
         _onnxProvider = services.BuildServiceProvider();
         _embedding = new EmbeddingService(
             _onnxProvider.GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>());

--- a/tests/ExpertiseApi.Tests/Unit/EmbeddingServiceTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/EmbeddingServiceTests.cs
@@ -43,6 +43,52 @@ public class EmbeddingServiceTests
     }
 
     [Fact]
+    public async Task GenerateEmbeddingAsync_BoundsInferenceConcurrency_ToOne()
+    {
+        // Review finding 2026-07-23: a ceiling-filling embed transiently peaks
+        // ~12 GB RSS (ADR-017), so overlapping inference is the memory-exhaustion
+        // vector on the A2 single host. This pins the InferenceGate: N parallel
+        // callers must never observe more than one in-flight generator call.
+        var inFlight = 0;
+        var maxObserved = 0;
+        var generator = Substitute.For<IEmbeddingGenerator<string, Embedding<float>>>();
+        generator.GenerateAsync(
+                Arg.Any<IEnumerable<string>>(),
+                Arg.Any<EmbeddingGenerationOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(async ci =>
+            {
+                var now = Interlocked.Increment(ref inFlight);
+                InterlockedExtensionsMax(ref maxObserved, now);
+                await Task.Delay(30);
+                Interlocked.Decrement(ref inFlight);
+                var res = new GeneratedEmbeddings<Embedding<float>>();
+                foreach (var input in ci.ArgAt<IEnumerable<string>>(0))
+                    res.Add(new Embedding<float>(TestHelpers.CreateContentEmbedding(input)));
+                return res;
+            });
+
+        var service = new EmbeddingService(generator);
+        await Task.WhenAll(Enumerable.Range(0, 6).Select(i =>
+            i % 2 == 0
+                ? service.GenerateEmbeddingAsync($"text {i}")
+                : (Task)service.GenerateBatchAsync([$"batch {i}"])));
+
+        maxObserved.Should().Be(1,
+            "the static inference gate must serialize ONNX calls across single and batch paths");
+    }
+
+    private static void InterlockedExtensionsMax(ref int target, int candidate)
+    {
+        int snapshot;
+        while (candidate > (snapshot = Volatile.Read(ref target)))
+        {
+            if (Interlocked.CompareExchange(ref target, candidate, snapshot) == snapshot)
+                break;
+        }
+    }
+
+    [Fact]
     public void BuildInputText_RemainsUnprefixed()
     {
         // jina-v2-small embeds queries and documents symmetrically with NO

--- a/tests/install/test-download-models.sh
+++ b/tests/install/test-download-models.sh
@@ -9,8 +9,9 @@
 #
 # Covers:
 #   1. stale oversized file → "re-downloading" path taken (not the old
-#      "Delete the file and re-run" abort), and a bad downloaded payload still
-#      aborts via the post-download checksum gate
+#      "Delete the file and re-run" abort); a bad downloaded payload aborts via
+#      the TEMP-FILE checksum gate, the previous file is left untouched
+#      (verify-before-move — review finding 2026-07-23), and no temp files leak
 #   2. missing file + failing network → clean download-failure abort
 #   3. undersized file → existing "suspiciously small" re-download path intact
 #
@@ -82,18 +83,26 @@ else
   fail "stale file: expected 're-downloading' in output, got: $out1"
 fi
 
-if printf '%s' "$out1" | grep -q "checksum mismatch" && [ "$rc1" -ne 0 ]; then
-  ok "bad downloaded payload still aborts via post-download checksum gate (rc=$rc1)"
+if printf '%s' "$out1" | grep -q "failed checksum" && [ "$rc1" -ne 0 ]; then
+  ok "bad downloaded payload aborts via the temp-file checksum gate (rc=$rc1)"
 else
-  fail "post-download gate: expected checksum-mismatch abort, rc=$rc1, output: $out1"
+  fail "download gate: expected temp-file checksum abort, rc=$rc1, output: $out1"
 fi
 
-# The stale file must have been REPLACED by the downloaded payload (all-x),
-# proving the download actually ran rather than the old abort-in-place.
+# Verify-before-move: the failed download must NOT have replaced the existing
+# file (its zero-byte content must survive; the stub payload is all 'x').
 if grep -q 'xxxx' "${DEST1}/model.onnx" 2>/dev/null; then
-  ok "stale file was replaced by the re-downloaded payload"
+  fail "destination was overwritten by an unverified payload (mv-before-verify regression)"
 else
-  fail "stale file content unchanged — re-download never wrote the destination"
+  ok "previous file left untouched after failed re-download"
+fi
+
+# And the rejected temp file must have been cleaned up.
+leftover=$(find "${DEST1}" -name 'model.onnx.*' | wc -l | tr -d ' ')
+if [ "$leftover" = "0" ]; then
+  ok "no temp files leaked after checksum rejection"
+else
+  fail "found $leftover leftover temp file(s) in ${DEST1}"
 fi
 
 # --- 2. missing file + network failure --------------------------------------


### PR DESCRIPTION
PR-D: applies **all 11 confirmed findings** (2 Error, 8 Warning, 1 Info — per request, the Info item included) from the six-dimension adversarially-verified review of the #437 model-swap PR set. Findings report: session artifact `model-swap-review-437` (2026-07-23).

## Errors
- **Memory-exhaustion path closed** — `EmbeddingService` gains a static `SemaphoreSlim(1)` inference gate: in-flight ONNX inference is bounded process-wide, so concurrent max-length writes can no longer stack ~12 GB transients on the A2 host. New unit test pins max observed concurrency to 1 across single + batch paths.
- **DESIGN.md API-surface table** — Body cap corrected 1500 → 16000 (was contradicting the same file's own gotchas section).

## Warnings
- `download-models.sh` — **verify-before-move**: size + SHA-256 checked on the temp file; destination replaced only on success; failed re-download preserves the existing file and cleans its temp file (staleness suite re-pinned to the new contract, 6 checks).
- `install.sh ensure_models` — symlink-TOCTOU refusal, matching STAGE_DIR/OLD_DIR/VERSION_MARKER/install.env.
- New `Architecture/EmbeddingDimensionConsistencyTests` — `vector(N)` column attribute must equal `EmbeddingModelInfo.Dimensions`; dimension drift now fails CI instead of production INSERTs.
- `Reembed`/`Rehash` — `ChangeTracker.Clear()` after each batch save.
- pi extension `expertise_search_semantic` description de-hardcoded (was "bge-micro-v2, 384-dim" — surfaced to the LLM every session; now model-name-free so it cannot drift again).
- SKILL.md "~510 tokens" → "~6144 tokens (ADR-017)"; RestoreCommand trust-policy xmldoc made dimension-generic; retrieval-assessment status line updated (recs 1–5 shipped; rec 1's bge prefix reverted by ADR-017 — do not re-apply).

## Info
- `EmbeddingModelInfo.CreateOnnxOptions()` factory replaces the three hand-rolled `BertOnnxOptions` call sites (Program.cs + both eval suites).

## Validation
Full suite **426/426** (+2 new tests); pi extension typecheck + 14/14; install staleness suite 6/6 under macOS /bin/bash 3.2; `dotnet format analyzers` clean; shellcheck/markdownlint clean (linter verdict PASS, no diff-introduced findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)