### PR TITLE
fix(security): fail-closed PII redaction and lookbehind-free AwsSecret

### DIFF
--- a/src/ExpertiseApi/Hygiene/PiiDetector.cs
+++ b/src/ExpertiseApi/Hygiene/PiiDetector.cs
@@ -4,9 +4,10 @@ namespace ExpertiseApi.Hygiene;
 
 /// <summary>
 /// Regex-based PII redaction for free-text response fields. Each detector class is
-/// compiled once at construction. Patterns use <see cref="RegexOptions.NonBacktracking"/>
-/// for linear-time guarantee against ReDoS (.NET 7+); each pattern carries a per-match
-/// timeout as belt-and-suspenders.
+/// compiled once at construction. <strong>Every</strong> pattern uses
+/// <see cref="RegexOptions.NonBacktracking"/> for a linear-time guarantee against ReDoS
+/// (.NET 7+); each also carries a per-match timeout as belt-and-suspenders, and the
+/// timeout path fails <strong>closed</strong> (see <see cref="ApplyOne"/>).
 /// </summary>
 /// <remarks>
 /// <para>
@@ -42,14 +43,16 @@ internal static class PiiDetector
     ];
 
     // RegexOptions.NonBacktracking guarantees linear-time matching for the supported
-    // subset (no backreferences, no lookaround). Patterns that need lookaround are
-    // called out below and use a tight timeout as the fallback.
+    // subset (no backreferences, no lookaround). ALL detectors are NonBacktracking as
+    // of #333 Finding 2 — the AwsSecret lookbehind that previously forced a
+    // backtracking-capable option was rewritten to capture the secret in a group
+    // instead (see below), removing the only pattern that could ReDoS. There is no
+    // longer a lookaround/backtracking option constant: a future lookaround pattern
+    // must reintroduce one deliberately, and the fail-closed timeout path in ApplyOne
+    // remains the safety net for any pattern that ever times out.
     private const RegexOptions NbOpts = RegexOptions.Compiled | RegexOptions.NonBacktracking
                                        | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant;
-    private const RegexOptions LookaroundOpts = RegexOptions.Compiled | RegexOptions.IgnoreCase
-                                              | RegexOptions.CultureInvariant;
     private static readonly TimeSpan FastTimeout = TimeSpan.FromMilliseconds(50);
-    private static readonly TimeSpan SlowTimeout = TimeSpan.FromMilliseconds(100);
 
     // Email: RFC-loose, anchored to word boundaries. Linear under NonBacktracking.
     private static readonly Regex Email = new(
@@ -66,12 +69,19 @@ internal static class PiiDetector
         @"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b", NbOpts, FastTimeout);
 
     // AWS secret: requires a context word within 32 chars before the candidate (40-char
-    // base64-ish run). The lookbehind allows any non-alphanumeric separator (e.g. '=',
-    // ':', ' ', newline) between the context word and the secret. Tight timeout because
-    // of the lookbehind quantifier.
+    // base64-ish run). Rewritten for #333 Finding 2 to be NonBacktracking-safe: the
+    // former lookbehind (context) + lookahead (trailing boundary) forced a
+    // backtracking-capable option and a ReDoS-vulnerable 100ms timeout. Now the context
+    // word and separator are matched inline (consumed, not looked-behind) and the secret
+    // is pulled into capture group 1; ApplyOne redacts ONLY group 1, so the emitted text
+    // is byte-identical to the old lookbehind form ("aws_secret_access_key=<40>" ->
+    // "aws_secret_access_key=[REDACTED:aws-secret]"). The trailing boundary is consumed
+    // via (?:[^...]|$) — a lookahead is not permitted under NonBacktracking — and, being
+    // outside group 1, is re-emitted verbatim. Bounded {0,32}/{40} quantifiers keep it
+    // linear; it can no longer time out on adversarial padding.
     private static readonly Regex AwsSecret = new(
-        @"(?<=(?:aws[_-]?secret(?:[_-]?access[_-]?key)?|secret(?:[_-]?key)?)[^A-Za-z0-9/+]{0,32})[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])",
-        LookaroundOpts, SlowTimeout);
+        @"(?:aws[_-]?secret(?:[_-]?access[_-]?key)?|secret(?:[_-]?key)?)[^A-Za-z0-9/+]{0,32}([A-Za-z0-9/+=]{40})(?:[^A-Za-z0-9/+=]|$)",
+        NbOpts, FastTimeout);
 
     private static readonly Regex GithubPat = new(
         @"\b(?:ghp|gho|ghs|ghr|ghu)_[A-Za-z0-9]{36}\b", NbOpts, FastTimeout);
@@ -81,7 +91,7 @@ internal static class PiiDetector
         NbOpts, FastTimeout);
 
     private static readonly Regex UrlCredentials = new(
-        @"\b(?:https?|ftp)://[^\s/:@]+:[^\s/@]+@\S+", NbOpts, SlowTimeout);
+        @"\b(?:https?|ftp)://[^\s/:@]+:[^\s/@]+@\S+", NbOpts, FastTimeout);
 
     private static readonly Regex PrivateKeyHeader = new(
         @"-----BEGIN (?:RSA |EC |OPENSSH |PGP |DSA )?PRIVATE KEY-----", NbOpts, FastTimeout);
@@ -93,9 +103,25 @@ internal static class PiiDetector
         @"|\b(?:[A-F0-9]{1,4}:){7}[A-F0-9]{1,4}\b",
         NbOpts, FastTimeout);
 
+    // Detector run order. URL credentials FIRST so the user:pass@host segment is
+    // replaced before the email pattern would otherwise consume the @host tail.
+    private static readonly (Regex Pattern, string Class)[] Detectors =
+    [
+        (UrlCredentials, "url-credentials"),
+        (Email, "email"),
+        (AwsAccessKey, "aws-access-key"),
+        (AwsSecret, "aws-secret"),
+        (GithubPat, "github-pat"),
+        (Jwt, "jwt"),
+        (PrivateKeyHeader, "private-key-header"),
+        (Phone, "phone"),
+        (IpAddress, "ip-address"),
+    ];
+
     /// <summary>
     /// Apply all detectors to <paramref name="input"/>. Returns the redacted text and
-    /// per-class match counts (zero-count classes omitted).
+    /// per-class match counts (zero-count classes omitted). On a regex timeout the field
+    /// is fully suppressed (fail-closed) and the remaining detectors are skipped.
     /// </summary>
     public static PiiResult Redact(string input)
     {
@@ -105,43 +131,63 @@ internal static class PiiDetector
         var counts = new Dictionary<string, int>(StringComparer.Ordinal);
         var current = input;
 
-        // Order matters: URL credentials FIRST so the user:pass@host segment is replaced
-        // before the email pattern would otherwise consume the @host tail.
-        current = ApplyOne(current, UrlCredentials, "url-credentials", counts);
-        current = ApplyOne(current, Email, "email", counts);
-        current = ApplyOne(current, AwsAccessKey, "aws-access-key", counts);
-        current = ApplyOne(current, AwsSecret, "aws-secret", counts);
-        current = ApplyOne(current, GithubPat, "github-pat", counts);
-        current = ApplyOne(current, Jwt, "jwt", counts);
-        current = ApplyOne(current, PrivateKeyHeader, "private-key-header", counts);
-        current = ApplyOne(current, Phone, "phone", counts);
-        current = ApplyOne(current, IpAddress, "ip-address", counts);
+        foreach (var (pattern, className) in Detectors)
+        {
+            current = ApplyOne(current, pattern, className, counts, out var timedOut);
+            if (timedOut)
+                // Fail-closed: the field is already replaced with a suppression
+                // sentinel. Running the remaining detectors against that sentinel is
+                // moot, so short-circuit \u2014 nothing sensitive can survive a fully
+                // suppressed field.
+                break;
+        }
 
         return new PiiResult(current, counts);
     }
 
-    private static string ApplyOne(string input, Regex pattern, string className, Dictionary<string, int> counts)
+    /// <summary>
+    /// Apply one detector. When the pattern defines capture group 1, only that span is
+    /// redacted and the surrounding match text is preserved verbatim (used by AwsSecret,
+    /// whose match includes a context word that must survive); otherwise the whole match
+    /// is replaced. On <see cref="RegexMatchTimeoutException"/> the method fails CLOSED
+    /// (#333 Finding 2): it returns a whole-field suppression sentinel and sets
+    /// <paramref name="timedOut"/>, because a timeout yields no match positions and
+    /// returning the original would ship an unredacted secret to an LLM consumer.
+    /// </summary>
+    internal static string ApplyOne(
+        string input, Regex pattern, string className, Dictionary<string, int> counts, out bool timedOut)
     {
         var matchCount = 0;
         try
         {
-            var replaced = pattern.Replace(input, _ =>
+            var replaced = pattern.Replace(input, m =>
             {
                 matchCount++;
+                if (m.Groups.Count > 1 && m.Groups[1].Success)
+                {
+                    var g = m.Groups[1];
+                    var rel = g.Index - m.Index;
+                    return $"{m.Value[..rel]}[REDACTED:{className}]{m.Value[(rel + g.Length)..]}";
+                }
                 return $"[REDACTED:{className}]";
             });
             if (matchCount > 0)
                 counts[className] = matchCount;
+            timedOut = false;
             return replaced;
         }
         catch (RegexMatchTimeoutException)
         {
-            // Pattern took too long on adversarial input \u2014 leave the field unredacted
-            // and record a sentinel so the orchestrator can flag the response with a
-            // "redaction-timeout" entry in hygieneApplied. Not raising: returning the
-            // original is safer than throwing 500 from a read endpoint.
+            // Fail CLOSED: a timeout carries no match boundaries, so selective redaction
+            // is impossible. Suppress the WHOLE field rather than return the original
+            // (the pre-#333 behaviour, which shipped the unredacted value). Consumers
+            // reading a "{class}-timeout" key in hygieneApplied MUST treat the field as
+            // fully suppressed, not partially redacted. The NonBacktracking rewrite of
+            // every detector makes this path unreachable on today's patterns; it remains
+            // the safety net for any future pattern or pathological input.
             counts[$"{className}-timeout"] = 1;
-            return input;
+            timedOut = true;
+            return $"[REDACTED:{className}-timeout]";
         }
     }
 

--- a/tests/ExpertiseApi.Tests/Unit/Hygiene/PiiDetectorTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/Hygiene/PiiDetectorTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using ExpertiseApi.Hygiene;
 
 namespace ExpertiseApi.Tests.Unit.Hygiene;
@@ -158,5 +159,74 @@ public class PiiDetectorTests
         result.Counts["email"].Should().Be(1);
         result.Counts["github-pat"].Should().Be(1);
         result.Text.Should().Contain("[REDACTED:email]").And.Contain("[REDACTED:github-pat]");
+    }
+
+    // --- AWS secret: capture-group redaction preserves surrounding context (#333 Finding 2) ---
+
+    [Fact]
+    public void AwsSecret_RedactsOnlyTheSecret_PreservingTheContextWord()
+    {
+        // The NonBacktracking rewrite consumes the context word into the match but pulls
+        // the secret into capture group 1; ApplyOne must redact ONLY the group, leaving
+        // the context prefix byte-identical to the pre-rewrite lookbehind behaviour.
+        var input = "aws_secret_access_key=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef01234567";
+        var result = PiiDetector.Redact(input);
+        result.Text.Should().Be("aws_secret_access_key=[REDACTED:aws-secret]");
+    }
+
+    [Fact]
+    public void AwsSecret_PreservesTrailingTextAfterTheSecret()
+    {
+        // The trailing boundary is consumed via (?:[^...]|$) (no lookahead under
+        // NonBacktracking) but sits outside group 1, so the separator and following
+        // text must be re-emitted verbatim.
+        var input = "secret ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef01234567 and then more";
+        var result = PiiDetector.Redact(input);
+        result.Text.Should().Be("secret [REDACTED:aws-secret] and then more");
+        result.Counts["aws-secret"].Should().Be(1);
+    }
+
+    [Fact]
+    public void AwsSecret_AtEndOfString_IsRedacted()
+    {
+        // The '$' alternative of the trailing boundary handles a secret flush against EOL.
+        var input = "secret=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef01234567";
+        var result = PiiDetector.Redact(input);
+        result.Text.Should().Be("secret=[REDACTED:aws-secret]");
+    }
+
+    // --- Fail-closed timeout handling (#333 Finding 2) ---
+
+    [Fact]
+    public void ApplyOne_OnRegexTimeout_SuppressesWholeField_AndSignalsTimeout()
+    {
+        // A catastrophic-backtracking pattern (NOT NonBacktracking) against non-matching
+        // input forces a RegexMatchTimeoutException deterministically at a 1ms budget.
+        // The production detectors can no longer reach this path (all NonBacktracking),
+        // so this exercises the fail-closed net directly through the internal seam.
+        var evil = new Regex("^(a+)+$", RegexOptions.None, TimeSpan.FromMilliseconds(1));
+        var adversarial = new string('a', 40) + "!";
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        var result = PiiDetector.ApplyOne(adversarial, evil, "aws-secret", counts, out var timedOut);
+
+        timedOut.Should().BeTrue();
+        result.Should().Be("[REDACTED:aws-secret-timeout]",
+            "fail-closed must replace the WHOLE field, never return the original unredacted value");
+        result.Should().NotContain(adversarial, "the original adversarial content must not survive");
+        counts.Should().ContainKey("aws-secret-timeout");
+    }
+
+    [Fact]
+    public void ApplyOne_NoTimeout_SignalsFalse()
+    {
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        var ok = new Regex("nomatch", RegexOptions.NonBacktracking, TimeSpan.FromMilliseconds(50));
+
+        var result = PiiDetector.ApplyOne("harmless text", ok, "email", counts, out var timedOut);
+
+        timedOut.Should().BeFalse();
+        result.Should().Be("harmless text");
+        counts.Should().BeEmpty();
     }
 }


### PR DESCRIPTION
**PR 1 of 4** in the #333 security-hardening series (Finding 2). Non-breaking, PATCH-level. Findings 1/2/4 are split into separate PRs per the agreed phased plan; this one is fully self-contained.

## Problem (Finding 2, Error)

`PiiDetector.ApplyOne` caught `RegexMatchTimeoutException` and **returned the original, unredacted text** (fail-open). The `AwsSecret` detector was the one lookbehind regex with a 100ms timeout, so an adversary could pad `Title`/`Body` to exceed the window and have an AWS-shaped secret shipped in cleartext to a consuming agent, with only a `{class}-timeout` sentinel in metadata.

## Fix (two layers)

1. **Root cause — make the timeout unreachable.** Rewrite `AwsSecret` without the lookbehind/lookahead so it's `NonBacktracking`-safe:
   - Context word + separator matched inline; the 40-char secret captured in **group 1**.
   - `ApplyOne` redacts **only group 1**, so output is byte-identical to the old lookbehind form (`aws_secret_access_key=<40>` → `aws_secret_access_key=[REDACTED:aws-secret]`).
   - Trailing boundary consumed via `(?:[^...]|$)` (a lookahead is disallowed under `NonBacktracking`); it sits outside the group and is re-emitted verbatim.
   - `UrlCredentials` moved to `FastTimeout`; the now-unused `LookaroundOpts` and `SlowTimeout` constants deleted (a dead backtracking-capable option in a redaction file is a footgun for the next detector added).

2. **Defense-in-depth — fail closed.** The shared timeout `catch` now replaces the **whole field** with `[REDACTED:{class}-timeout]` and **short-circuits** the remaining detectors, instead of returning the raw value. Unreachable by today's all-`NonBacktracking` detectors, but remains the safety net for any future pattern or pathological input.

## Tradeoff (noted)

Fail-closed means an attacker could deliberately trip a timeout to blank one field of one entry — strictly better than leaking a secret, and the regex rewrite makes it unreachable for AWS secrets regardless.

## Tests

Capture-group redaction preserves the context word and trailing text; end-of-string secret redacts; fail-closed path suppresses the whole field and signals timeout (deterministic via a catastrophic-backtracking regex through the now-internal `ApplyOne` seam). Full suite 432 passed / 3 skipped; `dotnet format analyzers` clean.

## Series context

Follow-ups filed: #468 (Finding 3 integrity verification, ADR-first), #469 (Finding 4 per-item permit precision), #470 (length guards). PRs 2 (bounded batch dedup) and 3 (batch rate policy) follow; a v1.6.1 release is planned after PR 3, then PR 4 (Finding 1) opens the breaking v2.0.0 tree.

Refs #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)