### PR TITLE
release: promote dev to main (v1.6.0 — jina model swap)

### DIFF
--- a/.agents/skills/expertise-api/SKILL.md
+++ b/.agents/skills/expertise-api/SKILL.md
@@ -83,7 +83,7 @@ cat > /tmp/entry.json <<'EOF'
 }
 EOF
 ./scripts/create.sh --file /tmp/entry.json
-# NOTE: title is capped at 200 characters and body at 1500 (HTTP 400 beyond).
+# NOTE: title is capped at 200 characters and body at 16000 (HTTP 400 beyond).
 # The embedding model sees at most ~510 tokens of "title + body"; longer text
 # would be silently invisible to semantic search, so keep titles concise and
 # bodies focused — split large topics into multiple entries.

--- a/.agents/skills/expertise-api/SKILL.md
+++ b/.agents/skills/expertise-api/SKILL.md
@@ -84,8 +84,9 @@ cat > /tmp/entry.json <<'EOF'
 EOF
 ./scripts/create.sh --file /tmp/entry.json
 # NOTE: title is capped at 200 characters and body at 16000 (HTTP 400 beyond).
-# The embedding model sees at most ~510 tokens of "title + body"; longer text
-# would be silently invisible to semantic search, so keep titles concise and
+# The embedding model sees at most ~6144 tokens of "title + body" (silently
+# truncated beyond that, ADR-017); text past the truncation point would be
+# invisible to semantic search, so keep titles concise and
 # bodies focused — split large topics into multiple entries.
 
 # Approve / reject (requires expertise.write.approve)

--- a/.agents/skills/expertise-api/references/DESIGN.md
+++ b/.agents/skills/expertise-api/references/DESIGN.md
@@ -17,10 +17,10 @@ curl toolkit and when to invoke it — lives in `SKILL.md`.
 | Database | PostgreSQL 17 (single backend, no MongoDB) |
 | PostgreSQL image | `pgvector/pgvector:pg17` |
 | Connection pooling | PgBouncer 1.21+ sidecar (`edoburu/pgbouncer`, transaction mode) |
-| Vector search | pgvector extension — `vector(384)` column with HNSW index (`vector_cosine_ops`) |
+| Vector search | pgvector extension — `vector(512)` column with HNSW index (`vector_cosine_ops`) |
 | Keyword search | PostgreSQL stored generated `tsvector` column with GIN index |
 | Embeddings | In-process ONNX via `Microsoft.SemanticKernel.Connectors.Onnx` |
-| Embedding model | `bge-micro-v2` (22.9MB, 384-dim, bundled in Docker image) |
+| Embedding model | `jina-embeddings-v2-small-en` (~130MB FP32, 512-dim, 6144-token ceiling, bundled in Docker image — ADR-017) |
 | Embedding abstraction | `IEmbeddingGenerator<string, Embedding<float>>` (Microsoft.Extensions.AI) |
 | Embedding input | `EmbeddingService.BuildInputText(title, body)` — single source of truth |
 | Auth | Multi-issuer OIDC (Entra + Authentik) via `JwtBearer` per issuer behind a `Bearer` policy scheme; `ApiKey`/`LocalDev`/`Hybrid` modes for Development only |
@@ -50,7 +50,7 @@ public class ExpertiseEntry
     public Severity Severity { get; set; }
     public required string Source { get; set; }      // self-reported — informational only post-rebuild
     public string? SourceVersion { get; set; }       // e.g. "EF Core 10.0.1" — staleness signal
-    public Vector? Embedding { get; set; }           // pgvector vector(384), nullable until embedded
+    public Vector? Embedding { get; set; }           // pgvector vector(512), nullable until embedded
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
     public DateTime? DeprecatedAt { get; set; }      // soft delete
@@ -242,7 +242,7 @@ src/ExpertiseApi/
   Services/                # EmbeddingService, DeduplicationService
   Auth/                    # ApiKeyAuthHandler, AuthExtensions, AuthConstants
   Cli/                     # ReembedCommand, RehashCommand, MigrateCommand, BackupCommand, RestoreCommand
-  models/                  # ONNX model files (bge-micro-v2) — not committed, needed at runtime
+  models/                  # ONNX model files (jina-v2-small) — not committed, needed at runtime
 helm/expertise-api/        # Helm chart (shared templates, generic values)
 deploy/local/              # Docker Compose, .env.example, pgvector init script
 scripts/                   # download-models.sh
@@ -265,8 +265,8 @@ scripts/                   # download-models.sh
 - **`reembed` CLI:** Run as a one-off k8s Job, not from a running API replica, to avoid concurrent row writes.
 - **Keyword search uses raw SQL:** The stored `SearchVector` column cannot be queried via LINQ — `KeywordSearchAsync` uses `FromSqlInterpolated` (`websearch_to_tsquery` + `ts_rank_cd` + `LIMIT`; all filtering and ordering must stay inside the SQL string — composing LINQ on top wraps it in a subquery and can drop the inner ORDER BY).
 - **Search `score` field semantics:** search responses carry a server-computed `score` per hit (#427) — keyword: raw `ts_rank_cd` (unbounded, comparable only within one response); semantic: cosine similarity (`1 - distance`, higher is closer); hybrid: the fused RRF sum (`Σ 1/(60+rank)` across arms, ADR-016). Never compare scores across modes; every score is comparable only within one response. Non-search reads emit no score.
-- **bge query-instruction prefix:** bge-family embedding models are trained asymmetrically — QUERY-side text must be prefixed with `Represent this sentence for searching relevant passages:` plus a trailing space (see `EmbeddingService.QueryInstruction`); document-side text is embedded unprefixed. Semantic search uses `GenerateQueryEmbeddingAsync`; create/reembed/dedup paths use the unprefixed document path. A model swap must re-verify the instruction wording against the new model's card.
-- **512-token embedding ceiling / `MaxBodyLength`:** bge-micro-v2 embeds at most 512 wordpiece tokens (510 content + `[CLS]`/`[SEP]`); the ONNX connector **silently truncates** anything longer — no exception, no log, confirmed empirically to the exact token (#429, 2026-07-22). `BuildInputText` embeds `"{title} {body}"` in one pass, so Title and Body share the budget. Writes enforce `MaxBodyLength = 1500` chars (hard 400; derivation: ~470 body tokens × ~3 chars/token measured on real entries). Entries created before the guard may exceed the cap: they are grandfathered (readable, non-Body PATCHes fine) but their embeddings only reflect the first ~510 tokens, and a Body PATCH must come in under the cap. `MaxTitleLength = 200` guards the Title share of the same budget (#436). Re-derive both constants on any model swap (#437).
+- **No query-instruction prefix (ADR-017):** jina-embeddings-v2-small-en embeds queries and documents symmetrically — NO instruction prefix on either side. The bge-era query prefix (PR #431) was model-specific and was removed with the swap; `EmbeddingServiceTests` pins the no-prefix contract. Any future model swap must re-verify prefix requirements against the new model’s card (bge-family needs one, jina forbids the asymmetry).
+- **6144-token embedding ceiling / `MaxBodyLength` (ADR-017):** the generator is wired with `MaximumTokens = 6144` (`EmbeddingModelInfo`) — the measured coverage plateau for this corpus (99.71%, identical to 8192, at 65% less peak RSS). The ONNX connector **silently truncates** beyond the ceiling — no exception, no log (#429). `BuildInputText` embeds `"{title} {body}"` in one pass, so Title and Body share the window. Writes enforce `MaxBodyLength = 16000` chars (hard 400; ≈5,390 worst-case body tokens at the measured 2.97 chars/token minimum density) and `MaxTitleLength = 200` (#436). Entries created before the model swap have NULL embeddings until `reembed` runs (invisible to semantic/hybrid search, still in keyword results). Ceiling-filling embeds transiently peak ~12 GB RSS — relevant to A2 host sizing, prohibitive for the current Helm limits (#458). Re-derive all constants on any model or ceiling change; ground-truth tables live on issue #437.
 - **A2 binds are plaintext http; non-loopback requires an explicit override:** `install.sh` hardcodes `ASPNETCORE_URLS=http://…` (no TLS on this path), so `preflight` refuses a non-loopback `--bind` unless `--allow-plaintext-bind` is passed (#332). Keep the API on loopback behind a co-located TLS edge (the LAN runbook topology); the override exists only for a remote TLS edge where cleartext on that segment is accepted. `AllowedHosts` is not a mitigation — HostFiltering checks only the client-controlled Host header.
 - **`secrets.env` is sourced, not parsed:** the wrapper, `migrate.sh`, and install flow all `set -a; . secrets.env` (deliberate — quoted `;`-bearing values survive). Consequence: write access to `secrets.env` is code-execution-equivalent in the service context at every start/restart/migrate, not merely config injection. It is the one 600-mode, owner-guarded object in the tree; treat it accordingly (#332, full deployment threat model tracked in #226).
 - **launchd services lack systemd-grade sandboxing:** the systemd unit ships `ProtectSystem`/`ProtectHome`/`RestrictAddressFamilies` etc.; the launchd plists have no first-class equivalent without code-signing/entitlements. Accepted platform-parity gap on macOS A2 installs (#332/#226).

--- a/.agents/skills/expertise-api/references/DESIGN.md
+++ b/.agents/skills/expertise-api/references/DESIGN.md
@@ -112,7 +112,7 @@ Single-row `EmbeddingMetadata` table tracks model name, dimensions, and `LastRee
 | GET | `/expertise/{id}` | `expertise.read` | Single entry | |
 | POST | `/expertise` | `expertise.write.draft` | Create entry (generates embedding) | |
 | POST | `/expertise/batch` | `expertise.write.draft` | Create up to 100 entries (generates embeddings, deduplicates) | Max 100 entries per batch |
-| PATCH | `/expertise/{id}` | `expertise.write.draft` | Update entry (regenerates embedding if title/body changed). Changing `visibility` — or PATCHing a `shared` entry at all (#330) — requires `expertise.write.approve`. | Title ≤ 200 / Body ≤ 1500 chars |
+| PATCH | `/expertise/{id}` | `expertise.write.draft` | Update entry (regenerates embedding if title/body changed). Changing `visibility` — or PATCHing a `shared` entry at all (#330) — requires `expertise.write.approve`. | Title ≤ 200 / Body ≤ 16000 chars |
 | DELETE | `/expertise/{id}` | `expertise.write.draft` | Soft delete (sets DeprecatedAt). Shared entries require `expertise.write.approve`. | |
 | GET | `/expertise/drafts` | `expertise.write.approve` | List Draft + Rejected entries in caller's tenant | |
 | POST | `/expertise/{id}/approve` | `expertise.write.approve` | Transition Draft → Approved | |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,10 +7,10 @@ Design document: GitHub issue #1. For architecture and implementation guidance, 
 ## Tech Stack
 
 - .NET 10 (LTS) with ASP.NET Core Minimal APIs
-- PostgreSQL 17 with pgvector extension (vector(384)) and tsvector full-text search
+- PostgreSQL 17 with pgvector extension (vector(512)) and tsvector full-text search
 - EF Core with repository pattern (`IExpertiseRepository`)
 - PgBouncer 1.21+ sidecar (transaction mode)
-- In-process ONNX embeddings: bge-micro-v2, 384-dim, via `Microsoft.SemanticKernel.Connectors.Onnx`
+- In-process ONNX embeddings: jina-embeddings-v2-small-en, 512-dim, 6144-token ceiling (ADR-017), via `Microsoft.SemanticKernel.Connectors.Onnx`
 - OpenAPI via Scalar (`Scalar.AspNetCore`)
 - Docker Compose for local dev; Helm chart for k3s deployment
 
@@ -64,7 +64,7 @@ All endpoints require a Bearer token in the Authorization header except the anon
 
 ## Model Files
 
-The bge-micro-v2 ONNX model files (`model.onnx`, `vocab.txt`) are not tracked in git. Download them with:
+The jina-embeddings-v2-small-en ONNX model files (`model.onnx`, `vocab.txt`) are not tracked in git. Download them with:
 
 ```bash
 ./scripts/download-models.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,15 @@ jobs:
       - name: Format gate (analyzers must be clean)
         run: dotnet format analyzers ExpertiseApi.slnx --verify-no-changes
 
+      - name: Cache ONNX model files
+        id: model-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: src/ExpertiseApi/models
+          key: onnx-models-${{ hashFiles('scripts/download-models.sh') }}
+
       - name: Download ONNX model files
+        if: steps.model-cache.outputs.cache-hit != 'true'
         run: bash scripts/download-models.sh
 
       - name: Test
@@ -176,6 +184,9 @@ jobs:
 
       - name: Run version resolver stdout-purity tests (#440)
         run: bash tests/install/test-resolve-version.sh
+
+      - name: Run model-download staleness tests (#456)
+        run: bash tests/install/test-download-models.sh
 
   install-script-guards:
     name: install/uninstall script guard tests (#242)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: src/ExpertiseApi/models
-          key: onnx-bge-micro-v2-quantized-${{ hashFiles('scripts/download-models.sh') }}
+          key: onnx-models-${{ hashFiles('scripts/download-models.sh') }}
 
       - name: Download ONNX model files
         if: steps.model-cache.outputs.cache-hit != 'true'
@@ -361,7 +361,7 @@ jobs:
           # existence alone is insufficient — a csproj that lists an RID
           # but produces an empty native dir would crash at runtime on
           # that host. If this fails, the csproj property was reverted or
-          # the bge-micro-v2 model dir lacks its native sidecar.
+          # the ONNX runtime dir lacks its native sidecar.
           for rid in linux-x64 linux-arm64 osx-arm64 osx-x64 win-x64; do
             native_dir="$out_pub/runtimes/$rid/native"
             if [ ! -d "$native_dir" ] || [ -z "$(ls -A "$native_dir" 2>/dev/null)" ]; then

--- a/.pi/extensions/expertise-api/index.ts
+++ b/.pi/extensions/expertise-api/index.ts
@@ -393,7 +393,7 @@ export default function (pi: ExtensionAPI): void {
 		name: "expertise_search_semantic",
 		label: "Expertise Search (Semantic)",
 		description:
-			"Semantic vector search via /expertise/search/semantic?q=. The server embeds the query in-process (bge-micro-v2, 384-dim) and ranks by cosine similarity. Use for conceptual or paraphrased queries.",
+			"Semantic vector search via /expertise/search/semantic?q=. The server embeds the query in-process with its configured embedding model and ranks by cosine similarity. Use for conceptual or paraphrased queries.",
 		promptSnippet:
 			"Semantic (vector) search over expertise — use for conceptual queries.",
 		promptGuidelines: [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Self-hosted .NET 10 REST API for storing and serving expertise entries consumed 
 - **PostgreSQL 17** with **pgvector** extension for semantic search
 - **EF Core** for data access (repository pattern via `IExpertiseRepository`)
 - **PgBouncer 1.21+** sidecar for connection pooling (transaction mode)
-- **In-process ONNX** embeddings via `Microsoft.SemanticKernel.Connectors.Onnx` (bge-micro-v2, 384-dim)
+- **In-process ONNX** embeddings via `Microsoft.SemanticKernel.Connectors.Onnx` (jina-embeddings-v2-small-en, 512-dim, 6144-token ceiling — ADR-017)
 - **Serilog** for structured logging (`Serilog.AspNetCore`)
 - **prometheus-net** for Prometheus metrics endpoint (`/metrics`)
 - **OpenAPI** docs via Scalar (`Scalar.AspNetCore`)
@@ -83,7 +83,7 @@ see [`docs/operations/backup-restore-runbook.md`](docs/operations/backup-restore
 The ONNX model files are not tracked in git. Download them before running locally or building Docker images:
 
 ```bash
-# Download bge-micro-v2 quantized model (~17.4 MB) and vocab.txt
+# Download jina-embeddings-v2-small-en model (~130 MB) and vocab.txt
 ./scripts/download-models.sh
 
 # Force re-download (e.g., after model version bump)
@@ -114,7 +114,7 @@ curl http://localhost:5000/health
 
 # 5. Create an entry (under Hybrid mode in Development — accepts the API key from .env)
 # POSTs require an Idempotency-Key header per ADR-010 (hard-required since 2026-05-19).
-# Write guards: title max 200 chars, body max 1500 (400 beyond — embedding-window caps, #429/#436).
+# Write guards: title max 200 chars, body max 16000 (400 beyond — embedding-window caps, #429/#436/ADR-017).
 curl -X POST http://localhost:5000/expertise \
   -H "Authorization: Bearer dev-api-key-change-me" \
   -H "Idempotency-Key: $(uuidgen)" \
@@ -147,7 +147,7 @@ curl "http://localhost:5000/expertise/search/semantic?q=test&limit=5" \
 # Browse to http://localhost:5000/query
 ```
 
-**Note:** Semantic search and embedding generation require the bge-micro-v2 ONNX model files (`model.onnx` and `vocab.txt`) in `src/ExpertiseApi/models/`. Without them, the API will start but POST/PATCH and semantic search will fail. CRUD and keyword search work without the model.
+**Note:** Semantic search and embedding generation require the jina-embeddings-v2-small-en ONNX model files (`model.onnx` and `vocab.txt`) in `src/ExpertiseApi/models/`. Without them, the API will start but POST/PATCH and semantic search will fail. CRUD and keyword search work without the model.
 
 ## Agent Integration
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ flowchart LR
     api["expertise-api\n(ASP.NET Core)"]
     pgbouncer["PgBouncer\n(connection pooling)"]
     postgres["PostgreSQL 17\n(pgvector + tsvector)"]
-    onnx["ONNX Runtime\n(bge-micro-v2, 384-dim)"]
+    onnx["ONNX Runtime\n(jina-v2-small, 512-dim)"]
 
     agents -->|"HTTP + Bearer token"| api
     api --> pgbouncer --> postgres
@@ -28,7 +28,7 @@ flowchart LR
 | Framework | ASP.NET Core Minimal APIs |
 | Database | PostgreSQL 17 + pgvector + tsvector |
 | Connection pooling | PgBouncer 1.21+ (transaction mode) |
-| Embeddings | In-process ONNX (bge-micro-v2, 384-dim) |
+| Embeddings | In-process ONNX (jina-embeddings-v2-small-en, 512-dim, 6144-token ceiling — ADR-017) |
 | Data access | EF Core (repository pattern) |
 | API docs | Scalar (OpenAPI) |
 | Local dev | Docker Compose |
@@ -45,7 +45,7 @@ The three POST writes (`/expertise`, `/expertise/{id}/approve`, `/expertise/{id}
 | GET | `/expertise/drafts` | — | List Draft + Rejected entries in caller's tenant (requires `expertise.write.approve`) |
 | POST | `/expertise` | **required** | Create entry (generates embedding, writes audit row) |
 | POST | `/expertise/batch` | — | Create up to 100 entries (generates embeddings, deduplicates) |
-| PATCH | `/expertise/{id}` | — | Update entry. Approved entries regress to Draft if caller lacks `write.approve`. Changing `visibility` — or PATCHing a `shared` entry at all (#330) — requires `write.approve`. Title ≤ 200 chars, body ≤ 1500 (embedding-window guards). |
+| PATCH | `/expertise/{id}` | — | Update entry. Approved entries regress to Draft if caller lacks `write.approve`. Changing `visibility` — or PATCHing a `shared` entry at all (#330) — requires `write.approve`. Title ≤ 200 chars, body ≤ 16000 (embedding-window guards, ADR-017). |
 | DELETE | `/expertise/{id}` | — | Soft delete (sets DeprecatedAt). Shared entries require `expertise.write.approve` |
 | POST | `/expertise/{id}/approve` | **required** | Transition Draft → Approved (requires `expertise.write.approve`) |
 | POST | `/expertise/{id}/reject` | **required** | Transition Draft → Rejected with required reason (requires `expertise.write.approve`) |

--- a/adrs/012-backup-artifact-format.md
+++ b/adrs/012-backup-artifact-format.md
@@ -67,7 +67,7 @@ Manifest schema (v1):
   "entriesMerkleRoot": "…",      // RFC 6962 over per-entry BackupRecordHash leaves
   "auditMerkleRoot": "…",        // RFC 6962 over per-audit-row leaves
   "dbSchemaVersion": "…",        // last applied EF migration id at export time
-  "embeddingModel": { "name": "bge-micro-v2", "dims": 384 },
+  "embeddingModel": { "name": "jina-embeddings-v2-small-en", "dims": 512 },
   "payloadSha256": "…"           // SHA-256 of payload.tar.gz.age as stored
 }
 ```

--- a/adrs/017-embedding-model-swap.md
+++ b/adrs/017-embedding-model-swap.md
@@ -1,0 +1,146 @@
+# 017 — Embedding model swap: jina-embeddings-v2-small-en at a 6144-token ceiling
+
+## Status
+
+Accepted (2026-07-23)
+
+## Context and Problem Statement
+
+The API embeds entries with bge-micro-v2 (384-dim, 512-token architectural window)
+via `Microsoft.SemanticKernel.Connectors.Onnx`. The connector silently truncates
+input beyond `MaximumTokens` (#429), which forced hard write caps of
+`MaxBodyLength = 1500` / `MaxTitleLength = 200` characters. Those caps are the
+binding constraint on entry authoring: real agent-generated fix/caveat entries
+routinely want more than 1500 characters of body. Issue #437 asked whether a
+long-context embedding model could raise the ceiling — and by how much —
+without changing the embedding architecture (in-process ONNX, WordPiece
+vocab.txt, the existing SK connector).
+
+## Decision Drivers
+
+- Must run **unmodified** through the existing connector: WordPiece `vocab.txt`
+  tokenizer, ONNX graph accepting `{input_ids, attention_mask, token_type_ids}`,
+  pooling limited to the connector's Mean/Max/MeanSqrt (no CLS).
+- Retrieval quality on the real corpus must not regress (golden-set harness,
+  #432) and should improve on long documents (needle-in-document test).
+- A2 single-host deployment: embedding is in-process; peak RSS during a
+  ceiling-filling embed is a real host constraint (O(n²) attention memory).
+- The ceiling should be a **compile-time constant**, chosen once from ground
+  truth, not a tunable that invites drift.
+
+## Considered Options
+
+### Model
+
+1. **jina-embeddings-v2-small-en** (33M params, 512-dim, ALiBi positions to
+   8192, mean pooling, no query prefixes) — **chosen**
+2. nomic-embed-text-v1.5 (137M, 768-dim, rotary, 4-way task prefixes)
+3. gte-base-en-v1.5 (rejected: ONNX graph lacks `token_type_ids`; CLS pooling —
+   connector hardcodes both)
+4. granite-embedding-r2 (rejected: BPE tokenizer; connector is WordPiece-only)
+5. Keep bge-micro-v2 (status quo)
+
+### Ceiling (`MaximumTokens`)
+
+4096 vs 6144 vs 8192, measured empirically (all tables in the #437 issue
+comments, 2026-07-23).
+
+## Decision Outcome
+
+**jina-embeddings-v2-small-en, `MaximumTokens = 6144`, derived caps
+`MaxBodyLength = 16000` / `MaxTitleLength = 200`.**
+
+### Why jina-v2-small over nomic (the a-priori favorite)
+
+Empirical, on this repo's corpus and harnesses:
+
+- Golden set (30 queries): jina semantic recall@10 **1.000** / MRR **0.925** vs
+  bge 1.000/0.894 — no regression, slight MRR gain.
+- Needle-in-document (8 docs, needles at 400–8000 chars): jina avg rank **1.5**
+  (5/8 rank-1) vs nomic 3.0 and truncated bge 3.38. Nomic runs safely at a true
+  8k window (verified 8190 encoded tokens, no degenerate vectors) but its
+  needle precision was no better than truncated bge — long window without
+  long-window retrieval value.
+- jina runs through the connector unmodified (model.onnx + vocab.txt +
+  `MaximumTokens`); mean pooling is the connector default. The root
+  `model.onnx` (token-level outputs, 129,809,014 bytes) is required — the
+  sibling `model-w-mean-pooling.onnx` bakes pooling into the graph and would
+  be pooled twice by the connector.
+- FP32 (~130 MB) vs bge's quantized 17.4 MB: accepted. The spike measured
+  quality and cost on this exact artifact; a quantized variant would be an
+  unverified substitution.
+
+**Liveliness:** Maintenance-only (upstream focus moved to jina-v3+), single
+vendor. Risk Medium, accepted: the artifact is pinned by SHA-256, fully
+self-hosted, and the fallback path (ML.Tokenizers + OnnxRuntime behind the
+existing `IEmbeddingGenerator` seam, ~120–190 LoC) is documented in #437.
+
+### Why 6144 — the ground-truth ceiling
+
+Measured on the live corpus (n=692 entries) and a token-calibrated needle
+matrix (#437 second findings comment):
+
+| Ceiling | Corpus coverage | Ceiling-filling embed cost | In-window needle precision |
+| --- | --- | --- | --- |
+| 4096 | 98.7% — **below p99 (4,347 tokens)** | 575 ms / 5.4 GB RSS | loses 6k/7.5k depths |
+| **6144** | **99.71% — the plateau** | **1.16 s / 12.1 GB RSS** | **matches 8192** |
+| 8192 | 99.71% — identical to 6144 | 1.86 s / 19.9 GB RSS | one measured mean-pooling dilution regression |
+
+8192 buys zero coverage (the only two entries beyond 6144 tokens exceed 8192
+too), costs 65% more peak RSS, and measurably *hurt* one always-in-window
+needle via mean-pooling dilution. 4096 sits below the corpus p99. 6144 is the
+smallest ceiling that captures everything capturable — a durable constant, not
+a tunable.
+
+### Derived caps
+
+Same method as #429, re-based on the 6144 window: reserve ~70 worst-case tokens
+for a 200-char title plus specials; body budget ≈ 6,000 tokens; at the measured
+worst-case density of 2.97 chars/token, `MaxBodyLength = 16000` chars lands at
+≈ 5,390 worst-case body tokens — comfortable headroom inside the window.
+`MaxTitleLength` stays 200 (#436 rationale unchanged).
+
+### Migration (two-phase, forward-only)
+
+1. **One atomic release** (this ADR's PR set): EF migration — drop the HNSW
+   index, `UPDATE ... SET "Embedding" = NULL` (pgvector's typmod cast rejects
+   `ALTER COLUMN TYPE` over live 384-dim values), retype to `vector(512)`,
+   recreate the HNSW index (NULLs are not indexed; it fills incrementally as
+   embeddings return) — plus model files, `MaximumTokens`, cap raise, and
+   removal of the bge query-instruction prefix (jina uses none; PR #431's
+   prefix was bge-specific).
+2. **Operator reembed** (`expertise-apictl reembed` / `dotnet run -- reembed`)
+   immediately after install. During the window, every read path already
+   filters `Embedding != null`: keyword search is unaffected; semantic/hybrid
+   gracefully surface only reembedded rows; embed-on-write uses the new model
+   from the first request. Dedup can only under-fire (miss), never misfire.
+   Measured wall-clock for ~700 entries: single-digit minutes (≤15 min bound);
+   the host needs RSS headroom for the ~12 GB p99 transient.
+
+**Rollback is NOT `install.sh`'s binary swap.** Once the migration commits,
+embeddings are nulled and the column is `vector(512)`; the previous binary's EF
+model does not match. Recovery from a bad rollout is roll-forward (fix and
+reembed — embeddings are regenerable, content is the source of truth) or full
+`backup`/`restore` from a pre-upgrade backup. Take a backup before upgrading.
+
+### Consequences
+
+- `Deduplication:SemanticThreshold = 0.10` was calibrated to bge's distance
+  geometry; it is re-derived against the jina space after the production
+  reembed (#457). Until then dedup under-fires only.
+- The eval gates (`RetrievalEvalTests`, window-aware `NeedleEvalTests`, #437
+  PR-B) are the merge gate for this and any future retrieval change; they are
+  `EXPERTISE_EVAL=1` opt-in, so running them is a release-checklist step, not
+  CI-automatic.
+- CI model downloads grow ~17 MB → ~130 MB; mitigated by the `actions/cache`
+  keyed on `download-models.sh` (added with #456's fix).
+- Helm/k8s resource sizing is NOT covered — tracked in #458; A2 native service
+  remains the hosting model of record.
+
+## Related
+
+- #437 (spike + ground-truth sweeps — both findings comments), #429 (silent
+  truncation + original cap derivation), #455/#456 (prerequisites), #457
+  (threshold retune), #458 (Helm sizing), #345 (reembed vintage detection)
+- ADR-016 (hybrid RRF search — the eval-gated precedent)
+- PR #431 (bge query prefix — reverted by this swap for the new model)

--- a/docs/operations/backup-restore-runbook.md
+++ b/docs/operations/backup-restore-runbook.md
@@ -111,7 +111,7 @@ Idempotent; only touches rows where `IntegrityHash IS NULL`. Costs nothing on a 
 SELECT "ModelName", "Dimensions", "LastReembedAt" FROM "EmbeddingMetadata";
 ```
 
-If that row is absent, or disagrees with the deployed model files (`./scripts/download-models.sh` fetches bge-micro-v2, 384-dim), regenerate:
+If that row is absent, or disagrees with the deployed model files (`./scripts/download-models.sh` fetches jina-embeddings-v2-small-en, 512-dim — ADR-017), regenerate:
 
 ```bash
 dotnet run --project src/ExpertiseApi -- reembed

--- a/docs/research/2026-07-retrieval-assessment.md
+++ b/docs/research/2026-07-retrieval-assessment.md
@@ -1,6 +1,10 @@
 # Retrieval Improvements Assessment — 2026-07-22
 
-**Status:** Assessment only — no decisions made, nothing implemented. Each adopted
+**Status (updated 2026-07-23):** Recommendations 1–5 shipped as PRs #431–#435 (ADR-016
+records the hybrid-RRF decision). Recommendation 1's bge-specific query-instruction prefix
+was subsequently REMOVED by ADR-017 — the jina-embeddings-v2-small-en swap embeds queries
+and documents symmetrically with no prefix, so do not re-apply it. The analysis below is
+retained as written (2026-07); the bge-specific reasoning is historical context. Each adopted
 recommendation requires its own plan and (where it changes retrieval architecture)
 an ADR before implementation.
 

--- a/docs/testing-and-coverage.md
+++ b/docs/testing-and-coverage.md
@@ -120,8 +120,8 @@ the csproj makes them reachable. Prefer this over re-deriving the logic in the t
 
 Correctness tests use the content-derived mock embeddings above; retrieval *quality*
 cannot be measured that way. `tests/ExpertiseApi.Tests/Evaluation/` holds an opt-in
-harness (#425) that seeds the corpus in `golden-set.json` with **real** bge-micro-v2
-embeddings (via `AddBertOnnxEmbeddingGenerator`), runs every golden query through
+harness (#425) that seeds the corpus in `golden-set.json` with **real** embeddings
+from the pinned ONNX model (jina-embeddings-v2-small-en, ADR-017) (via `AddBertOnnxEmbeddingGenerator`), runs every golden query through
 keyword and semantic search, and reports recall@5 / recall@10 / MRR@10 per mode plus
 every miss:
 

--- a/docs/testing-and-coverage.md
+++ b/docs/testing-and-coverage.md
@@ -139,6 +139,14 @@ paraphrases return empty — `websearch_to_tsquery` ANDs all terms), semantic 1.
 recall@10 / 0.894 MRR. Grow `golden-set.json` whenever a real agent query misses:
 add the query with its expected entry titles.
 
+A sibling suite, `NeedleEvalTests` (#437), gates long-context retrieval: eight
+deterministic ~8-10k-char documents with a distinctive fact planted at controlled
+depths, ranked through the same repository search paths. Its floors are
+**window-aware** — only needles whose worst-case token position fits inside
+`EmbeddingModelInfo.MaximumTokens` are asserted — so the suite passes at any
+ceiling and automatically activates deeper needles when the ceiling is raised
+(the #437 model swap). Same `EXPERTISE_EVAL=1` gating, filter `~NeedleEval`.
+
 ## Verifying a guard actually guards
 
 When adding or changing a guard, prove it catches the failure it targets: reintroduce the

--- a/scripts/download-models.sh
+++ b/scripts/download-models.sh
@@ -53,19 +53,6 @@ sha256_of() {
   fi
 }
 
-# Verify SHA-256 checksum of a file.
-# Args: <file> <expected_sha256>
-verify_checksum() {
-  local file="$1" expected="$2"
-  local filename="${file##*/}"
-  local actual
-  actual=$(sha256_of "${file}")
-  if [[ "${actual}" != "${expected}" ]]; then
-    err "${filename} checksum mismatch (expected ${expected}, got ${actual}). Delete the file and re-run, or check if the upstream model changed."
-  fi
-  log "  ${filename}: checksum OK"
-}
-
 # Download a single file if missing or suspiciously small.
 # Args: <dest_file> <url> <min_bytes> <display_name> <expected_sha256>
 download_file() {
@@ -85,8 +72,8 @@ download_file() {
       fi
       # A mismatching existing file is stale (model version bump) or corrupt —
       # re-download instead of aborting, so upgrade installs pick up new model
-      # files automatically (#456). verify_checksum after the download is still
-      # the hard gate: a bad upstream file aborts as before.
+      # files automatically (#456). The temp-file checksum below is still the
+      # hard gate: a bad upstream file aborts as before.
       log "  ${filename} checksum mismatch (expected ${expected_sha256}, got ${existing_sha}) — stale or corrupt; re-downloading"
     else
       log "  ${filename} exists but is suspiciously small (${existing_size} bytes) — re-downloading"
@@ -104,14 +91,24 @@ download_file() {
   # hard outage cannot stall the install indefinitely.
   curl -fsSL --retry 8 --retry-max-time 300 --retry-all-errors "${url}" -o "${tmpfile}" \
     || { rm -f "${tmpfile}"; err "Failed to download ${filename} from ${url}"; }
-  mv "${tmpfile}" "${dest}"
 
+  # Size + checksum are verified on the TEMP file, and the destination is only
+  # replaced after both pass (atomic-on-success). Moving before verifying let a
+  # failed re-download overwrite the existing file with unverified bytes
+  # (review finding, 2026-07-23).
   local size
-  size=$(wc -c < "${dest}")
-  (( size < min_bytes )) && err "${filename} is suspiciously small (${size} bytes). Check the URL."
-  log "  ${filename}: ${size} bytes"
+  size=$(wc -c < "${tmpfile}")
+  (( size < min_bytes )) && { rm -f "${tmpfile}"; err "${filename} is suspiciously small (${size} bytes). Check the URL."; }
 
-  verify_checksum "${dest}" "${expected_sha256}"
+  local actual
+  actual=$(sha256_of "${tmpfile}")
+  if [[ "${actual}" != "${expected_sha256}" ]]; then
+    rm -f "${tmpfile}"
+    err "${filename} downloaded file failed checksum (expected ${expected_sha256}, got ${actual}). Upstream may have changed — verify HF_BASE and the pinned SHA-256; any pre-existing ${filename} was left untouched."
+  fi
+
+  mv "${tmpfile}" "${dest}"
+  log "  ${filename}: ${size} bytes, checksum OK"
 }
 
 mkdir -p "${DEST_DIR}"

--- a/scripts/download-models.sh
+++ b/scripts/download-models.sh
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
-# download-models.sh — Download bge-micro-v2 ONNX model files
+# download-models.sh — Download jina-embeddings-v2-small-en ONNX model files
 #
 # Usage:
 #   ./scripts/download-models.sh                          # default: src/ExpertiseApi/models/
 #   DEST_DIR=/custom/path ./scripts/download-models.sh    # custom destination
 #   FORCE=1 ./scripts/download-models.sh                  # re-download even if files exist
 #
-# Downloads the quantized bge-micro-v2 model (~17.4 MB) and vocab.txt (~232 KB)
-# from the SmartComponents Hugging Face mirror (canonical source for .NET/SK).
+# Downloads the jina-embeddings-v2-small-en model (~130 MB, FP32) and
+# vocab.txt (~232 KB) from the upstream jinaai Hugging Face repo (ADR-017).
+# The root model.onnx (token-level outputs; the SK connector applies mean
+# pooling) is REQUIRED — model-w-mean-pooling.onnx bakes pooling into the
+# graph and would be pooled twice.
 #
-# Idempotent: skips files that already exist and pass size + checksum validation.
-# The model file is saved as model.onnx (not model_quantized.onnx) to match
-# the default path expected by Program.cs and the Dockerfile.
+# Idempotent: skips files that already exist and pass size + checksum
+# validation; re-downloads stale/corrupt files (#456).
 #
 # To update checksums after a model version bump:
 #   FORCE=1 ./scripts/download-models.sh
@@ -28,14 +30,14 @@ FORCE="${FORCE:-0}"
 # Bump MODEL_VERSION when model files change. This string is embedded in the
 # script, so any change here automatically busts the CI cache (keyed on
 # hashFiles('scripts/download-models.sh')).
-MODEL_VERSION="1"
+MODEL_VERSION="2"
 
-HF_BASE="https://huggingface.co/SmartComponents/bge-micro-v2/resolve/main"
+HF_BASE="https://huggingface.co/jinaai/jina-embeddings-v2-small-en/resolve/main"
 
 # SHA-256 checksums for model version ${MODEL_VERSION}.
 # Computed from: sha256sum model.onnx vocab.txt
-SHA256_MODEL_ONNX="ed65e36025aa94cb74207dab863c85452919ec0ab7df3512092932aa22c9a33a"
-SHA256_VOCAB_TXT="07eced375cec144d27c900241f3e339478dec958f92fddbc551f295c992038a3"
+SHA256_MODEL_ONNX="974fdefe71fc9889258f569132b35acae6278874c8d09dbdf7806d23ad0b4497"
+SHA256_VOCAB_TXT="109753d618dbb576a35112f9c20ef35cf3517d46106175bcf010c986a4bef1df"
 
 log() { printf '[download-models] %s\n' "$1"; }
 err() { printf '[download-models] ERROR: %s\n' "$1" >&2; exit 1; }
@@ -114,8 +116,12 @@ download_file() {
 
 mkdir -p "${DEST_DIR}"
 
-download_file "${DEST_DIR}/model.onnx" "${HF_BASE}/onnx/model_quantized.onnx" 1048576 \
-  "model.onnx (quantized bge-micro-v2, ~17.4 MB)" "${SHA256_MODEL_ONNX}"
+# min_bytes is a coarse error-page detector only (an HTML 404/consent page is
+# far under 1 MiB) — the SHA-256 pin below is the actual integrity gate, so the
+# floor deliberately does NOT track the model size (tests/install/ fixtures
+# depend on it staying small).
+download_file "${DEST_DIR}/model.onnx" "${HF_BASE}/model.onnx" 1048576 \
+  "model.onnx (jina-embeddings-v2-small-en FP32, ~130 MB)" "${SHA256_MODEL_ONNX}"
 
 download_file "${DEST_DIR}/vocab.txt" "${HF_BASE}/vocab.txt" 1024 \
   "vocab.txt" "${SHA256_VOCAB_TXT}"

--- a/scripts/download-models.sh
+++ b/scripts/download-models.sh
@@ -75,10 +75,20 @@ download_file() {
     existing_size=$(wc -c < "${dest}")
     if (( existing_size >= min_bytes )); then
       log "${filename} already present — verifying checksum"
-      verify_checksum "${dest}" "${expected_sha256}"
-      return 0
+      local existing_sha
+      existing_sha=$(sha256_of "${dest}")
+      if [[ "${existing_sha}" == "${expected_sha256}" ]]; then
+        log "  ${filename}: checksum OK"
+        return 0
+      fi
+      # A mismatching existing file is stale (model version bump) or corrupt —
+      # re-download instead of aborting, so upgrade installs pick up new model
+      # files automatically (#456). verify_checksum after the download is still
+      # the hard gate: a bad upstream file aborts as before.
+      log "  ${filename} checksum mismatch (expected ${expected_sha256}, got ${existing_sha}) — stale or corrupt; re-downloading"
+    else
+      log "  ${filename} exists but is suspiciously small (${existing_size} bytes) — re-downloading"
     fi
-    log "  ${filename} exists but is suspiciously small (${existing_size} bytes) — re-downloading"
   fi
 
   log "Downloading ${display_name}..."

--- a/scripts/expertise-apictl
+++ b/scripts/expertise-apictl
@@ -10,6 +10,7 @@
 #   expertise-apictl start|stop|restart|status
 #   expertise-apictl logs [-f] [-n LINES]
 #   expertise-apictl health
+#   expertise-apictl reembed [--batch-size N]
 #   expertise-apictl backup-init [--install-deps]
 #   expertise-apictl backup [--output DIR] [--instance-id ID]
 #   expertise-apictl restore ARTIFACT [--force-draft] [--i-accept-unsigned-backup]
@@ -34,7 +35,7 @@ READY_TIMEOUT="${EXPERTISE_API_READY_TIMEOUT:-30}"
 log() { printf '[expertise-apictl] %s\n' "$1"; }
 err() { printf '[expertise-apictl] ERROR: %s\n' "$1" >&2; exit 1; }
 
-usage() { sed -n '2,24p' "$0" | sed 's/^# \{0,1\}//'; }
+usage() { sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'; }
 
 detect_os() {
   case "$(uname -s)" in
@@ -72,10 +73,10 @@ _detect_install_scope() {
 }
 
 # The system-scope guard applies to service-LIFECYCLE subcommands only —
-# backup-init/backup/restore talk to the database and filesystem, never to
-# launchd, so they work fine against a --system install.
+# backup-init/backup/restore/reembed talk to the database and filesystem,
+# never to launchd, so they work fine against a --system install.
 case "${1:-}" in
-  backup-init|backup|restore) _lifecycle_cmd=0 ;;
+  backup-init|backup|restore|reembed) _lifecycle_cmd=0 ;;
   *)                          _lifecycle_cmd=1 ;;
 esac
 
@@ -574,6 +575,16 @@ cmd_backup() {
   log "backup: OK — ${artifact}"
 }
 
+cmd_reembed() {
+  # Pass-through to the ExpertiseApi reembed verb: regenerate every stored
+  # embedding with the currently installed model. Idempotent and safe while
+  # the service is running (per-batch row saves; reads tolerate NULL/stale
+  # embeddings). REQUIRED once after a model-swap release (ADR-017) — until it
+  # completes, pre-existing entries are invisible to semantic/hybrid search.
+  _run_api_verb reembed "$@" || err "reembed verb failed — see log output above"
+  log "reembed: OK"
+}
+
 cmd_restore() {
   local artifact="" force_draft=0 accept_unsigned=0
   while [[ $# -gt 0 ]]; do
@@ -644,6 +655,7 @@ case "${1:-}" in
   backup-init) shift; cmd_backup_init "$@" ;;
   backup)     shift; cmd_backup "$@" ;;
   restore)    shift; cmd_restore "$@" ;;
+  reembed)    shift; cmd_reembed "$@" ;;
   ''|-h|--help) usage ;;
   *) err "unknown subcommand: $1 (try --help)" ;;
 esac

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -725,11 +725,11 @@ publish_app_staged() {
 # ---------------------------------------------------------------------------
 ensure_models() {
   STAGE="models"
-  if [[ -f "${MODEL_DIR}/model.onnx" && -f "${MODEL_DIR}/vocab.txt" ]]; then
-    log "ONNX models present at ${MODEL_DIR}"
-    return
-  fi
-  log "downloading ONNX models to ${MODEL_DIR}"
+  # Always delegate to download-models.sh — it skips files whose checksum
+  # matches the pinned SHA-256 and re-downloads stale ones, so upgrade
+  # installs pick up a model version bump. Gating on file existence here
+  # (the pre-#456 behavior) silently kept an outdated model on upgrades.
+  log "ensuring ONNX models at ${MODEL_DIR}"
   mkdir -p "${MODEL_DIR}"
   DEST_DIR="${MODEL_DIR}" "${REPO_ROOT}/scripts/download-models.sh"
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -725,6 +725,11 @@ publish_app_staged() {
 # ---------------------------------------------------------------------------
 ensure_models() {
   STAGE="models"
+  # Same symlink-TOCTOU refusal as every other mutated path in this script
+  # (STAGE_DIR/OLD_DIR/VERSION_MARKER/install.env) — a pre-planted symlink
+  # here would redirect the model download outside the prefix (review
+  # finding, 2026-07-23).
+  if [[ -L "${MODEL_DIR}" ]]; then err "${MODEL_DIR} exists as a symlink — refusing to overwrite (potential TOCTOU)"; fi
   # Always delegate to download-models.sh — it skips files whose checksum
   # matches the pinned SHA-256 and re-downloads stale ones, so upgrade
   # installs pick up a model version bump. Gating on file existence here

--- a/src/ExpertiseApi/Cli/ReembedCommand.cs
+++ b/src/ExpertiseApi/Cli/ReembedCommand.cs
@@ -44,6 +44,11 @@ internal static class ReembedCommand
             }
 
             await db.SaveChangesAsync();
+            // Bound the tracker to one batch — without this the context tracks
+            // every processed entity for the whole run, and DetectChanges cost
+            // grows with corpus size while the host is also absorbing the
+            // model's inference transients (review finding, 2026-07-23).
+            db.ChangeTracker.Clear();
             lastId = entries[^1].Id;
             processed += entries.Count;
             logger.LogInformation("Reembedded {Processed} entries", processed);

--- a/src/ExpertiseApi/Cli/ReembedCommand.cs
+++ b/src/ExpertiseApi/Cli/ReembedCommand.cs
@@ -52,10 +52,15 @@ internal static class ReembedCommand
         var metadata = await db.EmbeddingMetadata.FirstOrDefaultAsync()
             ?? db.EmbeddingMetadata.Add(new EmbeddingMetadata
             {
-                ModelName = "bge-micro-v2",
-                Dimensions = 384
+                ModelName = EmbeddingModelInfo.Name,
+                Dimensions = EmbeddingModelInfo.Dimensions
             }).Entity;
 
+        // Always overwrite — a pre-existing row may describe a previous model
+        // (#455); after a full reembed the stored vectors are, by construction,
+        // the current model's.
+        metadata.ModelName = EmbeddingModelInfo.Name;
+        metadata.Dimensions = EmbeddingModelInfo.Dimensions;
         metadata.LastReembedAt = DateTime.UtcNow;
         await db.SaveChangesAsync();
 

--- a/src/ExpertiseApi/Cli/RehashCommand.cs
+++ b/src/ExpertiseApi/Cli/RehashCommand.cs
@@ -44,6 +44,8 @@ internal static class RehashCommand
             }
 
             await db.SaveChangesAsync();
+            // Same tracker-bounding as ReembedCommand (review finding, 2026-07-23).
+            db.ChangeTracker.Clear();
             lastId = entries[^1].Id;
             processed += entries.Count;
             logger.LogInformation("Rehashed {Processed} entries", processed);

--- a/src/ExpertiseApi/Cli/RestoreCommand.cs
+++ b/src/ExpertiseApi/Cli/RestoreCommand.cs
@@ -25,8 +25,9 @@ namespace ExpertiseApi.Cli;
 ///   * v1 is <c>--mode replace</c> only: target tables must be empty.
 ///   * Pending EF migrations → abort (MigrateCommand idiom).
 ///   * Manifest embedding model vs live EmbeddingMetadata mismatch → abort loudly,
-///     directing to <c>reembed</c>. Embeddings whose dimensions don't fit the
-///     vector(384) column are skipped (regenerable), never a reason to abort.
+///     directing to <c>reembed</c>. Embeddings whose dimensions don't fit the live
+///     vector(N) column (N = <see cref="EmbeddingModelInfo.Dimensions"/>) are
+///     skipped (regenerable), never a reason to abort.
 /// </summary>
 internal static class RestoreCommand
 {

--- a/src/ExpertiseApi/Cli/RestoreCommand.cs
+++ b/src/ExpertiseApi/Cli/RestoreCommand.cs
@@ -33,7 +33,6 @@ internal static class RestoreCommand
     public static bool IsRestoreRequested(string[] args) =>
         args.Length > 0 && args[0].Equals("restore", StringComparison.OrdinalIgnoreCase);
 
-    private const int EmbeddingDimensions = 384;
     private const string QuarantinePrincipal = "restore-cli";
 
     /// <summary>Imports a decrypted backup payload written by <see cref="BackupCommand"/>, verifying per-record hashes and Merkle roots against the manifest.</summary>
@@ -118,12 +117,12 @@ internal static class RestoreCommand
                 return 1;
             }
 
-            var importEmbeddings = manifest.EmbeddingModel is { Dims: EmbeddingDimensions };
+            var importEmbeddings = manifest.EmbeddingModel is { Dims: EmbeddingModelInfo.Dimensions };
             if (!importEmbeddings && manifest.EmbeddingModel is not null)
             {
                 logger.LogWarning(
                     "Restore: manifest embedding model {Model}/{Dims} does not fit the vector({Expected}) column — embeddings will be skipped; run `reembed` after restore.",
-                    manifest.EmbeddingModel.Name, manifest.EmbeddingModel.Dims, EmbeddingDimensions);
+                    manifest.EmbeddingModel.Name, manifest.EmbeddingModel.Dims, EmbeddingModelInfo.Dimensions);
             }
 
             // ---- Phase 1: parse + verify everything BEFORE writing anything. ----
@@ -209,7 +208,7 @@ internal static class RestoreCommand
                         Severity = ParseEnum<Severity>(record.Severity, record.Id),
                         Source = record.Source,
                         SourceVersion = record.SourceVersion,
-                        Embedding = importEmbeddings && record.Embedding is { Count: EmbeddingDimensions }
+                        Embedding = importEmbeddings && record.Embedding is { Count: EmbeddingModelInfo.Dimensions }
                             ? new Vector(record.Embedding.ToArray())
                             : null,
                         CreatedAt = record.CreatedAt,

--- a/src/ExpertiseApi/Data/ExpertiseDbContext.cs
+++ b/src/ExpertiseApi/Data/ExpertiseDbContext.cs
@@ -97,10 +97,14 @@ internal class ExpertiseDbContext(
         {
             entity.HasKey(e => e.Id);
             entity.Property(e => e.ModelName).IsRequired();
+            // Singleton-row invariant is enforced by a raw-SQL unique index over a
+            // constant expression (UX_EmbeddingMetadata_Singleton, #455) — EF's
+            // fluent API cannot express it, so it lives only in the migration.
         });
 
         // Spoke-side up-sync cursor (ADR-013). Singleton-row semantics are enforced at
-        // the call site (get-or-create), matching EmbeddingMetadata — no unique guard.
+        // the call site (get-or-create) — sole writer is the sync worker, so the
+        // EmbeddingMetadata-style DB guard (#455) is not replicated here.
         modelBuilder.Entity<SyncState>(entity =>
         {
             entity.HasKey(e => e.Id);

--- a/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
@@ -198,14 +198,16 @@ internal static class ExpertiseEndpoints
         !string.IsNullOrWhiteSpace(request.Body) &&
         !string.IsNullOrWhiteSpace(request.Source);
 
-    // MaxBodyLength derivation (#429): bge-micro-v2 embeds at most 512 wordpiece tokens
-    // (510 content + [CLS]/[SEP]) and the ONNX connector silently truncates beyond that
-    // with no signal. BuildInputText embeds "{title} {body}" in one pass; reserving
-    // ~40 tokens for Title leaves ~470 for Body. Measured density across the 60 longest
-    // real entries is 2.97–4.24 chars/token (median 3.46), so 1500 chars keeps a
-    // median-density Body fully embedded (~476/512 tokens); only the densest tail loses
-    // a few trailing tokens. Re-derive this constant if the embedding model changes (#437).
-    private const int MaxBodyLength = 1500;
+    // MaxBodyLength derivation (#429 method, re-based by ADR-017): the embedding
+    // window is EmbeddingModelInfo.MaximumTokens (6144) and the ONNX connector
+    // silently truncates beyond it with no signal. BuildInputText embeds
+    // "{title} {body}" in one pass; reserving ~70 worst-case tokens for a
+    // 200-char Title plus specials leaves ~6,000 for Body. Measured density
+    // across the 60 longest real entries is 2.97–4.24 chars/token, so 16,000
+    // chars lands at ≈5,390 worst-case Body tokens — fully embedded with
+    // headroom even at maximum density. Re-derive if the model or ceiling
+    // changes (ADR-017 ground-truth tables are on issue #437).
+    private const int MaxBodyLength = 16_000;
 
     private static string? BodyLengthError(string? body) =>
         body is { Length: > MaxBodyLength }
@@ -213,10 +215,11 @@ internal static class ExpertiseEndpoints
               "Content past the embedding window is invisible to semantic search; shorten the body or split the entry."
             : null;
 
-    // MaxTitleLength (#436): Title shares the 512-token embedding budget with Body
-    // (BuildInputText embeds "{title} {body}"); the MaxBodyLength derivation reserves
-    // ~40 tokens for Title, which 200 chars comfortably respects (observed corpus max
-    // is 142). Same guard shape as MaxBodyLength/MaxRejectionReasonLength.
+    // MaxTitleLength (#436): Title shares the embedding window with Body
+    // (BuildInputText embeds "{title} {body}"); the MaxBodyLength derivation
+    // reserves ~70 worst-case tokens for Title, which 200 chars comfortably
+    // respects (observed corpus max is 142). Unchanged by the ADR-017 ceiling
+    // raise — titles are a display/scan surface, not a content dump.
     private const int MaxTitleLength = 200;
 
     private static string? TitleLengthError(string? title) =>

--- a/src/ExpertiseApi/Migrations/20260723135538_EmbeddingMetadataSingletonGuard.Designer.cs
+++ b/src/ExpertiseApi/Migrations/20260723135538_EmbeddingMetadataSingletonGuard.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using ExpertiseApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -14,9 +15,11 @@ using Pgvector;
 namespace ExpertiseApi.Migrations
 {
     [DbContext(typeof(ExpertiseDbContext))]
-    partial class ExpertiseDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260723135538_EmbeddingMetadataSingletonGuard")]
+    partial class EmbeddingMetadataSingletonGuard
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ExpertiseApi/Migrations/20260723135538_EmbeddingMetadataSingletonGuard.cs
+++ b/src/ExpertiseApi/Migrations/20260723135538_EmbeddingMetadataSingletonGuard.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ExpertiseApi.Migrations
+{
+    /// <summary>
+    /// Enforces the EmbeddingMetadata singleton-row invariant at the database
+    /// level (#455). The get-or-create call sites (ReembedCommand,
+    /// RestoreCommand) are not atomic — two concurrent callers could both pass
+    /// the null check and insert two rows. A unique index over a constant
+    /// expression makes the second insert fail loudly instead. Raw SQL because
+    /// EF's fluent index API cannot express a constant-expression index.
+    /// </summary>
+    public partial class EmbeddingMetadataSingletonGuard : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """CREATE UNIQUE INDEX "UX_EmbeddingMetadata_Singleton" ON "EmbeddingMetadata" ((TRUE));""");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """DROP INDEX "UX_EmbeddingMetadata_Singleton";""");
+        }
+    }
+}

--- a/src/ExpertiseApi/Migrations/20260723141427_SwapEmbeddingModelTo512Dim.Designer.cs
+++ b/src/ExpertiseApi/Migrations/20260723141427_SwapEmbeddingModelTo512Dim.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using ExpertiseApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -14,9 +15,11 @@ using Pgvector;
 namespace ExpertiseApi.Migrations
 {
     [DbContext(typeof(ExpertiseDbContext))]
-    partial class ExpertiseDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260723141427_SwapEmbeddingModelTo512Dim")]
+    partial class SwapEmbeddingModelTo512Dim
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ExpertiseApi/Migrations/20260723141427_SwapEmbeddingModelTo512Dim.cs
+++ b/src/ExpertiseApi/Migrations/20260723141427_SwapEmbeddingModelTo512Dim.cs
@@ -1,0 +1,79 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using Pgvector;
+
+#nullable disable
+
+namespace ExpertiseApi.Migrations
+{
+    /// <summary>
+    /// ADR-017 model swap: bge-micro-v2 (384-dim) → jina-embeddings-v2-small-en
+    /// (512-dim). pgvector's typmod cast rejects ALTER COLUMN TYPE over live
+    /// vectors of a different dimension, and the old vectors are garbage in the
+    /// new space anyway, so the migration nulls them first. Every read path
+    /// filters Embedding != null, so the window until `reembed` repopulates is
+    /// a soft degradation of semantic search, not an outage. The HNSW index is
+    /// dropped before the retype and recreated after — NULLs are not indexed,
+    /// so the recreate is instant and fills incrementally as reembed writes.
+    ///
+    /// FORWARD-ONLY in practice: Down() restores the column type but cannot
+    /// restore the destroyed 384-dim vectors (regenerable via the old model's
+    /// `reembed` only). See ADR-017's rollback section.
+    /// </summary>
+    public partial class SwapEmbeddingModelTo512Dim : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ExpertiseEntries_Embedding",
+                table: "ExpertiseEntries");
+
+            migrationBuilder.Sql(
+                """UPDATE "ExpertiseEntries" SET "Embedding" = NULL;""");
+
+            migrationBuilder.AlterColumn<Vector>(
+                name: "Embedding",
+                table: "ExpertiseEntries",
+                type: "vector(512)",
+                nullable: true,
+                oldClrType: typeof(Vector),
+                oldType: "vector(384)",
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExpertiseEntries_Embedding",
+                table: "ExpertiseEntries",
+                column: "Embedding")
+                .Annotation("Npgsql:IndexMethod", "hnsw")
+                .Annotation("Npgsql:IndexOperators", new[] { "vector_cosine_ops" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ExpertiseEntries_Embedding",
+                table: "ExpertiseEntries");
+
+            // 512-dim vectors cannot survive a retype to vector(384) either.
+            migrationBuilder.Sql(
+                """UPDATE "ExpertiseEntries" SET "Embedding" = NULL;""");
+
+            migrationBuilder.AlterColumn<Vector>(
+                name: "Embedding",
+                table: "ExpertiseEntries",
+                type: "vector(384)",
+                nullable: true,
+                oldClrType: typeof(Vector),
+                oldType: "vector(512)",
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExpertiseEntries_Embedding",
+                table: "ExpertiseEntries",
+                column: "Embedding")
+                .Annotation("Npgsql:IndexMethod", "hnsw")
+                .Annotation("Npgsql:IndexOperators", new[] { "vector_cosine_ops" });
+        }
+    }
+}

--- a/src/ExpertiseApi/Models/ExpertiseEntry.cs
+++ b/src/ExpertiseApi/Models/ExpertiseEntry.cs
@@ -25,7 +25,7 @@ internal class ExpertiseEntry
 
     public string? SourceVersion { get; set; }
 
-    [Column(TypeName = "vector(384)")]
+    [Column(TypeName = "vector(512)")]
     public Vector? Embedding { get; set; }
 
     public DateTime CreatedAt { get; set; }

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -419,10 +419,7 @@ var vocabPath = builder.Configuration["Onnx:VocabPath"] ?? Path.Combine(baseDir,
 if (File.Exists(modelPath) && File.Exists(vocabPath))
 {
     builder.Services.AddBertOnnxEmbeddingGenerator(modelPath, vocabPath,
-        new Microsoft.SemanticKernel.Connectors.Onnx.BertOnnxOptions
-        {
-            MaximumTokens = EmbeddingModelInfo.MaximumTokens
-        });
+        EmbeddingModelInfo.CreateOnnxOptions());
 }
 builder.Services.AddScoped<EmbeddingService>();
 

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -418,7 +418,11 @@ var vocabPath = builder.Configuration["Onnx:VocabPath"] ?? Path.Combine(baseDir,
 
 if (File.Exists(modelPath) && File.Exists(vocabPath))
 {
-    builder.Services.AddBertOnnxEmbeddingGenerator(modelPath, vocabPath);
+    builder.Services.AddBertOnnxEmbeddingGenerator(modelPath, vocabPath,
+        new Microsoft.SemanticKernel.Connectors.Onnx.BertOnnxOptions
+        {
+            MaximumTokens = EmbeddingModelInfo.MaximumTokens
+        });
 }
 builder.Services.AddScoped<EmbeddingService>();
 

--- a/src/ExpertiseApi/Services/EmbeddingModelInfo.cs
+++ b/src/ExpertiseApi/Services/EmbeddingModelInfo.cs
@@ -13,4 +13,14 @@ internal static class EmbeddingModelInfo
 
     /// <summary>Must match the pgvector column type on ExpertiseEntries.Embedding (vector(384)).</summary>
     public const int Dimensions = 384;
+
+    /// <summary>
+    /// Token ceiling passed to the ONNX embedding generator. 512 is
+    /// bge-micro-v2's architectural window (and the connector's implicit
+    /// default — made explicit here so the ceiling is a visible, single-point
+    /// decision). Input beyond the ceiling is silently truncated by the
+    /// connector (#429); the MaxBodyLength/MaxTitleLength write guards are
+    /// derived from this value. The #437 model swap raises it.
+    /// </summary>
+    public const int MaximumTokens = 512;
 }

--- a/src/ExpertiseApi/Services/EmbeddingModelInfo.cs
+++ b/src/ExpertiseApi/Services/EmbeddingModelInfo.cs
@@ -2,25 +2,27 @@ namespace ExpertiseApi.Services;
 
 /// <summary>
 /// Single source of truth for the identity of the embedding model the API is
-/// built against. Every consumer that stamps, compares, or gates on the model
-/// name or vector dimensionality (reembed metadata upsert, restore
-/// compatibility gate) reads these constants — a model swap changes them in
-/// exactly one place (#455, #437).
+/// built against (ADR-017). Every consumer that stamps, compares, or gates on
+/// the model name, vector dimensionality, or token ceiling (reembed metadata
+/// upsert, restore compatibility gate, ONNX generator wiring, eval harness
+/// window math) reads these constants — a model swap changes them in exactly
+/// one place (#455, #437).
 /// </summary>
 internal static class EmbeddingModelInfo
 {
-    public const string Name = "bge-micro-v2";
+    public const string Name = "jina-embeddings-v2-small-en";
 
-    /// <summary>Must match the pgvector column type on ExpertiseEntries.Embedding (vector(384)).</summary>
-    public const int Dimensions = 384;
+    /// <summary>Must match the pgvector column type on ExpertiseEntries.Embedding (vector(512)).</summary>
+    public const int Dimensions = 512;
 
     /// <summary>
-    /// Token ceiling passed to the ONNX embedding generator. 512 is
-    /// bge-micro-v2's architectural window (and the connector's implicit
-    /// default — made explicit here so the ceiling is a visible, single-point
-    /// decision). Input beyond the ceiling is silently truncated by the
+    /// Token ceiling passed to the ONNX embedding generator. 6144 is the
+    /// ground-truth plateau for this corpus (ADR-017): coverage at 6144 equals
+    /// 8192 (99.71%, corpus p99 = 4,347 tokens), at 65% less peak RSS, and
+    /// 8192 measurably degraded one in-window needle via mean-pooling
+    /// dilution. Input beyond the ceiling is silently truncated by the
     /// connector (#429); the MaxBodyLength/MaxTitleLength write guards are
-    /// derived from this value. The #437 model swap raises it.
+    /// derived from this value.
     /// </summary>
-    public const int MaximumTokens = 512;
+    public const int MaximumTokens = 6144;
 }

--- a/src/ExpertiseApi/Services/EmbeddingModelInfo.cs
+++ b/src/ExpertiseApi/Services/EmbeddingModelInfo.cs
@@ -25,4 +25,13 @@ internal static class EmbeddingModelInfo
     /// derived from this value.
     /// </summary>
     public const int MaximumTokens = 6144;
+
+    /// <summary>
+    /// The one way to build the connector options — Program.cs and both eval
+    /// suites use this instead of hand-rolling an options object per call site
+    /// (review finding, 2026-07-23), so a future knob (pooling, casing) is a
+    /// one-place change.
+    /// </summary>
+    public static Microsoft.SemanticKernel.Connectors.Onnx.BertOnnxOptions CreateOnnxOptions() =>
+        new() { MaximumTokens = MaximumTokens };
 }

--- a/src/ExpertiseApi/Services/EmbeddingModelInfo.cs
+++ b/src/ExpertiseApi/Services/EmbeddingModelInfo.cs
@@ -1,0 +1,16 @@
+namespace ExpertiseApi.Services;
+
+/// <summary>
+/// Single source of truth for the identity of the embedding model the API is
+/// built against. Every consumer that stamps, compares, or gates on the model
+/// name or vector dimensionality (reembed metadata upsert, restore
+/// compatibility gate) reads these constants — a model swap changes them in
+/// exactly one place (#455, #437).
+/// </summary>
+internal static class EmbeddingModelInfo
+{
+    public const string Name = "bge-micro-v2";
+
+    /// <summary>Must match the pgvector column type on ExpertiseEntries.Embedding (vector(384)).</summary>
+    public const int Dimensions = 384;
+}

--- a/src/ExpertiseApi/Services/EmbeddingService.cs
+++ b/src/ExpertiseApi/Services/EmbeddingService.cs
@@ -5,6 +5,17 @@ namespace ExpertiseApi.Services;
 
 internal class EmbeddingService(IEmbeddingGenerator<string, Embedding<float>> generator)
 {
+    // Bounds in-flight ONNX inference process-wide (static: the service is
+    // scoped, the memory is not). A ceiling-filling embed transiently peaks
+    // ~12 GB RSS at MaximumTokens = 6144 (ADR-017 ground truth); without this
+    // gate, concurrent max-length writes stack those transients — an
+    // authenticated memory-exhaustion path on the single-host A2 target
+    // (review finding, 2026-07-23). The per-minute rate limiter bounds request
+    // RATE, not overlap; this bounds overlap. Serialized embeds cost ~1s of
+    // queueing only under exactly the burst that would otherwise exhaust the
+    // host.
+    private static readonly SemaphoreSlim InferenceGate = new(1, 1);
+
     // jina-embeddings-v2-small-en is trained symmetrically: queries and documents
     // embed identically, with NO instruction prefix (ADR-017). The bge-family
     // query instruction PR #431 added was model-specific and was removed with the
@@ -17,14 +28,30 @@ internal class EmbeddingService(IEmbeddingGenerator<string, Embedding<float>> ge
 
     public async Task<Vector> GenerateEmbeddingAsync(string text, CancellationToken ct = default)
     {
-        var result = await generator.GenerateAsync([text], cancellationToken: ct);
-        return new Vector(result[0].Vector.ToArray());
+        await InferenceGate.WaitAsync(ct);
+        try
+        {
+            var result = await generator.GenerateAsync([text], cancellationToken: ct);
+            return new Vector(result[0].Vector.ToArray());
+        }
+        finally
+        {
+            InferenceGate.Release();
+        }
     }
 
     public async Task<IReadOnlyList<Vector>> GenerateBatchAsync(IEnumerable<string> texts, CancellationToken ct = default)
     {
         var list = texts.ToList();
-        var results = await generator.GenerateAsync(list, cancellationToken: ct);
-        return results.Select(r => new Vector(r.Vector.ToArray())).ToList();
+        await InferenceGate.WaitAsync(ct);
+        try
+        {
+            var results = await generator.GenerateAsync(list, cancellationToken: ct);
+            return results.Select(r => new Vector(r.Vector.ToArray())).ToList();
+        }
+        finally
+        {
+            InferenceGate.Release();
+        }
     }
 }

--- a/src/ExpertiseApi/Services/EmbeddingService.cs
+++ b/src/ExpertiseApi/Services/EmbeddingService.cs
@@ -5,21 +5,15 @@ namespace ExpertiseApi.Services;
 
 internal class EmbeddingService(IEmbeddingGenerator<string, Embedding<float>> generator)
 {
-    // bge-family models are trained asymmetrically for retrieval: the QUERY side carries
-    // this instruction, the document side never does. bge-micro-v2's own card omits it,
-    // but the model is distilled from BAAI/bge-small-en-v1.5, whose card specifies it
-    // (optional in v1.5 — "slight degradation" without — and most beneficial for short
-    // queries, which is exactly this API's agent query profile). Documents embedded via
-    // BuildInputText and the dedup path stay unprefixed: dedup compares document-vs-
-    // document, which is symmetric (#424).
-    internal const string QueryInstruction = "Represent this sentence for searching relevant passages: ";
-
+    // jina-embeddings-v2-small-en is trained symmetrically: queries and documents
+    // embed identically, with NO instruction prefix (ADR-017). The bge-family
+    // query instruction PR #431 added was model-specific and was removed with the
+    // swap — a model change must re-verify prefix requirements against the new
+    // model's card (bge needs one, jina forbids none-vs-some asymmetry).
     public static string BuildInputText(string title, string body) => $"{title} {body}";
 
-    public static string BuildQueryInputText(string query) => $"{QueryInstruction}{query}";
-
     public Task<Vector> GenerateQueryEmbeddingAsync(string query, CancellationToken ct = default)
-        => GenerateEmbeddingAsync(BuildQueryInputText(query), ct);
+        => GenerateEmbeddingAsync(query, ct);
 
     public async Task<Vector> GenerateEmbeddingAsync(string text, CancellationToken ct = default)
     {

--- a/tests/ExpertiseApi.Tests/Architecture/EmbeddingDimensionConsistencyTests.cs
+++ b/tests/ExpertiseApi.Tests/Architecture/EmbeddingDimensionConsistencyTests.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Reflection;
+using ExpertiseApi.Models;
+using ExpertiseApi.Services;
+
+namespace ExpertiseApi.Tests.Architecture;
+
+/// <summary>
+/// Ties the two declarations of the vector dimension together (review finding,
+/// 2026-07-23): <c>EmbeddingModelInfo.Dimensions</c> is documented as the single
+/// source of truth, but the pgvector column width lives in a data-annotation
+/// string on <c>ExpertiseEntry.Embedding</c> that nothing else enforces. A model
+/// swap that bumps the constant without the attribute (or vice versa) compiles
+/// cleanly and only fails at INSERT time in production — this test makes that
+/// drift a CI failure instead.
+/// </summary>
+public class EmbeddingDimensionConsistencyTests
+{
+    [Fact]
+    public void EmbeddingColumnType_MatchesEmbeddingModelInfoDimensions()
+    {
+        var column = typeof(ExpertiseEntry)
+            .GetProperty(nameof(ExpertiseEntry.Embedding), BindingFlags.Public | BindingFlags.Instance)!
+            .GetCustomAttribute<ColumnAttribute>();
+
+        column.Should().NotBeNull("ExpertiseEntry.Embedding must declare its pgvector column type");
+        column!.TypeName.Should().Be($"vector({EmbeddingModelInfo.Dimensions})",
+            "the column attribute and EmbeddingModelInfo.Dimensions must move together — " +
+            "a mismatch surfaces as a runtime INSERT failure, not a compile error");
+    }
+}

--- a/tests/ExpertiseApi.Tests/Evaluation/EvalFactAttribute.cs
+++ b/tests/ExpertiseApi.Tests/Evaluation/EvalFactAttribute.cs
@@ -1,7 +1,7 @@
 namespace ExpertiseApi.Tests.Evaluation;
 
 /// <summary>
-/// Marks a retrieval-evaluation test that runs the REAL bge-micro-v2 ONNX model
+/// Marks a retrieval-evaluation test that runs the REAL pinned ONNX model (ADR-017)
 /// against a real PostgreSQL container — deliberately excluded from normal
 /// <c>dotnet test</c> runs (and CI) because it measures retrieval quality, not
 /// correctness, and its metrics are for human comparison across revisions (#425).

--- a/tests/ExpertiseApi.Tests/Evaluation/NeedleEvalTests.cs
+++ b/tests/ExpertiseApi.Tests/Evaluation/NeedleEvalTests.cs
@@ -1,0 +1,237 @@
+using ExpertiseApi.Auth;
+using ExpertiseApi.Data;
+using ExpertiseApi.Services;
+using ExpertiseApi.Tests.Infrastructure;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Text;
+using Microsoft.SemanticKernel.Connectors.Onnx;
+using Xunit.Abstractions;
+
+namespace ExpertiseApi.Tests.Evaluation;
+
+/// <summary>
+/// Needle-in-document long-context retrieval gate (#437). Eight synthetic
+/// ~8-10k-char incident-review documents, each carrying one distinctive fact
+/// (the "needle") at a controlled character depth (two docs each at ~400 /
+/// ~2500 / ~5000 / ~8000 chars), seeded through the real repository search
+/// paths. Each query targets exactly one needle.
+///
+/// The floors are WINDOW-AWARE: only needles whose worst-case token position
+/// fits inside <see cref="EmbeddingModelInfo.MaximumTokens"/> are asserted, so
+/// the suite is meaningful at any ceiling — at 512 tokens only the shallow
+/// needles gate; raising the ceiling (#437) activates the deeper ones with no
+/// test change. Out-of-window needles are still reported (the report is the
+/// product, as in <see cref="RetrievalEvalTests"/>); they are expected to rank
+/// poorly under a small window — that gap is the empirical case for the swap.
+///
+/// Deterministic construction: fixed filler paragraphs cycled by index, no RNG.
+/// Corpus and methodology are ported from the #437 spike (issue #437, findings
+/// comments of 2026-07-23).
+///
+/// <code>
+/// EXPERTISE_EVAL=1 dotnet test --filter "FullyQualifiedName~NeedleEval"
+/// </code>
+/// </summary>
+[Collection("Postgres")]
+public sealed class NeedleEvalTests(PostgresFixture postgres, ITestOutputHelper output) : IAsyncLifetime
+{
+    private const string EvalTenant = "eval-needle";
+    private const int ReportDepth = 10;
+
+    // Worst-case token density measured on the 60 longest real corpus entries
+    // (#429 derivation: 2.97–4.24 chars/token). Dividing a character position
+    // by the MINIMUM observed density over-estimates its token position, so an
+    // "in-window" classification here is conservative — a needle classified
+    // in-window is genuinely inside the embedding window.
+    private const double MinCharsPerToken = 2.9;
+
+    // Headroom for the title + separator BuildInputText prepends, [CLS]/[SEP],
+    // and tokenizer variance.
+    private const int TokenMargin = 64;
+
+    // Floors for IN-WINDOW needles only (catastrophic-regression tripwire, not
+    // a target — see RetrievalEvalTests class doc). Spike-measured semantic
+    // ranks for in-window needles were 1–2 across bge-micro-v2@512 (shallow
+    // needles) and jina-v2-small@6144 (all depths, avg rank 1.5).
+    private const double SemanticAvgRankCeiling = 3.0;
+    private const int SemanticWorstRankCeiling = 5;
+
+    private ServiceProvider? _onnxProvider;
+    private ExpertiseDbContext _db = null!;
+    private EmbeddingService _embedding = null!;
+    private ExpertiseRepository _repo = null!;
+
+    public async Task InitializeAsync()
+    {
+        if (Environment.GetEnvironmentVariable("EXPERTISE_EVAL") != "1" || ModelFiles.ModelPath is null)
+            return;
+
+        var services = new ServiceCollection();
+        services.AddBertOnnxEmbeddingGenerator(ModelFiles.ModelPath!, ModelFiles.VocabPath!,
+            new BertOnnxOptions { MaximumTokens = EmbeddingModelInfo.MaximumTokens });
+        _onnxProvider = services.BuildServiceProvider();
+        _embedding = new EmbeddingService(
+            _onnxProvider.GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>());
+
+        var options = new DbContextOptionsBuilder<ExpertiseDbContext>()
+            .UseNpgsql(postgres.ConnectionString, o => o.UseVector())
+            .Options;
+        _db = new ExpertiseDbContext(options, new NoOpTenantContextAccessor());
+        _repo = new ExpertiseRepository(_db, new HttpContextAccessor(), NullLogger<ExpertiseRepository>.Instance);
+
+        await _db.ExpertiseEntries.Where(e => e.Tenant == EvalTenant).ExecuteDeleteAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_db is not null)
+        {
+            await _db.ExpertiseEntries.Where(e => e.Tenant == EvalTenant).ExecuteDeleteAsync();
+            await _db.DisposeAsync();
+        }
+        _onnxProvider?.Dispose();
+    }
+
+    [EvalFact]
+    public async Task NeedleQueries_ReportAndWindowAwareFloor()
+    {
+        var docs = NeedleCorpus.Build();
+
+        // ---- Seed through the real entry shape with real embeddings ----
+        var docTexts = docs.Select(d => EmbeddingService.BuildInputText(d.Title, d.Body));
+        var docVectors = await _embedding.GenerateBatchAsync(docTexts);
+        for (var i = 0; i < docs.Count; i++)
+        {
+            var entry = TestHelpers.SeedEntry(
+                domain: "needle-eval", title: docs[i].Title, body: docs[i].Body, tenant: EvalTenant);
+            entry.Embedding = docVectors[i];
+            _db.ExpertiseEntries.Add(entry);
+        }
+        await _db.SaveChangesAsync();
+
+        // ---- Rank every needle query in all three modes ----
+        var ctx = TestHelpers.CreateTenantContext(tenant: EvalTenant);
+        var results = new List<(NeedleDoc Doc, bool InWindow, int Semantic, int Keyword, int Hybrid)>();
+
+        foreach (var doc in docs)
+        {
+            var inWindow = ((doc.NeedleEndChars / MinCharsPerToken) + TokenMargin)
+                < EmbeddingModelInfo.MaximumTokens;
+
+            var queryVector = await _embedding.GenerateQueryEmbeddingAsync(doc.Query);
+            var semanticResults = await _repo.SemanticSearchAsync(queryVector, ctx, limit: ReportDepth, includeDeprecated: false,
+                domain: null, tags: null, entryType: null, severity: null, CancellationToken.None);
+            var keywordResults = await _repo.KeywordSearchAsync(doc.Query, ctx, includeDeprecated: false, limit: ReportDepth,
+                domain: null, tags: null, entryType: null, severity: null, CancellationToken.None);
+            var fused = RankFusion.ReciprocalRankFusion(keywordResults, semanticResults, ReportDepth);
+
+            results.Add((doc, inWindow,
+                RankOf(semanticResults.Select(r => r.Entry.Title), doc.Title),
+                RankOf(keywordResults.Select(r => r.Entry.Title), doc.Title),
+                RankOf(fused.Select(r => r.Entry.Title), doc.Title)));
+        }
+
+        // ---- Report ----
+        output.WriteLine($"Needle corpus: {docs.Count} docs, ceiling {EmbeddingModelInfo.MaximumTokens} tokens " +
+            $"(in-window: {results.Count(r => r.InWindow)}/{docs.Count}); rank 0 = not in top {ReportDepth}");
+        output.WriteLine("");
+        output.WriteLine($"{"doc",-28} {"depth",6} {"window",7} {"sem",4} {"kw",4} {"hyb",4}");
+        foreach (var r in results)
+            output.WriteLine($"{r.Doc.Title,-28} {r.Doc.DepthChars,6} {(r.InWindow ? "in" : "out"),7} {r.Semantic,4} {r.Keyword,4} {r.Hybrid,4}");
+        output.WriteLine("");
+
+        // ---- Window-aware floors (semantic arm — the capability under test) ----
+        var inWindowResults = results.Where(r => r.InWindow).ToList();
+        inWindowResults.Should().NotBeEmpty(
+            "the window-gating math must leave at least the shallow needles asserted at any plausible ceiling");
+
+        foreach (var r in inWindowResults)
+        {
+            r.Semantic.Should().BeInRange(1, SemanticWorstRankCeiling,
+                $"in-window needle '{r.Doc.Title}' (depth {r.Doc.DepthChars} chars) must be semantically retrievable");
+        }
+
+        var avgRank = inWindowResults.Average(r => (double)r.Semantic);
+        avgRank.Should().BeLessThanOrEqualTo(SemanticAvgRankCeiling,
+            "in-window needles collapsing on average indicates a broken embedding path or a ceiling regression");
+    }
+
+    private static int RankOf(IEnumerable<string> rankedTitles, string title)
+    {
+        var idx = rankedTitles.ToList().FindIndex(t => string.Equals(t, title, StringComparison.Ordinal));
+        return idx + 1; // 0 = miss
+    }
+
+    internal sealed record NeedleDoc(string Title, string Body, string Query, int DepthChars, int NeedleEndChars);
+
+    /// <summary>
+    /// Deterministic needle-document builder ported from the #437 spike
+    /// (fixed filler paragraphs cycled by seed index; no randomness).
+    /// </summary>
+    internal static class NeedleCorpus
+    {
+        private static readonly string[] Filler =
+        [
+            "During the incident review, the on-call engineer confirmed that the alerting pipeline correctly paged the secondary responder within the expected two-minute window, and the runbook link attached to the page resolved without redirect errors. ",
+            "The service mesh sidecar proxies reported steady p99 latency throughout the affected window, which initially misled the responding team into ruling out network-layer causes before the eventual root cause was isolated. ",
+            "Capacity planning for the quarter had already flagged the affected cluster as running close to its provisioned memory ceiling, though the on-call rotation had not yet actioned the recommended node pool expansion at the time of the incident. ",
+            "Synthetic monitoring checks against the public API endpoints continued to pass green throughout the degradation, since the synthetic probes exercised a code path that happened not to intersect with the failing component. ",
+            "The postmortem timeline was reconstructed from a combination of structured application logs, the deployment audit trail, and the on-call chat transcript, which together gave a minute-by-minute account of the response. ",
+            "Several downstream consumers of the affected service implemented their own retry-with-backoff logic, which absorbed a portion of the failure and delayed customer-visible symptoms by roughly eleven minutes after the underlying fault began. ",
+            "The engineering team maintains a shared dashboard of golden signals for every tier-one service, covering latency, traffic, errors and saturation, and this dashboard was the first place the responder looked once paged. ",
+            "A follow-up action item was filed to add a synthetic check that specifically exercises the failure mode uncovered by this incident, closing the monitoring gap that let the issue reach production undetected. ",
+            "The affected component had passed its most recent quarterly disaster-recovery exercise without any findings, which the review board noted as a gap in how those exercises are scoped going forward. ",
+            "Escalation paging went through the secondary on-call rotation because the primary responder's phone was in do-not-disturb mode during a scheduled maintenance window unrelated to this incident. ",
+        ];
+
+        private static readonly (int Depth, string Needle, string Title, string Query, int Total, int Seed)[] Defs =
+        [
+            (400, "The incident was ultimately traced to a misconfigured retry budget of exactly seven hundred forty three milliseconds configured on the payment-gateway sidecar.",
+                "incident review doc1", "What was the exact retry budget value that caused the payment gateway incident?", 8200, 0),
+            (400, "Root cause: an expired TLS client certificate issued to the inventory-sync-worker service account expired at zero three fourteen UTC.",
+                "incident review doc2", "Which service account had an expired certificate that caused the inventory sync failure?", 8600, 1),
+            (2500, "The fix required rotating the Redis eviction policy from allkeys-lru to volatile-ttl on the session-cache cluster.",
+                "incident review doc3", "What Redis eviction policy change fixed the session cache issue?", 9000, 2),
+            (2500, "The regression was introduced by a commit that removed the idempotency check inside the checkout-reconciler job.",
+                "incident review doc4", "What change introduced the checkout idempotency regression?", 9400, 3),
+            (5000, "The database deadlock was caused by two migrations acquiring locks on the orders table and the order_items table in reverse order.",
+                "incident review doc5", "What caused the database deadlock between the orders and order_items tables?", 9800, 4),
+            (5000, "The outage was resolved by increasing the file descriptor limit from one thousand twenty four to sixty five thousand five hundred thirty six on the log-shipper daemonset.",
+                "incident review doc6", "What file descriptor limit change fixed the log shipper outage?", 8400, 5),
+            (8000, "The root cause was a clock skew of forty seven seconds between the auth-broker service and the token-validation service.",
+                "incident review doc7", "How much clock skew caused the auth broker token validation issue?", 9200, 6),
+            (8000, "The leak was traced to an unclosed gRPC channel inside the notification-dispatcher retry loop.",
+                "incident review doc8", "What caused the gRPC channel leak in the notification dispatcher?", 8800, 7),
+        ];
+
+        public static List<NeedleDoc> Build() => Defs.Select(d =>
+        {
+            var before = FillerUpTo(d.Depth, d.Seed);
+            if (before.Length > d.Depth)
+                before = before[..d.Depth];
+            var afterTarget = Math.Max(d.Total - before.Length - d.Needle.Length - 2, 0);
+            var after = FillerUpTo(afterTarget, d.Seed + 5);
+            if (after.Length > afterTarget)
+                after = after[..afterTarget];
+            var body = $"{before} {d.Needle} {after}";
+            var needleEnd = before.Length + 1 + d.Needle.Length;
+            return new NeedleDoc(d.Title, body, d.Query, d.Depth, needleEnd);
+        }).ToList();
+
+        private static string FillerUpTo(int targetChars, int startIdx)
+        {
+            var sb = new StringBuilder();
+            var i = startIdx;
+            while (sb.Length < targetChars)
+            {
+                sb.Append(Filler[i % Filler.Length]);
+                i++;
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/tests/ExpertiseApi.Tests/Evaluation/NeedleEvalTests.cs
+++ b/tests/ExpertiseApi.Tests/Evaluation/NeedleEvalTests.cs
@@ -72,7 +72,7 @@ public sealed class NeedleEvalTests(PostgresFixture postgres, ITestOutputHelper 
 
         var services = new ServiceCollection();
         services.AddBertOnnxEmbeddingGenerator(ModelFiles.ModelPath!, ModelFiles.VocabPath!,
-            new BertOnnxOptions { MaximumTokens = EmbeddingModelInfo.MaximumTokens });
+            EmbeddingModelInfo.CreateOnnxOptions());
         _onnxProvider = services.BuildServiceProvider();
         _embedding = new EmbeddingService(
             _onnxProvider.GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>());

--- a/tests/ExpertiseApi.Tests/Evaluation/RetrievalEvalTests.cs
+++ b/tests/ExpertiseApi.Tests/Evaluation/RetrievalEvalTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Microsoft.SemanticKernel.Connectors.Onnx;
 using ExpertiseApi.Auth;
 using ExpertiseApi.Data;
 using ExpertiseApi.Models;
@@ -60,7 +61,8 @@ public sealed class RetrievalEvalTests(PostgresFixture postgres, ITestOutputHelp
             return; // the [EvalFact] skip fires before the test body; nothing to set up.
 
         var services = new ServiceCollection();
-        services.AddBertOnnxEmbeddingGenerator(ModelFiles.ModelPath!, ModelFiles.VocabPath!);
+        services.AddBertOnnxEmbeddingGenerator(ModelFiles.ModelPath!, ModelFiles.VocabPath!,
+            new BertOnnxOptions { MaximumTokens = EmbeddingModelInfo.MaximumTokens });
         _onnxProvider = services.BuildServiceProvider();
         _embedding = new EmbeddingService(
             _onnxProvider.GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>());

--- a/tests/ExpertiseApi.Tests/Evaluation/RetrievalEvalTests.cs
+++ b/tests/ExpertiseApi.Tests/Evaluation/RetrievalEvalTests.cs
@@ -18,7 +18,7 @@ namespace ExpertiseApi.Tests.Evaluation;
 /// Golden-query retrieval evaluation harness (#425, recommendation 5 of
 /// docs/research/2026-07-retrieval-assessment.md).
 ///
-/// Seeds the corpus from <c>golden-set.json</c> with REAL bge-micro-v2 embeddings
+/// Seeds the corpus from <c>golden-set.json</c> with REAL embeddings from the pinned ONNX model (ADR-017: jina-embeddings-v2-small-en)
 /// (the normal test suite's content-derived mock cannot measure retrieval quality),
 /// runs every golden query through keyword and semantic search, and reports
 /// recall@5 / recall@10 / MRR@10 per mode plus every miss. Run with:

--- a/tests/ExpertiseApi.Tests/Evaluation/RetrievalEvalTests.cs
+++ b/tests/ExpertiseApi.Tests/Evaluation/RetrievalEvalTests.cs
@@ -62,7 +62,7 @@ public sealed class RetrievalEvalTests(PostgresFixture postgres, ITestOutputHelp
 
         var services = new ServiceCollection();
         services.AddBertOnnxEmbeddingGenerator(ModelFiles.ModelPath!, ModelFiles.VocabPath!,
-            new BertOnnxOptions { MaximumTokens = EmbeddingModelInfo.MaximumTokens });
+            EmbeddingModelInfo.CreateOnnxOptions());
         _onnxProvider = services.BuildServiceProvider();
         _embedding = new EmbeddingService(
             _onnxProvider.GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>());

--- a/tests/ExpertiseApi.Tests/Evaluation/golden-set.json
+++ b/tests/ExpertiseApi.Tests/Evaluation/golden-set.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Golden retrieval-evaluation set (#425). Corpus entries are seeded with REAL bge-micro-v2 embeddings; queries score keyword and semantic retrieval via recall@5/@10 and MRR. Expected titles must match corpus titles exactly. Grow this set when a real agent query misses — add the query with its expected entry.",
+  "$comment": "Golden retrieval-evaluation set (#425). Corpus entries are seeded with REAL embeddings from the pinned ONNX model (ADR-017); queries score keyword and semantic retrieval via recall@5/@10 and MRR. Expected titles must match corpus titles exactly. Grow this set when a real agent query misses — add the query with its expected entry.",
   "corpus": [
     { "domain": "dotnet", "title": "CS8618 non-nullable property warning on EF Core entities", "body": "EF Core entity classes with required string properties raise CS8618 nullable warnings. Use the required modifier or initialize with null! when the ORM guarantees materialization.", "entryType": "Caveat", "severity": "Info" },
     { "domain": "dotnet", "title": "EF Core migration conflict after parallel feature branches", "body": "Two branches each adding a migration produce a model snapshot conflict. Re-scaffold the later migration after rebase: remove it, then run dotnet ef migrations add again.", "entryType": "IssueFix", "severity": "Warning" },

--- a/tests/ExpertiseApi.Tests/Infrastructure/ApiFactory.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/ApiFactory.cs
@@ -53,7 +53,7 @@ public class ApiFactory : WebApplicationFactory<Program>
             services.AddDbContext<ExpertiseDbContext>(options =>
                 options.UseNpgsql(_connectionString, o => o.UseVector()));
 
-            // Replace ONNX embedding generator with a mock that returns 384-dim vectors.
+            // Replace ONNX embedding generator with a mock that returns 512-dim vectors.
             // AddBertOnnxEmbeddingGenerator opens the model file at registration time,
             // so we must remove the existing registration and substitute it.
             var embeddingDescriptor = services.SingleOrDefault(

--- a/tests/ExpertiseApi.Tests/Infrastructure/TestHelpers.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/TestHelpers.cs
@@ -101,7 +101,7 @@ internal static class TestHelpers
     }
 
     /// <summary>Content-independent fixed vector (query vectors / unit-test stubs that don't care).</summary>
-    internal static Vector CreateTestVector(int dimensions = 384)
+    internal static Vector CreateTestVector(int dimensions = 512)
     {
         var values = new float[dimensions];
         var rng = new Random(42);
@@ -118,7 +118,7 @@ internal static class TestHelpers
     /// vector for every input — which made semantic-dedup behaviour structurally unobservable
     /// and forced two integration tests into per-test workarounds.
     /// </summary>
-    internal static float[] CreateContentEmbedding(string content, int dimensions = 384)
+    internal static float[] CreateContentEmbedding(string content, int dimensions = 512)
     {
         var rng = new Random(StableSeed(content));
         var values = new float[dimensions];
@@ -127,7 +127,7 @@ internal static class TestHelpers
         return values;
     }
 
-    internal static Vector CreateContentVector(string content, int dimensions = 384)
+    internal static Vector CreateContentVector(string content, int dimensions = 512)
         => new(CreateContentEmbedding(content, dimensions));
 
     // FNV-1a over UTF-16 code units. Stable across processes, unlike string.GetHashCode

--- a/tests/ExpertiseApi.Tests/Integration/BackupRestoreCommandTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/BackupRestoreCommandTests.cs
@@ -87,8 +87,8 @@ public class BackupRestoreCommandTests : IAsyncLifetime
         audit.Should().HaveCount(seeded.Count, "the audit log is restored verbatim, no new rows for a clean restore");
 
         var metadata = await db.EmbeddingMetadata.SingleAsync();
-        metadata.ModelName.Should().Be("bge-micro-v2");
-        metadata.Dimensions.Should().Be(384);
+        metadata.ModelName.Should().Be("jina-embeddings-v2-small-en");
+        metadata.Dimensions.Should().Be(512);
     }
 
     [Fact]
@@ -236,7 +236,7 @@ public class BackupRestoreCommandTests : IAsyncLifetime
             ReviewState = ReviewState.Approved,
             ReviewedBy = "reviewer@example.com",
             ReviewedAt = new DateTime(2026, 7, 1, 9, 0, 0, DateTimeKind.Utc),
-            Embedding = new Vector(Enumerable.Repeat(0.5f, 384).ToArray()),
+            Embedding = new Vector(Enumerable.Repeat(0.5f, 512).ToArray()),
         };
         var deprecated = new ExpertiseEntry
         {
@@ -262,8 +262,8 @@ public class BackupRestoreCommandTests : IAsyncLifetime
 
         db.EmbeddingMetadata.Add(new EmbeddingMetadata
         {
-            ModelName = "bge-micro-v2",
-            Dimensions = 384,
+            ModelName = "jina-embeddings-v2-small-en",
+            Dimensions = 512,
             LastReembedAt = DateTime.UtcNow,
         });
         await db.SaveChangesAsync();

--- a/tests/ExpertiseApi.Tests/Integration/BatchEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/BatchEndpointTests.cs
@@ -143,14 +143,14 @@ public class BatchEndpointTests : IAsyncLifetime
         var response = await client.PostAsJsonAsync("/expertise/batch", new[]
         {
             Item(freshDomain, "within cap", "a normal-sized body"),
-            Item(freshDomain, "over cap", new string('a', 1501)), // #429 MaxBodyLength = 1500
+            Item(freshDomain, "over cap", new string('a', 16001)), // #429 MaxBodyLength = 16000 (ADR-017)
         });
 
         response.StatusCode.Should().Be(HttpStatusCode.MultiStatus);
         var results = (await response.Content.ReadFromJsonAsync<List<BatchResult>>())!;
         results[0].Status.Should().Be("Created");
         results[1].Status.Should().Be("Rejected");
-        results[1].Error.Should().Contain("maximum length of 1500");
+        results[1].Error.Should().Contain("maximum length of 16000");
     }
 
     [Fact]

--- a/tests/ExpertiseApi.Tests/Integration/CliMaintenanceCommandTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/CliMaintenanceCommandTests.cs
@@ -78,6 +78,53 @@ public class CliMaintenanceCommandTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Reembed_OverwritesStaleEmbeddingMetadata()
+    {
+        // #455: a pre-existing metadata row describing a PREVIOUS model must be
+        // corrected by reembed — after a full reembed the stored vectors are, by
+        // construction, the current model's. The pre-fix get-or-create only
+        // stamped LastReembedAt and left the stale identity in place.
+        await using (var db = NewContext())
+        {
+            db.EmbeddingMetadata.Add(new EmbeddingMetadata
+            {
+                ModelName = "previous-model",
+                Dimensions = 999,
+                LastReembedAt = DateTime.UtcNow.AddDays(-30)
+            });
+            await db.SaveChangesAsync();
+        }
+
+        await using (var app = BuildApp())
+            await ReembedCommand.RunAsync(app, ["reembed"]);
+
+        await using var verify = NewContext();
+        var metadata = await verify.EmbeddingMetadata.SingleAsync();
+        metadata.ModelName.Should().Be("bge-micro-v2");
+        metadata.Dimensions.Should().Be(384);
+        metadata.LastReembedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(1));
+    }
+
+    [Fact]
+    public async Task EmbeddingMetadata_SecondRow_IsRejectedByDbSingletonGuard()
+    {
+        // #455: the singleton invariant is enforced at the DB level
+        // (UX_EmbeddingMetadata_Singleton) so a get-or-create race duplicates
+        // loudly instead of silently.
+        await using (var db = NewContext())
+        {
+            db.EmbeddingMetadata.Add(new EmbeddingMetadata { ModelName = "m1", Dimensions = 1 });
+            await db.SaveChangesAsync();
+        }
+
+        await using var second = NewContext();
+        second.EmbeddingMetadata.Add(new EmbeddingMetadata { ModelName = "m2", Dimensions = 2 });
+        var act = () => second.SaveChangesAsync();
+        await act.Should().ThrowAsync<DbUpdateException>(
+            "the unique constant-expression index must reject a second metadata row");
+    }
+
+    [Fact]
     public async Task Rehash_BackfillsNullHashes_AndIsIdempotent()
     {
         var ids = new List<Guid>();

--- a/tests/ExpertiseApi.Tests/Integration/CliMaintenanceCommandTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/CliMaintenanceCommandTests.cs
@@ -52,7 +52,7 @@ public class CliMaintenanceCommandTests : IAsyncLifetime
             var entry = TestHelpers.SeedEntry(
                 domain: "reembed", title: $"entry {i}", body: $"body {i}",
                 tenant: i % 2 == 0 ? "team-a" : "team-b");
-            entry.Embedding = new Vector(new float[384]);
+            entry.Embedding = new Vector(new float[512]);
             db.ExpertiseEntries.Add(entry);
             await db.SaveChangesAsync();
             seeded.Add(entry);
@@ -72,8 +72,8 @@ public class CliMaintenanceCommandTests : IAsyncLifetime
         }
 
         var metadata = await verify.EmbeddingMetadata.SingleAsync();
-        metadata.ModelName.Should().Be("bge-micro-v2");
-        metadata.Dimensions.Should().Be(384);
+        metadata.ModelName.Should().Be("jina-embeddings-v2-small-en");
+        metadata.Dimensions.Should().Be(512);
         metadata.LastReembedAt.Should().NotBe(default);
     }
 
@@ -100,8 +100,8 @@ public class CliMaintenanceCommandTests : IAsyncLifetime
 
         await using var verify = NewContext();
         var metadata = await verify.EmbeddingMetadata.SingleAsync();
-        metadata.ModelName.Should().Be("bge-micro-v2");
-        metadata.Dimensions.Should().Be(384);
+        metadata.ModelName.Should().Be("jina-embeddings-v2-small-en");
+        metadata.Dimensions.Should().Be(512);
         metadata.LastReembedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(1));
     }
 

--- a/tests/ExpertiseApi.Tests/Integration/ExpertiseEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/ExpertiseEndpointTests.cs
@@ -186,19 +186,19 @@ public class ExpertiseEndpointTests : IAsyncLifetime
     [Fact]
     public async Task CreateEntry_WithOverlongBody_Returns400()
     {
-        // 1500 is the #429 embedding-window cap (MaxBodyLength in ExpertiseEndpoints).
-        var payload = new { domain = "shared", title = "Overlong", body = new string('a', 1501), entryType = "Pattern", severity = "Info", source = "test" };
+        // 16000 is the embedding-window cap (#429 method, re-based by ADR-017).
+        var payload = new { domain = "shared", title = "Overlong", body = new string('a', 16001), entryType = "Pattern", severity = "Info", source = "test" };
         var response = await _client.PostAsJsonAsync("/expertise", payload);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var problem = await response.Content.ReadAsStringAsync();
-        problem.Should().Contain("maximum length of 1500");
+        problem.Should().Contain("maximum length of 16000");
     }
 
     [Fact]
     public async Task CreateEntry_WithBodyAtLimit_Returns201()
     {
-        var payload = new { domain = "shared", title = "At limit", body = new string('a', 1500), entryType = "Pattern", severity = "Info", source = "test" };
+        var payload = new { domain = "shared", title = "At limit", body = new string('a', 16000), entryType = "Pattern", severity = "Info", source = "test" };
         var response = await _client.PostAsJsonAsync("/expertise", payload);
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -242,11 +242,11 @@ public class ExpertiseEndpointTests : IAsyncLifetime
     {
         var entry = await SeedEntryViaRepo("shared", "Patch target");
 
-        var response = await _client.PatchAsJsonAsync($"/expertise/{entry.Id}", new { body = new string('b', 1501) });
+        var response = await _client.PatchAsJsonAsync($"/expertise/{entry.Id}", new { body = new string('b', 16001) });
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var problem = await response.Content.ReadAsStringAsync();
-        problem.Should().Contain("maximum length of 1500");
+        problem.Should().Contain("maximum length of 16000");
     }
 
     private async Task<ExpertiseEntry> SeedEntryViaRepo(

--- a/tests/ExpertiseApi.Tests/Integration/MigrationReversibilityTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/MigrationReversibilityTests.cs
@@ -84,6 +84,75 @@ public class MigrationReversibilityTests : IAsyncLifetime
         await AssertActorClassColumnsExist(db, expected: false);
     }
 
+    [Fact]
+    public async Task SwapEmbeddingModelTo512Dim_NullsPopulated384DimData_AndRetypes()
+    {
+        // ADR-017. The empty-DB apply path is exercised by every PostgresFixture
+        // test for free; THIS test covers the only path where the migration's
+        // internal ordering matters — an UPGRADE over populated 384-dim rows.
+        // pgvector's typmod cast rejects a naive ALTER COLUMN TYPE over live
+        // vectors, so a migration that "works" on fresh CI databases would break
+        // the first real production upgrade. Seeding uses raw SQL because the
+        // current EF model already reflects vector(512).
+        await using var db = NewContext();
+        var migrator = db.GetInfrastructure().GetRequiredService<IMigrator>();
+
+        await migrator.MigrateAsync(SwapBaselineMigration);
+
+        var conn = db.Database.GetDbConnection();
+        if (conn.State != System.Data.ConnectionState.Open)
+            await conn.OpenAsync();
+        await using (var insert = conn.CreateCommand())
+        {
+            insert.CommandText = """
+                INSERT INTO "ExpertiseEntries"
+                    ("Domain","Tags","Title","Body","EntryType","Severity","Source",
+                     "Tenant","Visibility","AuthorPrincipal","ReviewState","Embedding")
+                VALUES ('mig','{}','migration seed','populated 384-dim row','Pattern','Info','human',
+                        'legacy','Private','test','Approved',
+                        (SELECT array_agg(0.5)::vector(384) FROM generate_series(1,384)));
+                """;
+            await insert.ExecuteNonQueryAsync();
+        }
+
+        await migrator.MigrateAsync(SwapMigration);
+
+        (await ScalarLong(db, """
+            SELECT COUNT(*) FROM information_schema.columns
+            WHERE table_name = 'ExpertiseEntries' AND column_name = 'Embedding'
+              AND udt_name = 'vector';
+            """)).Should().Be(1);
+        (await ScalarLong(db, """SELECT atttypmod FROM pg_attribute WHERE attrelid = '"ExpertiseEntries"'::regclass AND attname = 'Embedding';"""))
+            .Should().Be(512, "the column typmod must carry the new dimension");
+        (await ScalarLong(db, """SELECT COUNT(*) FROM "ExpertiseEntries" WHERE "Embedding" IS NOT NULL;"""))
+            .Should().Be(0, "old-model vectors are garbage in the new space and must be nulled");
+        (await ScalarLong(db, """SELECT COUNT(*) FROM "ExpertiseEntries";"""))
+            .Should().Be(1, "the row itself must survive — only its embedding is invalidated");
+        (await ScalarLong(db, """SELECT COUNT(*) FROM pg_indexes WHERE tablename = 'ExpertiseEntries' AND indexname = 'IX_ExpertiseEntries_Embedding' AND indexdef LIKE '%hnsw%';"""))
+            .Should().Be(1, "the HNSW index must be recreated after the retype");
+
+        // Down(): the column type reverts; the destroyed vectors do NOT come
+        // back (forward-only in practice — ADR-017 rollback section).
+        await migrator.MigrateAsync(SwapBaselineMigration);
+        (await ScalarLong(db, """SELECT atttypmod FROM pg_attribute WHERE attrelid = '"ExpertiseEntries"'::regclass AND attname = 'Embedding';"""))
+            .Should().Be(384);
+        (await ScalarLong(db, """SELECT COUNT(*) FROM "ExpertiseEntries" WHERE "Embedding" IS NOT NULL;"""))
+            .Should().Be(0, "Down() cannot restore destroyed vectors — documented, deliberate");
+    }
+
+    private const string SwapBaselineMigration = "20260723135538_EmbeddingMetadataSingletonGuard";
+    private const string SwapMigration = "20260723141427_SwapEmbeddingModelTo512Dim";
+
+    private static async Task<long> ScalarLong(ExpertiseDbContext db, string sql)
+    {
+        var conn = db.Database.GetDbConnection();
+        if (conn.State != System.Data.ConnectionState.Open)
+            await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        return Convert.ToInt64(await cmd.ExecuteScalarAsync());
+    }
+
     private static async Task AssertActorClassColumnsExist(ExpertiseDbContext db, bool expected)
     {
         foreach (var column in new[] { "ActorClass", "AuthMethod", "ActorClassHeader" })

--- a/tests/ExpertiseApi.Tests/Integration/SyncWorkerTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/SyncWorkerTests.cs
@@ -200,7 +200,7 @@ public class SyncWorkerTests : IAsyncLifetime
             ReviewedBy = state == ReviewState.Approved ? "reviewer@spoke.local" : null,
             ReviewedAt = state == ReviewState.Approved ? DateTime.UtcNow : null,
             DeprecatedAt = deprecatedAt,
-            Embedding = new Vector(new float[384]),
+            Embedding = new Vector(new float[512]),
         };
 
         var hidden = new List<ExpertiseEntry>

--- a/tests/ExpertiseApi.Tests/Unit/CosineDistanceTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/CosineDistanceTests.cs
@@ -65,12 +65,12 @@ public class CosineDistanceTests
     }
 
     [Fact]
-    public void MatchingDimensions_384dim_ShouldReturnValidDistance()
+    public void MatchingDimensions_512dim_ShouldReturnValidDistance()
     {
-        var a = new float[384];
-        var b = new float[384];
+        var a = new float[512];
+        var b = new float[512];
         var rng = new Random(42);
-        for (var i = 0; i < 384; i++)
+        for (var i = 0; i < 512; i++)
         {
             a[i] = (float)(rng.NextDouble() * 2 - 1);
             b[i] = (float)(rng.NextDouble() * 2 - 1);

--- a/tests/ExpertiseApi.Tests/Unit/DeduplicationServiceTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/DeduplicationServiceTests.cs
@@ -206,7 +206,7 @@ public class DeduplicationServiceTests
         var requests = new List<CreateExpertiseRequest> { CreateRequest(title: "Unique Title") };
 
         // Build a vector that is orthogonal to _testVector (cosine distance == 1)
-        var orthogonalValues = new float[384];
+        var orthogonalValues = new float[512];
         orthogonalValues[0] = 1.0f; // all other dims zero — orthogonal to random _testVector
         var farVector = new Vector(orthogonalValues);
 

--- a/tests/ExpertiseApi.Tests/Unit/EmbeddingServiceTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/EmbeddingServiceTests.cs
@@ -43,6 +43,52 @@ public class EmbeddingServiceTests
     }
 
     [Fact]
+    public async Task GenerateEmbeddingAsync_BoundsInferenceConcurrency_ToOne()
+    {
+        // Review finding 2026-07-23: a ceiling-filling embed transiently peaks
+        // ~12 GB RSS (ADR-017), so overlapping inference is the memory-exhaustion
+        // vector on the A2 single host. This pins the InferenceGate: N parallel
+        // callers must never observe more than one in-flight generator call.
+        var inFlight = 0;
+        var maxObserved = 0;
+        var generator = Substitute.For<IEmbeddingGenerator<string, Embedding<float>>>();
+        generator.GenerateAsync(
+                Arg.Any<IEnumerable<string>>(),
+                Arg.Any<EmbeddingGenerationOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(async ci =>
+            {
+                var now = Interlocked.Increment(ref inFlight);
+                InterlockedExtensionsMax(ref maxObserved, now);
+                await Task.Delay(30);
+                Interlocked.Decrement(ref inFlight);
+                var res = new GeneratedEmbeddings<Embedding<float>>();
+                foreach (var input in ci.ArgAt<IEnumerable<string>>(0))
+                    res.Add(new Embedding<float>(TestHelpers.CreateContentEmbedding(input)));
+                return res;
+            });
+
+        var service = new EmbeddingService(generator);
+        await Task.WhenAll(Enumerable.Range(0, 6).Select(i =>
+            i % 2 == 0
+                ? service.GenerateEmbeddingAsync($"text {i}")
+                : (Task)service.GenerateBatchAsync([$"batch {i}"])));
+
+        maxObserved.Should().Be(1,
+            "the static inference gate must serialize ONNX calls across single and batch paths");
+    }
+
+    private static void InterlockedExtensionsMax(ref int target, int candidate)
+    {
+        int snapshot;
+        while (candidate > (snapshot = Volatile.Read(ref target)))
+        {
+            if (Interlocked.CompareExchange(ref target, candidate, snapshot) == snapshot)
+                break;
+        }
+    }
+
+    [Fact]
     public void BuildInputText_RemainsUnprefixed()
     {
         // jina-v2-small embeds queries and documents symmetrically with NO

--- a/tests/ExpertiseApi.Tests/Unit/EmbeddingServiceTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/EmbeddingServiceTests.cs
@@ -43,21 +43,18 @@ public class EmbeddingServiceTests
     }
 
     [Fact]
-    public void BuildQueryInputText_PrefixesBgeQueryInstruction()
+    public void BuildInputText_RemainsUnprefixed()
     {
-        // bge-family asymmetric retrieval: the query side carries the instruction, the
-        // document side (BuildInputText) never does (#424). If the instruction wording
-        // ever changes (model swap), stored document embeddings stay valid — only
-        // query-side embedding changes — but this pin forces the change to be deliberate.
-        EmbeddingService.BuildQueryInputText("pgvector index tuning")
-            .Should().Be("Represent this sentence for searching relevant passages: pgvector index tuning");
-
+        // jina-v2-small embeds queries and documents symmetrically with NO
+        // instruction prefix (ADR-017). This pin forces any future prefix
+        // reintroduction (another model swap) to be deliberate — bge needed
+        // one (PR #431), jina must not have one.
         EmbeddingService.BuildInputText("title", "body")
             .Should().Be("title body", "document-side input must remain unprefixed");
     }
 
     [Fact]
-    public async Task GenerateQueryEmbeddingAsync_EmbedsPrefixedQuery_NotRawQuery()
+    public async Task GenerateQueryEmbeddingAsync_EmbedsRawQuery_NoInstructionPrefix()
     {
         var generator = Substitute.For<IEmbeddingGenerator<string, Embedding<float>>>();
         generator.GenerateAsync(
@@ -78,10 +75,8 @@ public class EmbeddingServiceTests
         var queryVector = await service.GenerateQueryEmbeddingAsync("kafka rebalance");
 
         queryVector.ToArray().Should().Equal(
-            TestHelpers.CreateContentEmbedding(EmbeddingService.BuildQueryInputText("kafka rebalance")),
-            "the query embedding must be generated from the instruction-prefixed text");
-        queryVector.ToArray().Should().NotEqual(
             TestHelpers.CreateContentEmbedding("kafka rebalance"),
-            "embedding the raw query would silently drop the bge query instruction");
+            "ADR-017: jina embeds the raw query — a leftover bge-style instruction prefix " +
+            "would silently degrade every semantic search against the new model");
     }
 }

--- a/tests/ExpertiseApi.Tests/Unit/RepositoryQueryTranslationTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/RepositoryQueryTranslationTests.cs
@@ -121,7 +121,7 @@ public class RepositoryQueryTranslationTests
     public void SemanticSearch_CosineDistanceOrdering_Translates()
     {
         using var db = NewContext();
-        var vector = new Vector(new float[384]);
+        var vector = new Vector(new float[512]);
         var query = ExpertiseRepository.ApplyApprovedReviewFilter(
                 ExpertiseRepository.ApplyTenantFilter(db.ExpertiseEntries, Ctx()))
             .Where(e => e.Embedding != null)
@@ -136,7 +136,7 @@ public class RepositoryQueryTranslationTests
     public void FindNearestInDomain_CosineDistanceOrdering_Translates()
     {
         using var db = NewContext();
-        var vector = new Vector(new float[384]);
+        var vector = new Vector(new float[512]);
         var query = ExpertiseRepository.ApplyTenantFilter(db.ExpertiseEntries, Ctx())
             .Where(e => e.DeprecatedAt == null)
             .Where(e => e.ReviewState != ReviewState.Rejected)
@@ -253,7 +253,7 @@ public class RepositoryQueryTranslationTests
     {
         using var db = NewContext();
         var tags = new List<string> { "postgres", "ef-core" };
-        var queryVector = new Vector(new float[384]);
+        var queryVector = new Vector(new float[512]);
 
         // Mirrors the production SemanticSearchAsync composition: shared tenant+approved
         // seam -> ApplyMetadataFilters (shared with BuildListQuery, #426) -> pgvector

--- a/tests/install/test-download-models.sh
+++ b/tests/install/test-download-models.sh
@@ -9,8 +9,9 @@
 #
 # Covers:
 #   1. stale oversized file → "re-downloading" path taken (not the old
-#      "Delete the file and re-run" abort), and a bad downloaded payload still
-#      aborts via the post-download checksum gate
+#      "Delete the file and re-run" abort); a bad downloaded payload aborts via
+#      the TEMP-FILE checksum gate, the previous file is left untouched
+#      (verify-before-move — review finding 2026-07-23), and no temp files leak
 #   2. missing file + failing network → clean download-failure abort
 #   3. undersized file → existing "suspiciously small" re-download path intact
 #
@@ -82,18 +83,26 @@ else
   fail "stale file: expected 're-downloading' in output, got: $out1"
 fi
 
-if printf '%s' "$out1" | grep -q "checksum mismatch" && [ "$rc1" -ne 0 ]; then
-  ok "bad downloaded payload still aborts via post-download checksum gate (rc=$rc1)"
+if printf '%s' "$out1" | grep -q "failed checksum" && [ "$rc1" -ne 0 ]; then
+  ok "bad downloaded payload aborts via the temp-file checksum gate (rc=$rc1)"
 else
-  fail "post-download gate: expected checksum-mismatch abort, rc=$rc1, output: $out1"
+  fail "download gate: expected temp-file checksum abort, rc=$rc1, output: $out1"
 fi
 
-# The stale file must have been REPLACED by the downloaded payload (all-x),
-# proving the download actually ran rather than the old abort-in-place.
+# Verify-before-move: the failed download must NOT have replaced the existing
+# file (its zero-byte content must survive; the stub payload is all 'x').
 if grep -q 'xxxx' "${DEST1}/model.onnx" 2>/dev/null; then
-  ok "stale file was replaced by the re-downloaded payload"
+  fail "destination was overwritten by an unverified payload (mv-before-verify regression)"
 else
-  fail "stale file content unchanged — re-download never wrote the destination"
+  ok "previous file left untouched after failed re-download"
+fi
+
+# And the rejected temp file must have been cleaned up.
+leftover=$(find "${DEST1}" -name 'model.onnx.*' | wc -l | tr -d ' ')
+if [ "$leftover" = "0" ]; then
+  ok "no temp files leaked after checksum rejection"
+else
+  fail "found $leftover leftover temp file(s) in ${DEST1}"
 fi
 
 # --- 2. missing file + network failure --------------------------------------

--- a/tests/install/test-download-models.sh
+++ b/tests/install/test-download-models.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# tests/install/test-download-models.sh — regression tests for #456:
+# download-models.sh must RE-DOWNLOAD an existing file whose checksum does not
+# match the pinned SHA-256 (stale model after a version bump, or corruption)
+# instead of hard-erroring, so install.sh's ensure_models can unconditionally
+# delegate to it on upgrade installs. The post-download checksum verification
+# must remain a hard gate.
+#
+# Covers:
+#   1. stale oversized file → "re-downloading" path taken (not the old
+#      "Delete the file and re-run" abort), and a bad downloaded payload still
+#      aborts via the post-download checksum gate
+#   2. missing file + failing network → clean download-failure abort
+#   3. undersized file → existing "suspiciously small" re-download path intact
+#
+# Runs under bash 3.2 (macOS /bin/bash) and newer bash.
+# Follows script-output conventions (OK/ERROR labels, PASS/FAIL summary).
+#
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+TARGET="${SCRIPT_DIR}/scripts/download-models.sh"
+
+[ -f "$TARGET" ] || { echo "ERROR [test-download-models] ${TARGET} not found" >&2; exit 2; }
+
+PASS=0
+FAIL=0
+ok()   { PASS=$((PASS+1)); printf 'OK    %s\n' "$1"; }
+fail() { FAIL=$((FAIL+1)); printf 'ERROR %s\n' "$1" >&2; }
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# Stub curl on PATH. Behavior is selected via CURL_STUB_MODE:
+#   fail    → exit 1 (network down)
+#   garbage → write >=1MB of junk to the -o target, exit 0
+STUB_BIN="${TMP_ROOT}/bin"
+mkdir -p "$STUB_BIN"
+cat > "${STUB_BIN}/curl" <<'EOF'
+#!/usr/bin/env bash
+out=""
+prev=""
+for a in "$@"; do
+  [ "$prev" = "-o" ] && out="$a"
+  prev="$a"
+done
+case "${CURL_STUB_MODE:-fail}" in
+  garbage)
+    [ -n "$out" ] || exit 1
+    dd if=/dev/zero bs=1024 count=2048 2>/dev/null | tr '\0' 'x' > "$out"
+    exit 0
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${STUB_BIN}/curl"
+
+run_script() {
+  # Args: <dest_dir> <curl_mode>. Prints combined output; returns script's exit.
+  DEST_DIR="$1" CURL_STUB_MODE="$2" PATH="${STUB_BIN}:${PATH}" \
+    bash "$TARGET" 2>&1
+}
+
+# --- 1. stale oversized file: re-download path + post-download hard gate ----
+DEST1="${TMP_ROOT}/case1"
+mkdir -p "$DEST1"
+# >= 1 MiB so it passes the size check and reaches the checksum comparison,
+# but with content that cannot match the pinned SHA-256.
+dd if=/dev/zero of="${DEST1}/model.onnx" bs=1024 count=2048 2>/dev/null
+printf 'stale' >> "${DEST1}/model.onnx"
+
+out1="$(run_script "$DEST1" garbage)"
+rc1=$?
+
+if printf '%s' "$out1" | grep -q "stale or corrupt; re-downloading"; then
+  ok "stale file takes the re-download path"
+else
+  fail "stale file: expected 're-downloading' in output, got: $out1"
+fi
+
+if printf '%s' "$out1" | grep -q "checksum mismatch" && [ "$rc1" -ne 0 ]; then
+  ok "bad downloaded payload still aborts via post-download checksum gate (rc=$rc1)"
+else
+  fail "post-download gate: expected checksum-mismatch abort, rc=$rc1, output: $out1"
+fi
+
+# The stale file must have been REPLACED by the downloaded payload (all-x),
+# proving the download actually ran rather than the old abort-in-place.
+if grep -q 'xxxx' "${DEST1}/model.onnx" 2>/dev/null; then
+  ok "stale file was replaced by the re-downloaded payload"
+else
+  fail "stale file content unchanged — re-download never wrote the destination"
+fi
+
+# --- 2. missing file + network failure --------------------------------------
+DEST2="${TMP_ROOT}/case2"
+mkdir -p "$DEST2"
+out2="$(run_script "$DEST2" fail)"
+rc2=$?
+if [ "$rc2" -ne 0 ] && printf '%s' "$out2" | grep -q "Failed to download"; then
+  ok "missing file with failing network aborts cleanly (rc=$rc2)"
+else
+  fail "missing-file case: expected download-failure abort, rc=$rc2, output: $out2"
+fi
+
+# --- 3. undersized existing file keeps the re-download path -----------------
+DEST3="${TMP_ROOT}/case3"
+mkdir -p "$DEST3"
+printf 'tiny' > "${DEST3}/model.onnx"
+out3="$(run_script "$DEST3" fail)"
+rc3=$?
+if printf '%s' "$out3" | grep -q "suspiciously small" && [ "$rc3" -ne 0 ]; then
+  ok "undersized file still routes to re-download ('suspiciously small')"
+else
+  fail "undersized case: expected 'suspiciously small' path, rc=$rc3, output: $out3"
+fi
+
+# --- summary ----------------------------------------------------------------
+echo "=================================="
+if [ "$FAIL" -eq 0 ]; then
+  echo "PASS — 0 errors ($PASS checks)"
+  exit 0
+else
+  echo "FAIL — $FAIL errors, $PASS passed"
+  exit 1
+fi


### PR DESCRIPTION
Promotes the #437 model-swap train: PR #459 (prerequisites: #455 metadata upsert + singleton guard, #456 stale-model refresh), #460 (window-aware needle eval gate), #461 (ADR-017 swap: jina-embeddings-v2-small-en, MaximumTokens=6144, vector(512) migration, caps 16000/200), #462 (full-review findings: inference concurrency gate, atomic model download, symlink guard, drift test, doc corrections).

Expected bump: MINOR → v1.6.0 (feat #461).

Post-release operator sequence (ADR-017): backup → stop → install.sh --from-release → expertise-apictl reembed → verify. No binary rollback after the migration commits — backup is the rollback path.

**Merge with a merge commit, not squash** (github-flow: promotions preserve shared SHAs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)