### PR TITLE
fix(dedup): retune semantic threshold for the jina embedding space

### DIFF
--- a/adrs/017-embedding-model-swap.md
+++ b/adrs/017-embedding-model-swap.md
@@ -127,7 +127,8 @@ reembed — embeddings are regenerable, content is the source of truth) or full
 
 - `Deduplication:SemanticThreshold = 0.10` was calibrated to bge's distance
   geometry; it is re-derived against the jina space after the production
-  reembed (#457). Until then dedup under-fires only.
+  reembed (#457). Until then dedup under-fires only. *(Resolved — see
+  Amendment 1 below: retuned to 0.05 on 2026-07-24.)*
 - The eval gates (`RetrievalEvalTests`, window-aware `NeedleEvalTests`, #437
   PR-B) are the merge gate for this and any future retrieval change; they are
   `EXPERTISE_EVAL=1` opt-in, so running them is a release-checklist step, not
@@ -136,6 +137,37 @@ reembed — embeddings are regenerable, content is the source of truth) or full
   keyed on `download-models.sh` (added with #456's fix).
 - Helm/k8s resource sizing is NOT covered — tracked in #458; A2 native service
   remains the hosting model of record.
+
+## Amendment 1 (2026-07-24): `Deduplication:SemanticThreshold` retuned 0.10 → 0.05 (#457)
+
+The Consequences section deferred the dedup-threshold retune to #457, gated on
+the production reembed. Measured on the live corpus (604 approved embedded
+entries, within-domain nearest-neighbor cosine distances over the stored
+jina-v2-small vectors, pgvector `<=>`):
+
+- **True duplicates cluster at ≈ 0** — 131 entries with NN distance < 0.01,
+  130/131 with byte-identical bodies (accumulated while dedup under-fired,
+  e.g. during the swap's NULL-embedding window).
+- **Hand-labeled near-dups (retitles/light rewordings of the same fact)
+  extend to ≤ 0.048**; the valley 0.01–0.05 holds only 6 entries, all labeled
+  near-dup.
+- **The closest genuinely distinct same-domain neighbors begin at ≈ 0.051**,
+  with the distinct mass at 0.06–0.13 peaking around 0.10–0.13. The bge-era
+  0.10 default sits INSIDE that mass: 272/604 entries (45%) have a legitimate
+  distinct neighbor within 0.10, i.e. under jina geometry 0.10 would false-409
+  roughly half of comparable future submissions.
+- Synthetic pair measurement with the real model (`DedupThresholdEvalTests`)
+  agrees: light rewordings 0.016–0.048, moderate rewordings 0.052–0.065, full
+  paraphrases 0.13–0.16, distinct same-topic pairs ≥ 0.12.
+
+**Decision: 0.05** — the valley midpoint. Biased low deliberately: a false 409
+rejects a legitimate write (the costly, user-visible failure); a missed
+near-dup lands as a Draft in the curator review queue (noise). Moderate and
+full rewordings of the same fact are accepted under-fire — they are
+geometrically inseparable from distinct entries under this model. Changes to
+the threshold or model must re-run `EXPERTISE_EVAL=1
+dotnet test --filter DedupThresholdEval` and re-derive against the live corpus
+per the method above (recorded in #457).
 
 ## Related
 

--- a/docs/testing-and-coverage.md
+++ b/docs/testing-and-coverage.md
@@ -64,14 +64,15 @@ cannot drift from production.
 The test embedding generator seeds each vector from a **stable FNV hash of the input
 content** (not `string.GetHashCode`, which is randomized per process). Identical content
 yields the identical vector (cosine distance 0 → a real duplicate); distinct content yields
-a near-orthogonal vector (distance ≈ 1.0, far above the 0.10 dedup threshold → not a
+a near-orthogonal vector (distance ≈ 1.0, far above the 0.05 dedup threshold → not a
 duplicate). This replaced an earlier mock that returned the *same* vector for every input,
 which made semantic-dedup behaviour structurally unobservable and forced tests into
 per-test workarounds.
 
 **Limitation to remember:** hash-based vectors are all-or-nothing (identical vs orthogonal).
 They eliminate *false* collisions but do not model *graded* semantic similarity. Testing the
-0.10 threshold itself needs real embeddings and is out of scope for the mock.
+0.05 threshold itself needs real embeddings — that is `DedupThresholdEvalTests`
+(`EXPERTISE_EVAL=1` opt-in, #457), out of scope for the mock.
 
 ### 3. Frozen enum-name guard (`EnumContractTests`)
 

--- a/src/ExpertiseApi/Services/DeduplicationService.cs
+++ b/src/ExpertiseApi/Services/DeduplicationService.cs
@@ -10,7 +10,15 @@ namespace ExpertiseApi.Services;
 internal class DeduplicationOptions
 {
     public bool Enabled { get; set; } = true;
-    public double SemanticThreshold { get; set; } = 0.10;
+
+    // Cosine-DISTANCE ceiling for the semantic near-duplicate check, calibrated
+    // per embedding model (#457, ADR-017 Amendment 1): under jina-v2-small the
+    // live corpus's true near-dups sit at <= 0.048 and its closest genuinely
+    // distinct same-domain neighbors begin at ~0.051, so 0.05 splits the valley.
+    // Biased LOW by design — a false 409 rejects a legitimate write, a miss
+    // merely lands as a Draft for curator review. Gate any change with
+    // EXPERTISE_EVAL=1 DedupThresholdEvalTests.
+    public double SemanticThreshold { get; set; } = 0.05;
 }
 
 internal class DeduplicationService(IExpertiseRepository repo, IOptions<DeduplicationOptions> options)

--- a/src/ExpertiseApi/appsettings.json
+++ b/src/ExpertiseApi/appsettings.json
@@ -69,7 +69,7 @@
   },
   "Deduplication": {
     "Enabled": true,
-    "SemanticThreshold": 0.10
+    "SemanticThreshold": 0.05
   },
   "Idempotency": {
     "_comment": "Part D C3 / ADR-010. RequireKey is hard-on by default since 2026-05-19 (PR closes Idempotency-Key Part D control). All POSTs to /expertise, /expertise/{id}/approve, /expertise/{id}/reject must carry an Idempotency-Key header; absence returns 400. The skill caller (#211) and pi extension caller (#212) generate keys automatically. Set to false only for short-lived debugging or a controlled rollback.",

--- a/tests/ExpertiseApi.Tests/Evaluation/DedupThresholdEvalTests.cs
+++ b/tests/ExpertiseApi.Tests/Evaluation/DedupThresholdEvalTests.cs
@@ -1,0 +1,196 @@
+using ExpertiseApi.Data;
+using ExpertiseApi.Services;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.SemanticKernel.Connectors.Onnx;
+using Xunit.Abstractions;
+
+namespace ExpertiseApi.Tests.Evaluation;
+
+/// <summary>
+/// Dedup semantic-threshold gate (#457). Embeds labeled entry pairs with the
+/// REAL pinned ONNX model and asserts the shipped
+/// <see cref="DeduplicationOptions.SemanticThreshold"/> default separates them:
+///
+/// <list type="bullet">
+///   <item><b>near-dup pairs</b> (same fact resubmitted with light rewording —
+///     the class dedup exists to catch) must land BELOW the threshold;</item>
+///   <item><b>distinct pairs</b> (different facts in the same topic area — the
+///     class a false 409 would wrongly reject) must land ABOVE it;</item>
+///   <item><b>moderate-to-full rewordings</b> (same fact, heavier rewrite) are
+///     REPORT-ONLY: per #457's risk profile dedup may under-fire (the miss
+///     lands as a Draft for curator review) but must not misfire.</item>
+/// </list>
+///
+/// Pair texts are class exemplars modeled on hand-labeled live-corpus
+/// neighbor pairs from the 2026-07-24 derivation (issue #457): under
+/// jina-v2-small, corpus near-dups clustered at distance ≤ 0.048 and the
+/// closest genuinely-distinct pairs began at ≈ 0.051, with the bulk of
+/// distinct neighbors at 0.06–0.13. The bge-era default of 0.10 sat inside
+/// the distinct mass (45% of corpus entries had a legitimate same-domain
+/// neighbor within 0.10) — hence the retune.
+///
+/// No database: this measures raw embedding geometry only.
+/// <code>
+/// EXPERTISE_EVAL=1 dotnet test --filter "FullyQualifiedName~DedupThresholdEval"
+/// </code>
+/// </summary>
+public sealed class DedupThresholdEvalTests(ITestOutputHelper output) : IAsyncLifetime
+{
+    private ServiceProvider? _onnxProvider;
+    private EmbeddingService _embedding = null!;
+
+    public Task InitializeAsync()
+    {
+        if (Environment.GetEnvironmentVariable("EXPERTISE_EVAL") != "1" || ModelFiles.ModelPath is null)
+            return Task.CompletedTask;
+
+        var services = new ServiceCollection();
+        services.AddBertOnnxEmbeddingGenerator(ModelFiles.ModelPath!, ModelFiles.VocabPath!,
+            EmbeddingModelInfo.CreateOnnxOptions());
+        _onnxProvider = services.BuildServiceProvider();
+        _embedding = new EmbeddingService(
+            _onnxProvider.GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>());
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        _onnxProvider?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private sealed record Pair(string Label, string TitleA, string BodyA, string TitleB, string BodyB);
+
+    // ---- Near-dup pairs: same fact, light rewording / retitle. ----
+    // The agent-resubmission class: an agent re-learns a fact and re-submits it
+    // with different phrasing. Modeled on real corpus dup pairs (e.g. the
+    // "VS Code Copilot hook parity" retitle at 0.031).
+    private static readonly IReadOnlyList<Pair> NearDupPairs =
+    [
+        new("neardup-pgbouncer",
+            "Npgsql with PgBouncer transaction mode needs No Reset On Close",
+            "When running Npgsql behind PgBouncer in transaction pooling mode, the connection string must set No Reset On Close=True. Without it Npgsql issues DISCARD ALL on connection return, which breaks under transaction pooling because the session state reset races other clients sharing the server connection.",
+            "PgBouncer transaction pooling requires No Reset On Close=True in the Npgsql connection string",
+            "Npgsql behind PgBouncer in transaction pool mode must include No Reset On Close=True. Otherwise Npgsql sends DISCARD ALL when a connection is returned, and under transaction pooling that reset conflicts with other clients that share the same server connection."),
+        new("neardup-docker-copy",
+            "Dockerfile COPY of the models directory fails silently when it is empty",
+            "A multi-stage Dockerfile COPY of src/models/ succeeds even when the directory was never populated, producing an image without model files. The failure only surfaces at container start when the API tries to load the ONNX model. CI must download models before docker build.",
+            "COPY of ONNX model files in the Dockerfile silently produces a broken image without pre-download",
+            "In a multi-stage build, COPY src/models/ does not fail when the directory is empty, so the image builds cleanly but is missing the ONNX model files. The error appears only at runtime when model load fails. Run the model download script before building the image in CI."),
+        new("neardup-ssh-socket",
+            "Debian 13 ssh.socket activation ignores Port changes in sshd_config on restart",
+            "On a fresh Debian 13 install SSH is socket-activated. Restarting ssh.service after editing Port in sshd_config does not change the listener, because the socket unit owns the bind. You must edit the socket unit or restart ssh.socket for a port change to take effect.",
+            "SSH port changes need ssh.socket restart on Debian 13 fresh installs",
+            "Debian 13 fresh installs use ssh.socket activation, so the listening port is bound by the socket unit. Editing Port in sshd_config and restarting only ssh.service leaves the old listener in place — restart ssh.socket (or override the socket unit) instead."),
+    ];
+
+    // ---- Report-only pairs: same fact, moderate-to-full rewording. ----
+    // Measured 2026-07-24 (jina-v2-small@6144): moderate rewordings land at
+    // 0.05–0.07 — the SAME band where the live corpus's closest genuinely
+    // distinct neighbors begin (0.051) — and full paraphrases at 0.13–0.16.
+    // No threshold separates these from distinct entries, so per #457's risk
+    // profile they are accepted under-fire (the miss lands as a Draft for
+    // curator review); this suite reports their drift but does not gate them.
+    private static readonly IReadOnlyList<Pair> ReportOnlyPairs =
+    [
+        new("moderate-set-e-counter",
+            "bash set -e aborts on ((counter++)) when the counter starts at zero",
+            "Under set -e, the arithmetic expression ((counter++)) returns the pre-increment value, so incrementing from 0 evaluates to 0 which is falsy and terminates the script. Use ((counter++)) || true or counter=$((counter + 1)) instead.",
+            "((counter++)) from zero kills scripts running under set -e",
+            "With errexit enabled, ((counter++)) yields the value before the increment; starting from 0 that is 0, bash treats it as failure, and the script exits. The safe forms are counter=$((counter + 1)) or appending || true to the arithmetic command."),
+        new("moderate-actions-cache",
+            "GitHub Actions cache key must hash the lockfile, not the manifest",
+            "Keying actions/cache on package.json misses dependency updates that only change package-lock.json, serving stale node_modules. Use hashFiles('**/package-lock.json') in the cache key so any resolved-dependency change busts the cache.",
+            "actions/cache keyed on package.json serves stale dependencies",
+            "A cache key built from package.json does not change when only package-lock.json moves, so dependency bumps restore an outdated node_modules. Build the key with hashFiles over the lockfile instead of the manifest."),
+        new("para-pgbouncer",
+            "Npgsql with PgBouncer transaction mode needs No Reset On Close",
+            "When running Npgsql behind PgBouncer in transaction pooling mode, the connection string must set No Reset On Close=True. Without it Npgsql issues DISCARD ALL on connection return, which breaks under transaction pooling because the session state reset races other clients sharing the server connection.",
+            "Session-reset commands from the .NET Postgres driver conflict with shared pooler connections",
+            "Our API pods started throwing prepared-statement errors after we introduced a connection pooler in transaction mode. Root cause: the driver's automatic cleanup command on connection release assumes it owns the session, but the pooler hands the same backend to many clients. The fix is a driver flag that disables the automatic session reset."),
+        new("para-ssh-socket",
+            "Debian 13 ssh.socket activation ignores Port changes in sshd_config on restart",
+            "On a fresh Debian 13 install SSH is socket-activated. Restarting ssh.service after editing Port in sshd_config does not change the listener, because the socket unit owns the bind. You must edit the socket unit or restart ssh.socket for a port change to take effect.",
+            "Why changing the SSH listening port appeared to do nothing on a new Trixie VM",
+            "Spent an hour debugging why the daemon kept answering on 22 after a config edit and service restart. Turns out systemd owns the listener through socket activation on new installs of this release, so the daemon config's port directive is not consulted for the bind — the systemd socket unit is."),
+    ];
+
+    // ---- Distinct pairs: same topic area, different fact (must NOT dedup). ----
+    // Modeled on real corpus neighbor pairs hand-labeled distinct (0.06–0.09).
+    private static readonly IReadOnlyList<Pair> DistinctPairs =
+    [
+        new("distinct-ado-networking",
+            "Azure DevOps hosted agents cannot reach Azure Private Endpoints",
+            "Microsoft-hosted ADO agents run outside your vnet and resolve private-endpoint hostnames to public IPs that refuse connections. Builds needing private resources must use self-hosted agents or vnet-injected pools.",
+            "Managed DevOps Pools support vnet injection for private endpoint access",
+            "Managed DevOps Pools can be injected into a subnet of your vnet, giving pipeline jobs direct line-of-sight to private endpoints without standing up self-hosted VMs. Configure the pool's network profile with the target subnet resource id."),
+        new("distinct-markdownlint",
+            "markdownlint MD060 flags compact pipe-table separators",
+            "markdownlint v0.40 introduced MD060 which fires on |---|---| style table separator rows, wanting padded | --- | --- | form. Existing docs with compact separators fail lint after the version bump.",
+            "markdownlint MD013 line-length ignores tables only when configured",
+            "MD013 counts table rows against the line-length limit unless the tables:false option is set for the rule. Wide comparison tables need that override or they fail lint at the default 80-character limit."),
+        new("distinct-bash-traps",
+            "set -u unbound-variable exits bypass ERR traps",
+            "An unbound variable expansion under set -u terminates the shell directly without running the ERR trap, so cleanup handlers keyed on ERR never fire for this failure class. Guard expansions with ${var:-} where cleanup must run.",
+            "ERR traps do not inherit into functions without set -E",
+            "A trap on ERR set at the top level does not fire for failures inside shell functions unless errtrace (set -E) is enabled, so function-level failures skip the handler even though the script-level command would have triggered it."),
+        new("distinct-kitty",
+            "kitten ssh is required for a working TTY on kitty terminals",
+            "Plain ssh from kitty sends the xterm-kitty TERM value that remote hosts lack a terminfo entry for, breaking full-screen programs. kitten ssh copies the terminfo to the remote host on connect.",
+            "kitty file transfer over nested SSH has low throughput",
+            "The transfer kitten works across nested SSH hops but its escape-sequence encoding caps throughput well below scp for large files; use it for small config files and fall back to scp or rsync for anything sizable."),
+        new("distinct-keda-ado",
+            "KEDA azure-pipelines scaler prefers poolName over poolID when both are set",
+            "When a ScaledObject sets both poolName and poolID, the scaler resolves the pool by name and silently ignores the id, which surprises configs that rotated pool names but pinned ids.",
+            "ADO agent pool ScaledJobs should target pool ID, not display name",
+            "Pool display names are mutable and org-unique only per project collection; jobs keyed on the name break when an admin renames the pool. Configure the numeric pool id, which is stable across renames."),
+    ];
+
+    [EvalFact]
+    public async Task PairDistances_SeparateAtTheShippedThreshold()
+    {
+        var threshold = new DeduplicationOptions().SemanticThreshold;
+
+        // Sanity pin: identical text must embed to (near-)zero distance.
+        var idText = EmbeddingService.BuildInputText(NearDupPairs[0].TitleA, NearDupPairs[0].BodyA);
+        var idVecs = await _embedding.GenerateBatchAsync([idText, idText]);
+        var selfDistance = ExpertiseRepository.CosineDistance(idVecs[0].ToArray(), idVecs[1].ToArray());
+        selfDistance.Should().NotBeNull().And.BeLessThan(0.001);
+
+        async Task<List<(string Label, double Distance)>> MeasureAsync(IReadOnlyList<Pair> pairs)
+        {
+            var texts = pairs.SelectMany(p => new[]
+            {
+                EmbeddingService.BuildInputText(p.TitleA, p.BodyA),
+                EmbeddingService.BuildInputText(p.TitleB, p.BodyB),
+            });
+            var vecs = await _embedding.GenerateBatchAsync(texts);
+            return pairs.Select((p, i) =>
+                (p.Label, ExpertiseRepository.CosineDistance(
+                    vecs[2 * i].ToArray(), vecs[2 * i + 1].ToArray())!.Value)).ToList();
+        }
+
+        var nearDups = await MeasureAsync(NearDupPairs);
+        var reportOnly = await MeasureAsync(ReportOnlyPairs);
+        var distincts = await MeasureAsync(DistinctPairs);
+
+        output.WriteLine($"SemanticThreshold under test: {threshold}");
+        output.WriteLine("");
+        output.WriteLine("class      | pair                     | distance | vs threshold");
+        output.WriteLine("-----------|--------------------------|----------|-------------");
+        foreach (var (label, d) in nearDups)
+            output.WriteLine($"near-dup   | {label,-24} | {d:F4}   | {(d < threshold ? "CAUGHT" : "MISSED")}");
+        foreach (var (label, d) in reportOnly)
+            output.WriteLine($"report     | {label,-24} | {d:F4}   | {(d < threshold ? "caught" : "missed (accepted under-fire)")}");
+        foreach (var (label, d) in distincts)
+            output.WriteLine($"distinct   | {label,-24} | {d:F4}   | {(d > threshold ? "PASSED THROUGH" : "FALSE 409")}");
+
+        // Gates. Near-dups must be caught; distincts must never false-409.
+        // Moderate/full rewordings are report-only (accepted under-fire, #457).
+        nearDups.Should().OnlyContain(p => p.Distance < threshold,
+            "light-rewording resubmissions are the class the semantic dedup threshold exists to catch");
+        distincts.Should().OnlyContain(p => p.Distance > threshold,
+            "a distinct same-topic entry rejected as a duplicate is a false 409 — the costly failure direction");
+    }
+}

--- a/tests/ExpertiseApi.Tests/Infrastructure/TestHelpers.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/TestHelpers.cs
@@ -113,7 +113,7 @@ internal static class TestHelpers
     /// <summary>
     /// Deterministic, CONTENT-DERIVED embedding for tests (#353). Identical content yields
     /// the identical vector (cosine distance 0 → a real duplicate); different content yields
-    /// a near-orthogonal vector (cosine distance ≈ 1.0, far above the 0.10 dedup threshold →
+    /// a near-orthogonal vector (cosine distance ≈ 1.0, far above the dedup threshold →
     /// NOT a duplicate). Replaces the old content-independent mock that returned the same
     /// vector for every input — which made semantic-dedup behaviour structurally unobservable
     /// and forced two integration tests into per-test workarounds.

--- a/tests/ExpertiseApi.Tests/Unit/DeduplicationServiceTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/DeduplicationServiceTests.cs
@@ -16,6 +16,17 @@ public class DeduplicationServiceTests
     private readonly Vector _testVector = TestHelpers.CreateTestVector();
     private readonly TenantContext _ctx = TestHelpers.CreateTenantContext();
 
+    [Fact]
+    public void SemanticThreshold_DefaultIsTheAdr017Amendment1Value()
+    {
+        // Pins the shipped default (#457, ADR-017 Amendment 1: derived against
+        // the jina-v2-small corpus geometry). Runs in normal CI — unlike the
+        // EXPERTISE_EVAL-gated DedupThresholdEvalTests — so an accidental
+        // default drift is caught without the opt-in eval pass. Change both
+        // together, re-deriving per the amendment's method.
+        new DeduplicationOptions().SemanticThreshold.Should().Be(0.05);
+    }
+
     private DeduplicationService CreateService(bool enabled = true, double threshold = 0.10)
     {
         var options = Options.Create(new DeduplicationOptions
@@ -184,7 +195,7 @@ public class DeduplicationServiceTests
 
         // No exact title match — entry title differs
         var domainEntry = TestHelpers.SeedEntry(title: "Similar But Different Title");
-        // Use the same vector so cosine distance == 0, well below the 0.10 threshold
+        // Use the same vector so cosine distance == 0, well below any sane threshold
         domainEntry.Embedding = _testVector;
 
         _repo.FindExactMatchesAsync("shared", Arg.Any<IReadOnlyList<string>>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())


### PR DESCRIPTION
## Summary

Closes #457. `Deduplication:SemanticThreshold` drops **0.10 → 0.05**, re-derived against the post-#437 jina-v2-small embedding space per the plan in the issue. Full derivation recorded as **ADR-017 Amendment 1**.

## Derivation (live corpus, 604 approved embedded entries)

Within-domain nearest-neighbor cosine distances computed directly over the stored vectors (pgvector `<=>`):

| Band | Count | Hand-labeled as |
|---|---|---|
| < 0.01 | 131 | Literal duplicates (130/131 byte-identical bodies — accumulated while dedup under-fired) |
| 0.01 – 0.05 | 6 | Near-dups: retitles / light rewordings of the same fact |
| ≥ 0.051 | rest | Genuinely distinct same-topic neighbors (mass at 0.06–0.13) |

The bge-era 0.10 sits inside the distinct mass: **272/604 entries (45%) have a legitimate distinct neighbor within 0.10**, i.e. under jina geometry the old default would false-409 roughly half of comparable future submissions.

Synthetic pair measurement with the real model agrees: light rewordings 0.016–0.048, moderate rewordings 0.052–0.065, full paraphrases 0.13–0.16, distinct same-topic pairs ≥ 0.12.

**0.05 splits the valley**, biased low deliberately: a false 409 rejects a legitimate write (costly, user-visible); a missed near-dup lands as a Draft for curator review (noise). Moderate/full rewordings are accepted under-fire — geometrically inseparable from distinct entries under this model.

## Changes

- `DeduplicationOptions.SemanticThreshold` default + `appsettings.json` → 0.05, with the derivation summarized at the declaration.
- **New `DedupThresholdEvalTests`** (`EXPERTISE_EVAL=1` opt-in, no DB): embeds labeled pair classes with the real pinned model; gates that light-rewording pairs land below the shipped threshold and distinct same-topic pairs land above it; reports (without gating) the accepted under-fire band.
- Normal-CI unit pin `SemanticThreshold_DefaultIsTheAdr017Amendment1Value` so default drift is caught without the opt-in eval pass.
- ADR-017: Consequences bullet marked resolved; Amendment 1 added with the full method and numbers.
- `docs/testing-and-coverage.md` mock-embedding section updated (0.10 → 0.05, points at the new eval suite).

## Doc-impact

| Surface | Classification |
|---|---|
| ADR-017 Amendment 1 | in-scope (the derivation record — amendment, not supersession, since ADR-017 explicitly deferred this value to #457) |
| docs/testing-and-coverage.md | in-scope (updated) |
| DESIGN.md / SKILL.md / README | not-a-thing — none document the threshold value |

## Gate evidence

- `EXPERTISE_EVAL=1` DedupThresholdEval: PASS at 0.05 (table in test output; near-dups CAUGHT, distincts PASSED THROUGH).
- Full suite: 427 passed, 0 failed, 3 skipped (the opt-in evals).
- `dotnet format analyzers --verify-no-changes`: clean. markdownlint on touched docs: clean.

Note: the running local A2 service picks this up at the next release/install (config default; no env overlay is set for `Deduplication__SemanticThreshold`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)