### PR TITLE
fix(skill): support EXPERTISE_API_TOKEN_FILE token indirection

### DIFF
--- a/.agents/skills/expertise-api/SKILL.md
+++ b/.agents/skills/expertise-api/SKILL.md
@@ -17,23 +17,26 @@ Do **not** invoke this skill for: API design questions, schema decisions, scope-
 
 ## Prerequisites
 
-The skill scripts require two environment variables. The skill will fail loudly if either is missing.
+The skill scripts require a base URL and a bearer token. The skill will fail loudly if either is missing.
 
 | Variable | Purpose | Example |
 | --- | --- | --- |
 | `EXPERTISE_API_BASE_URL` | Origin of the API. No trailing slash. | `https://expertise.example.com` |
-| `EXPERTISE_API_TOKEN` | Bearer token. JWT for OIDC mode, or `dev:{tenant}:{scopes}` for LocalDev. | `dev:teamA:expertise.read+expertise.write.draft` |
+| `EXPERTISE_API_TOKEN` | Bearer token. JWT for OIDC mode, or `dev:{tenant}:{scopes}` for LocalDev. Wins over `EXPERTISE_API_TOKEN_FILE` when both are set. | `dev:teamA:expertise.read+expertise.write.draft` |
+| `EXPERTISE_API_TOKEN_FILE` | Path to a file holding the token (trailing newline stripped). Used when `EXPERTISE_API_TOKEN` is unset. **Recommended** — keeps the bearer literal out of the env file. | `~/tokens/expertise.jwt` |
 
-If the user has not set them, prompt for the values once and offer to write them to `~/.config/expertise-api/secrets.env`:
+If the user has not set them, prompt for the values once and offer to write them to `~/.config/expertise-api/secrets.env`. Prefer the token-file form:
 
 ```sh
 mkdir -p ~/.config/expertise-api
 cat > ~/.config/expertise-api/secrets.env <<'EOF'
 EXPERTISE_API_BASE_URL=https://expertise.example.com
-EXPERTISE_API_TOKEN=...
+EXPERTISE_API_TOKEN_FILE=/path/to/token.jwt
 EOF
 chmod 600 ~/.config/expertise-api/secrets.env
 ```
+
+(Inlining `EXPERTISE_API_TOKEN=...` instead also works; the file indirection just avoids a secret literal that secret scanners and session guards would otherwise flag.)
 
 The scripts source this file automatically when present, so env vars do not need to be exported per-shell.
 

--- a/.agents/skills/expertise-api/scripts/lib/common.sh
+++ b/.agents/skills/expertise-api/scripts/lib/common.sh
@@ -9,6 +9,13 @@
 # Provides:
 #   - load_secrets       Source ~/.config/expertise-api/secrets.env if present.
 #   - require_env        Fail loudly if EXPERTISE_API_BASE_URL/_TOKEN unset.
+#                        Resolves EXPERTISE_API_TOKEN_FILE indirection first
+#                        (issue #464): when EXPERTISE_API_TOKEN is empty and
+#                        EXPERTISE_API_TOKEN_FILE names a readable non-empty
+#                        file, the token is read from that file. Token-by-path
+#                        is the recommended contract for agent hosts — no
+#                        bearer literal sits in an env file for scanners or
+#                        session hooks to trip on.
 #   - api_curl ARGS...   Wrap curl with -sS, Bearer auth, and HTTP-status check.
 #                        Writes response body to stdout. On non-2xx, writes the
 #                        body to stderr along with the status line and exits 1.
@@ -46,14 +53,49 @@ load_secrets() {
     fi
 }
 
+# _resolve_token
+# Resolution ladder (issue #464), mirrored by the pi extension's
+# resolveToken() in .pi/extensions/expertise-api/index.ts:
+#   1. EXPERTISE_API_TOKEN set and non-empty       -> wins (explicit beats
+#      indirection, the standard *_FILE convention).
+#   2. EXPERTISE_API_TOKEN_FILE set                -> read the file; trailing
+#      newline/whitespace stripped. A missing, unreadable, or empty file is a
+#      hard exit 2 naming the path — never a silent fall-through to "not set",
+#      which would misdiagnose a bad path as absent configuration.
+#   3. Neither                                     -> leave unset; require_env
+#      reports both variables.
+_resolve_token() {
+    if [ -n "${EXPERTISE_API_TOKEN:-}" ]; then
+        return 0
+    fi
+    if [ -z "${EXPERTISE_API_TOKEN_FILE:-}" ]; then
+        return 0
+    fi
+    if [ ! -f "$EXPERTISE_API_TOKEN_FILE" ] || [ ! -r "$EXPERTISE_API_TOKEN_FILE" ]; then
+        echo "error: EXPERTISE_API_TOKEN_FILE points to a missing or unreadable file: ${EXPERTISE_API_TOKEN_FILE}" >&2
+        exit 2
+    fi
+    # $(cat ...) strips trailing newlines; the extra trim handles a file whose
+    # last line carries trailing spaces/tabs (e.g. hand-edited token files).
+    EXPERTISE_API_TOKEN="$(cat "$EXPERTISE_API_TOKEN_FILE")"
+    while [ "${EXPERTISE_API_TOKEN%[[:space:]]}" != "$EXPERTISE_API_TOKEN" ]; do
+        EXPERTISE_API_TOKEN="${EXPERTISE_API_TOKEN%[[:space:]]}"
+    done
+    if [ -z "$EXPERTISE_API_TOKEN" ]; then
+        echo "error: EXPERTISE_API_TOKEN_FILE is empty: ${EXPERTISE_API_TOKEN_FILE}" >&2
+        exit 2
+    fi
+}
+
 require_env() {
+    _resolve_token
     local missing=0
     if [ -z "${EXPERTISE_API_BASE_URL:-}" ]; then
         echo "error: EXPERTISE_API_BASE_URL is not set" >&2
         missing=1
     fi
     if [ -z "${EXPERTISE_API_TOKEN:-}" ]; then
-        echo "error: EXPERTISE_API_TOKEN is not set" >&2
+        echo "error: EXPERTISE_API_TOKEN is not set (set it, or point EXPERTISE_API_TOKEN_FILE at a token file)" >&2
         missing=1
     fi
     if [ "$missing" -ne 0 ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,9 @@ jobs:
       - name: Run model-download staleness tests (#456)
         run: bash tests/install/test-download-models.sh
 
+      - name: Run skill token-file resolution tests (#464)
+        run: bash tests/skill/test-common-token-file.sh
+
   install-script-guards:
     name: install/uninstall script guard tests (#242)
     runs-on: ubuntu-latest

--- a/.pi/extensions/expertise-api/README.md
+++ b/.pi/extensions/expertise-api/README.md
@@ -46,10 +46,14 @@ Same as the action skill. Set either via shell environment or
 mkdir -p ~/.config/expertise-api
 cat > ~/.config/expertise-api/secrets.env <<'EOF'
 EXPERTISE_API_BASE_URL=https://expertise.example.com
-EXPERTISE_API_TOKEN=...
+EXPERTISE_API_TOKEN_FILE=/path/to/token.jwt
 EOF
 chmod 600 ~/.config/expertise-api/secrets.env
 ```
+
+`EXPERTISE_API_TOKEN_FILE` (recommended) points at a file holding the token —
+no bearer literal in the env file. Setting `EXPERTISE_API_TOKEN=...` directly
+also works and wins when both are present (#464).
 
 The token reaches `fetch()` via an HTTP header — it is **not** visible in `ps`/`/proc` like the skill's `curl`-based path.
 

--- a/.pi/extensions/expertise-api/index.ts
+++ b/.pi/extensions/expertise-api/index.ts
@@ -10,8 +10,12 @@
  * this extension is the native pi path.
  *
  * Env contract (same as the skill):
- *   EXPERTISE_API_BASE_URL  Origin of the API (no trailing slash).
- *   EXPERTISE_API_TOKEN     Bearer token: OIDC JWT or LocalDev "dev:t:s+s".
+ *   EXPERTISE_API_BASE_URL    Origin of the API (no trailing slash).
+ *   EXPERTISE_API_TOKEN       Bearer token: OIDC JWT or LocalDev "dev:t:s+s".
+ *   EXPERTISE_API_TOKEN_FILE  Path to a file holding the token (issue #464).
+ *                             Used when EXPERTISE_API_TOKEN is unset/empty;
+ *                             recommended on agent hosts so no bearer literal
+ *                             sits in an env file.
  *
  * Auto-sources ~/.config/expertise-api/secrets.env (or
  * $EXPERTISE_API_SECRETS_FILE) on extension load.
@@ -158,14 +162,56 @@ function getBaseUrl(): string {
 	return normalised;
 }
 
-function getToken(): string {
-	const tok = process.env.EXPERTISE_API_TOKEN;
-	if (!tok || tok.trim() === "") {
-		throw new Error(
-			"EXPERTISE_API_TOKEN is not set. Export it or write it to ~/.config/expertise-api/secrets.env.",
-		);
+/**
+ * Resolve the bearer token (issue #464). Mirrors the skill's
+ * _resolve_token in .agents/skills/expertise-api/scripts/lib/common.sh:
+ *
+ *   1. EXPERTISE_API_TOKEN set and non-empty -> wins (explicit beats
+ *      indirection, the standard *_FILE convention).
+ *   2. EXPERTISE_API_TOKEN_FILE set -> read the file, trim trailing
+ *      whitespace. A missing, unreadable, or empty file throws naming the
+ *      path — never a silent fall-through to "not set", which would
+ *      misdiagnose a bad path as absent configuration.
+ *   3. Neither -> throw naming both variables.
+ *
+ * Re-read on every call (one API call each) so a rotated token file is
+ * picked up without restarting the extension. Exported (vs inlined into
+ * apiCall) so unit tests can assert the ladder without mocking fetch;
+ * `env` is injectable for the same reason and defaults to process.env.
+ */
+export function resolveToken(
+	env: Record<string, string | undefined> = process.env,
+): string {
+	const tok = env.EXPERTISE_API_TOKEN;
+	if (tok && tok.trim() !== "") {
+		return tok;
 	}
-	return tok;
+	let tokenFile = env.EXPERTISE_API_TOKEN_FILE;
+	if (tokenFile && tokenFile.trim() !== "") {
+		// secrets.env is shared with the shell skill, where `VAR=~/path` is a
+		// shell assignment and the tilde expands. This loader parses the file
+		// as plain text, so expand a leading `~/` here for parity — otherwise
+		// the same secrets.env works under the skill and fails under pi.
+		if (tokenFile.startsWith("~/")) {
+			tokenFile = path.join(os.homedir(), tokenFile.slice(2));
+		}
+		let contents: string;
+		try {
+			contents = fs.readFileSync(tokenFile, "utf8");
+		} catch {
+			throw new Error(
+				`EXPERTISE_API_TOKEN_FILE points to a missing or unreadable file: ${tokenFile}`,
+			);
+		}
+		const fileToken = contents.trimEnd();
+		if (fileToken === "") {
+			throw new Error(`EXPERTISE_API_TOKEN_FILE is empty: ${tokenFile}`);
+		}
+		return fileToken;
+	}
+	throw new Error(
+		"EXPERTISE_API_TOKEN is not set (set it, or point EXPERTISE_API_TOKEN_FILE at a token file). Write either to ~/.config/expertise-api/secrets.env.",
+	);
 }
 
 async function apiCall(
@@ -174,7 +220,7 @@ async function apiCall(
 	signal?: AbortSignal,
 ): Promise<ApiCallResult> {
 	const base: string = getBaseUrl();
-	const token: string = getToken();
+	const token: string = resolveToken();
 	const url: string = `${base}${pathAndQuery}`;
 	const headers: Headers = new Headers(init.headers ?? {});
 	headers.set("Authorization", `Bearer ${token}`);

--- a/.pi/extensions/expertise-api/package.json
+++ b/.pi/extensions/expertise-api/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "test": "node --import tsx --test apiCall.test.ts"
+    "test": "node --import tsx --test apiCall.test.ts resolveToken.test.ts"
   },
   "devDependencies": {
     "@earendil-works/pi-ai": "0.81.1",

--- a/.pi/extensions/expertise-api/resolveToken.test.ts
+++ b/.pi/extensions/expertise-api/resolveToken.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for resolveToken (issue #464).
+ *
+ * Runs via `node --test` (same harness as apiCall.test.ts). The env is
+ * injected as a plain object, so no process.env mutation and no fetch
+ * mocking is needed; the file cases use real temp files.
+ *
+ * Contract being asserted (mirrors the skill's _resolve_token in
+ * .agents/skills/expertise-api/scripts/lib/common.sh):
+ *   1. EXPERTISE_API_TOKEN set and non-empty wins over the file.
+ *   2. EXPERTISE_API_TOKEN_FILE is read when the token is unset/empty,
+ *      with trailing whitespace stripped.
+ *   3. Missing/unreadable file throws naming the path (no silent
+ *      fall-through to "not set").
+ *   4. Empty file throws.
+ *   5. Neither variable set throws naming both variables.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { resolveToken } from "./index.js";
+
+const workDir: string = fs.mkdtempSync(path.join(os.tmpdir(), "resolve-token-"));
+process.on("exit", () => {
+	fs.rmSync(workDir, { recursive: true, force: true });
+});
+
+test("resolveToken: reads the token from EXPERTISE_API_TOKEN_FILE", () => {
+	const tokenFile = path.join(workDir, "token1");
+	fs.writeFileSync(tokenFile, "file-token-value\n");
+	assert.equal(
+		resolveToken({ EXPERTISE_API_TOKEN_FILE: tokenFile }),
+		"file-token-value",
+	);
+});
+
+test("resolveToken: explicit EXPERTISE_API_TOKEN beats the file", () => {
+	const tokenFile = path.join(workDir, "token2");
+	fs.writeFileSync(tokenFile, "file-token-value\n");
+	assert.equal(
+		resolveToken({
+			EXPERTISE_API_TOKEN: "explicit-wins",
+			EXPERTISE_API_TOKEN_FILE: tokenFile,
+		}),
+		"explicit-wins",
+	);
+});
+
+test("resolveToken: whitespace-only EXPERTISE_API_TOKEN falls through to the file", () => {
+	const tokenFile = path.join(workDir, "token3");
+	fs.writeFileSync(tokenFile, "file-token-value\n");
+	assert.equal(
+		resolveToken({
+			EXPERTISE_API_TOKEN: "   ",
+			EXPERTISE_API_TOKEN_FILE: tokenFile,
+		}),
+		"file-token-value",
+	);
+});
+
+test("resolveToken: missing file throws naming the path", () => {
+	const missing = path.join(workDir, "does-not-exist");
+	assert.throws(
+		() => resolveToken({ EXPERTISE_API_TOKEN_FILE: missing }),
+		new RegExp(`missing or unreadable file: .*does-not-exist`),
+	);
+});
+
+test("resolveToken: empty file throws", () => {
+	const emptyFile = path.join(workDir, "empty");
+	fs.writeFileSync(emptyFile, "");
+	assert.throws(
+		() => resolveToken({ EXPERTISE_API_TOKEN_FILE: emptyFile }),
+		/EXPERTISE_API_TOKEN_FILE is empty/,
+	);
+});
+
+test("resolveToken: whitespace-only file content throws as empty", () => {
+	const blankFile = path.join(workDir, "blank");
+	fs.writeFileSync(blankFile, " \t\n");
+	assert.throws(
+		() => resolveToken({ EXPERTISE_API_TOKEN_FILE: blankFile }),
+		/EXPERTISE_API_TOKEN_FILE is empty/,
+	);
+});
+
+test("resolveToken: trailing whitespace stripped from file token", () => {
+	const paddedFile = path.join(workDir, "padded");
+	fs.writeFileSync(paddedFile, "padded-token \t\n\n");
+	assert.equal(
+		resolveToken({ EXPERTISE_API_TOKEN_FILE: paddedFile }),
+		"padded-token",
+	);
+});
+
+test("resolveToken: leading ~/ in the file path expands to the home directory", () => {
+	// Parity with the shell skill, where secrets.env is sourced and
+	// `VAR=~/path` tilde-expands. Uses a real file under os.homedir() so the
+	// expansion is exercised end-to-end, then cleans it up.
+	const relName = `.resolve-token-test-${process.pid}.jwt`;
+	const realPath = path.join(os.homedir(), relName);
+	fs.writeFileSync(realPath, "tilde-token\n");
+	try {
+		assert.equal(
+			resolveToken({ EXPERTISE_API_TOKEN_FILE: `~/${relName}` }),
+			"tilde-token",
+		);
+	} finally {
+		fs.rmSync(realPath, { force: true });
+	}
+});
+
+test("resolveToken: neither variable set throws naming both", () => {
+	assert.throws(
+		() => resolveToken({}),
+		/EXPERTISE_API_TOKEN is not set \(set it, or point EXPERTISE_API_TOKEN_FILE/,
+	);
+});

--- a/.pi/extensions/expertise-api/tsconfig.json
+++ b/.pi/extensions/expertise-api/tsconfig.json
@@ -15,5 +15,5 @@
     "allowImportingTsExtensions": false,
     "noEmit": true
   },
-  "include": ["index.ts", "apiCall.test.ts"]
+  "include": ["index.ts", "apiCall.test.ts", "resolveToken.test.ts"]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,12 +193,12 @@ Env contract used by every script in the skill:
 mkdir -p ~/.config/expertise-api
 cat > ~/.config/expertise-api/secrets.env <<'EOF'
 EXPERTISE_API_BASE_URL=https://expertise.example.com
-EXPERTISE_API_TOKEN=...
+EXPERTISE_API_TOKEN_FILE=/path/to/token.jwt
 EOF
 chmod 600 ~/.config/expertise-api/secrets.env
 ```
 
-The scripts source that file automatically when present — no per-shell exports needed.
+The scripts source that file automatically when present — no per-shell exports needed. `EXPERTISE_API_TOKEN_FILE` (recommended, #464) points at a file holding the token so no bearer literal sits in the env file; `EXPERTISE_API_TOKEN=...` inline also works and wins when both are set. Both the skill scripts and the pi extension honor the indirection.
 
 ## Native OS service install (Archetype A2)
 

--- a/README.md
+++ b/README.md
@@ -160,12 +160,12 @@ Env contract for all three harnesses:
 mkdir -p ~/.config/expertise-api
 cat > ~/.config/expertise-api/secrets.env <<'EOF'
 EXPERTISE_API_BASE_URL=https://expertise.example.com
-EXPERTISE_API_TOKEN=...
+EXPERTISE_API_TOKEN_FILE=/path/to/token.jwt
 EOF
 chmod 600 ~/.config/expertise-api/secrets.env
 ```
 
-The scripts source that file automatically, so env vars do not need to be exported per shell. See the skill's [`SKILL.md`](.agents/skills/expertise-api/SKILL.md) for the full toolkit (`search`, `search-semantic`, `get`, `create`, `approve`, `reject`) and `references/DESIGN.md` for the underlying scope hierarchy and approval state machine.
+The scripts source that file automatically, so env vars do not need to be exported per shell. `EXPERTISE_API_TOKEN_FILE` (recommended, #464) keeps the bearer literal out of the env file; setting `EXPERTISE_API_TOKEN=...` directly also works and wins when both are present. See the skill's [`SKILL.md`](.agents/skills/expertise-api/SKILL.md) for the full toolkit (`search`, `search-semantic`, `get`, `create`, `approve`, `reject`) and `references/DESIGN.md` for the underlying scope hierarchy and approval state machine.
 
 ### Response hygiene
 

--- a/tests/skill/test-common-token-file.sh
+++ b/tests/skill/test-common-token-file.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# tests/skill/test-common-token-file.sh
+#
+# Unit tests for the EXPERTISE_API_TOKEN_FILE resolution ladder in
+# .agents/skills/expertise-api/scripts/lib/common.sh (issue #464).
+#
+# Each case runs require_env in a subshell with a controlled environment and
+# asserts on the resolved token / exit code / stderr. No network, no API.
+#
+# Usage: bash tests/skill/test-common-token-file.sh
+# Exit codes: 0 all cases pass, 1 one or more cases fail.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+COMMON_SH="${REPO_ROOT}/.agents/skills/expertise-api/scripts/lib/common.sh"
+
+WORK_DIR="$(mktemp -d -t skill-token-test.XXXXXX)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+errors=0
+ok()   { printf 'OK    [%s] %s\n' "$1" "$2"; }
+err()  { printf 'ERROR [%s] %s\n' "$1" "$2" >&2; errors=$((errors + 1)); }
+
+# run_require_env NAME [VAR=VALUE ...]
+# Sources common.sh with a scrubbed env plus the given assignments, runs
+# require_env, and prints "<exit>|<resolved-token>" for the caller to assert.
+run_require_env() {
+    shift # NAME is for the caller's bookkeeping only
+    # shellcheck disable=SC2016  # deliberate: $? / $EXPERTISE_API_TOKEN must expand in the INNER shell
+    env -i HOME="$WORK_DIR" PATH="$PATH" "$@" bash -c '
+        . "'"$COMMON_SH"'"
+        require_env >/dev/null 2>"'"$WORK_DIR"'/stderr"
+        printf "%s|%s" "$?" "$EXPERTISE_API_TOKEN"
+    ' 2>>"$WORK_DIR/stderr" || printf '%s|' "$?"
+}
+
+BASE="EXPERTISE_API_BASE_URL=https://api.example.test"
+
+# --- case 1: file-only resolves the token -----------------------------------
+printf 'file-token-value\n' > "$WORK_DIR/token1"
+result="$(run_require_env case1 "$BASE" EXPERTISE_API_TOKEN_FILE="$WORK_DIR/token1")"
+if [ "$result" = "0|file-token-value" ]; then
+    ok token-file-resolves "token read from EXPERTISE_API_TOKEN_FILE"
+else
+    err token-file-resolves "expected '0|file-token-value', got '$result'"
+fi
+
+# --- case 2: explicit token beats the file ----------------------------------
+result="$(run_require_env case2 "$BASE" EXPERTISE_API_TOKEN=explicit-wins EXPERTISE_API_TOKEN_FILE="$WORK_DIR/token1")"
+if [ "$result" = "0|explicit-wins" ]; then
+    ok explicit-wins "EXPERTISE_API_TOKEN takes precedence over the file"
+else
+    err explicit-wins "expected '0|explicit-wins', got '$result'"
+fi
+
+# --- case 3: missing file is a hard exit 2 naming the path ------------------
+result="$(run_require_env case3 "$BASE" EXPERTISE_API_TOKEN_FILE="$WORK_DIR/does-not-exist")"
+if [ "$result" = "2|" ] && grep -q "missing or unreadable file: ${WORK_DIR}/does-not-exist" "$WORK_DIR/stderr"; then
+    ok missing-file "missing token file exits 2 and names the path"
+else
+    err missing-file "expected exit 2 + path in stderr, got '$result' / $(tr '\n' ' ' < "$WORK_DIR/stderr")"
+fi
+
+# --- case 4: empty file is a hard exit 2 -------------------------------------
+: > "$WORK_DIR/empty"
+result="$(run_require_env case4 "$BASE" EXPERTISE_API_TOKEN_FILE="$WORK_DIR/empty")"
+if [ "$result" = "2|" ] && grep -q "EXPERTISE_API_TOKEN_FILE is empty" "$WORK_DIR/stderr"; then
+    ok empty-file "empty token file exits 2"
+else
+    err empty-file "expected exit 2 + empty-file message, got '$result' / $(tr '\n' ' ' < "$WORK_DIR/stderr")"
+fi
+
+# --- case 5: neither variable set names both in the error --------------------
+result="$(run_require_env case5 "$BASE")"
+if [ "$result" = "2|" ] && grep -q "EXPERTISE_API_TOKEN is not set (set it, or point EXPERTISE_API_TOKEN_FILE" "$WORK_DIR/stderr"; then
+    ok neither-set "unset token errors naming both variables"
+else
+    err neither-set "expected exit 2 + both-variable message, got '$result' / $(tr '\n' ' ' < "$WORK_DIR/stderr")"
+fi
+
+# --- case 6: trailing newline and whitespace stripped -------------------------
+printf 'padded-token \t\n\n' > "$WORK_DIR/token-padded"
+result="$(run_require_env case6 "$BASE" EXPERTISE_API_TOKEN_FILE="$WORK_DIR/token-padded")"
+if [ "$result" = "0|padded-token" ]; then
+    ok trailing-trim "trailing whitespace/newlines stripped from file token"
+else
+    err trailing-trim "expected '0|padded-token', got '$result'"
+fi
+
+echo "=================================="
+if [ "$errors" -eq 0 ]; then
+    echo "PASS — 0 errors"
+    exit 0
+fi
+echo "FAIL — ${errors} errors"
+exit 1


### PR DESCRIPTION
## Summary

Closes #464. Both token consumers — the skill's `common.sh` and the pi extension — only read `EXPERTISE_API_TOKEN`, so a `secrets.env` using path indirection (`EXPERTISE_API_TOKEN_FILE=/path/to/token.jwt`) failed with "token is not set". Found during the v1.6.0 post-upgrade verification, where every skill script errored until the token was resolved inline.

## Changes

- **`common.sh`**: new `_resolve_token()` called from `require_env`. Ladder: explicit `EXPERTISE_API_TOKEN` wins → else read `EXPERTISE_API_TOKEN_FILE` (trailing whitespace stripped; missing/unreadable/empty file is a hard exit 2 naming the path, never a silent fall-through) → else error naming both variables.
- **pi extension**: `getToken()` → exported `resolveToken(env)` implementing the same ladder via `readFileSync` + trim, re-read per API call so token rotation needs no restart. Also expands a leading `~/` for parity with shell sourcing of the shared `secrets.env`.
- **Docs**: SKILL.md, CLAUDE.md, README.md, and the pi extension README now show the token-file form as the recommended setup — no bearer literal in the env file for scanners or session guards to trip on. Deliberately no `EXPERTISE_API_BASE_URL_FILE`: the base URL is not a secret.

## Tests

- `tests/skill/test-common-token-file.sh` — 6 cases (file resolves / explicit wins / missing file exit 2 / empty file exit 2 / neither set names both vars / trailing trim), wired as a `ci.yml` step alongside the other single-script suites.
- `resolveToken.test.ts` — 9 cases covering the same ladder plus whitespace-only token fall-through and `~/` expansion; added to `npm test` and the `tsc --noEmit` include list.

## Doc-impact

| Surface | Classification |
|---|---|
| SKILL.md env table + setup block | in-scope (updated) |
| CLAUDE.md env-contract block | in-scope (updated) |
| README.md agent-integration block | in-scope (updated) |
| pi extension README env block | in-scope (updated) |
| ADR | not-a-thing — additive option following the standard `*_FILE` convention |

Per-task gate: shellcheck clean (both shell files), actionlint clean, `npm run typecheck` + 23/23 extension tests, 6/6 shell test cases, markdownlint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)