### PR TITLE
ci: make macos install-smoke jobs blocking again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,10 +377,6 @@ jobs:
   install-smoke-macos:
     name: install.sh end-to-end smoke (macOS / launchd / postgres-17)
     runs-on: macos-latest
-    # Non-blocking until the upstream Homebrew postgresql@17 bottle is fixed (#366):
-    # the runner bottle has a share-dir path mismatch that fails initdb. The job
-    # still runs and reports; it just does not gate merges. REMOVE when #366 closes.
-    continue-on-error: true
     timeout-minutes: 15
     # E2 of #166 / closes #259. Sibling of install-smoke-linux above: same
     # harness (scripts/test/test-install-smoke.sh), different OS provisioning.
@@ -477,9 +473,6 @@ jobs:
   install-smoke-macos-system:
     name: "install.sh end-to-end smoke (macOS / LaunchDaemon / system scope / #145)"
     runs-on: macos-latest
-    # Non-blocking until the upstream Homebrew postgresql@17 bottle is fixed (#366).
-    # REMOVE when #366 closes.
-    continue-on-error: true
     timeout-minutes: 15
     # System-scope LaunchDaemon smoke (#145). GHA macOS runners have passwordless
     # sudo, so a real root install is exercisable here. Gated behind

--- a/.github/workflows/install-smoke-from-release.yml
+++ b/.github/workflows/install-smoke-from-release.yml
@@ -167,9 +167,6 @@ jobs:
   install-smoke-macos-from-release:
     name: install.sh --from-release smoke (macOS / launchd / postgres-17)
     runs-on: macos-latest
-    # Non-blocking until the upstream Homebrew postgresql@17 bottle is fixed (#366).
-    # REMOVE when #366 closes.
-    continue-on-error: true
     timeout-minutes: 15
     # macOS GHA runners have no Docker daemon. Unlike the Linux job there is
     # no privileged-container requirement so no fork-PR guard is needed —

--- a/scripts/test/brew-install-postgres17.sh
+++ b/scripts/test/brew-install-postgres17.sh
@@ -3,14 +3,14 @@
 # brew-install-postgres17.sh — install PostgreSQL 17 + pgvector via Homebrew for the
 # macOS install-smoke CI jobs, self-healing a corrupt pre-cached bottle.
 #
-# BEST-EFFORT heal for the macOS install-smoke jobs. The `postgresql@17` bottle on
-# current macOS runner images fails at service start with:
+# BEST-EFFORT heal for the macOS install-smoke jobs, retained as defense-in-depth
+# after #366 closed. That upstream Homebrew bug (`postgresql@17` bottle share-dir
+# path mismatch on a keg-only formula — initdb failed with
 #     initdb: error: file "/opt/homebrew/share/postgresql@17/postgres.bki" does not exist
-# Diagnosed as an upstream Homebrew bug (share-dir path mismatch on a keg-only
-# formula; the file exists in the keg but initdb/server look in the unpopulated
-# top-level prefix). Tracked in #366 — the three macOS smoke jobs are
-# `continue-on-error: true` until it is fixed, so this heal not landing does not
-# block merges. Remove the continue-on-error (and revisit this heal) when #366 closes.
+# while the file existed inside the keg) recurred across runner-image updates
+# (arm64_sequoia, then arm64_tahoe) before Homebrew fixed the bottle, so the heal
+# stays in case a future image regresses. The three macOS smoke jobs are BLOCKING
+# again — a failure here fails the PR.
 #
 # The two heals below are retained because they DO fix adjacent variants and cost
 # nothing when they no-op:


### PR DESCRIPTION
## Summary

Closes #366 by executing its recorded revert trigger: the upstream Homebrew `postgresql@17` bottle (share-dir path mismatch → `initdb: postgres.bki does not exist`) is fixed on current `macos-latest` runner images, so the three macOS install-smoke jobs go back to **blocking**.

## Revert-trigger evidence

- Last **10** `ci.yml` runs (dev + PRs): both macOS smoke jobs (`install-smoke-macos`, `install-smoke-macos-system`) concluded success, with **every step green** — including `Install Postgres 17 + pgvector via Homebrew` and the smoke harness — verified at step level via the Actions API (runs 30015522846 … 30085978022), not just job conclusion.
- `install-smoke-from-release.yml`: latest 5 runs success; yesterday's two macOS failures were runner network transients (curl 28 to api.github.com; sigstore TUF CDN timeout in cosign-installer), not the bottle, and passed on rerun.

## Changes

- Remove `continue-on-error: true` + the "non-blocking until #366" comments from all three jobs (`ci.yml` ×2, `install-smoke-from-release.yml` ×1).
- `scripts/test/brew-install-postgres17.sh` header updated: heal **retained as defense-in-depth** (the bottle bug recurred across runner-image updates — arm64_sequoia, then arm64_tahoe — before Homebrew fixed it), jobs documented as blocking again.

## Consequence to note

Runner network transients on the macOS jobs (like yesterday's) now fail the PR instead of showing a soft failure — rerun is the remedy, which is the intended trade per #366's definition of done.

Gates: actionlint clean, shellcheck clean, no `continue-on-error` remaining anywhere in `.github/workflows/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)