### PR TITLE
fix(dedup): bound batch dedup via per-item HNSW nearest-neighbour

### DIFF
--- a/.agents/skills/expertise-api/references/DESIGN.md
+++ b/.agents/skills/expertise-api/references/DESIGN.md
@@ -186,7 +186,7 @@ When the principal authenticates successfully but no tenant maps (e.g. group not
 2. **Repository** — primary safeguard. Each method applies an explicit `WHERE Tenant IN (ctx.Tenant, "shared")`; `GetByIdAsync`, `UpdateAsync`, and `SoftDeleteAsync` use `Where(id) + FirstOrDefaultAsync` rather than `FindAsync` so the filter cannot be bypassed via the EF identity map.
 3. **EF global query filter** — `HasQueryFilter` on `ExpertiseEntry` reads `ITenantContextAccessor.Tenant` (HTTP-backed). Defense-in-depth: when a future query forgets the explicit `WHERE`, this still applies. Short-circuits to no filter when the accessor returns null (CLI / design-time / direct test seeding) — those paths rely on the explicit repository `WHERE` for correctness.
 4. **CLI bypass** — `reembed` and `rehash` commands call `IgnoreQueryFilters()` explicitly so they process every tenant.
-5. **Dedup tenant scoping** — `FindExactMatchAsync`, `FindExactMatchesAsync`, `FindNearestInDomainAsync`, and `FindAllEmbeddingsInDomainAsync` are tenant-scoped so a `409 Conflict` on `POST /expertise` cannot leak another tenant's entry contents in the response body.
+5. **Dedup tenant scoping** — `FindExactMatchAsync`, `FindExactMatchesAsync`, and `FindNearestInDomainAsync` are tenant-scoped so a `409 Conflict` on `POST /expertise` cannot leak another tenant's entry contents in the response body. Both the single-create and batch dedup paths use the HNSW-indexed `FindNearestInDomainAsync` for the semantic phase (#333 Finding 4 unified them; the former unbounded in-memory batch scan was removed).
 
 Cross-tenant operations return **404, not 403**, on `GET`, `PATCH`, and `DELETE` so existence is not disclosed.
 

--- a/src/ExpertiseApi/Data/ExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/ExpertiseRepository.cs
@@ -610,16 +610,6 @@ internal class ExpertiseRepository(
         return distance.Value <= maxDistance ? candidate : null;
     }
 
-    public async Task<List<ExpertiseEntry>> FindAllEmbeddingsInDomainAsync(string domain, TenantContext ctx, CancellationToken ct)
-    {
-        return await ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx)
-            .Where(e => e.DeprecatedAt == null)
-            .Where(e => e.ReviewState != ReviewState.Rejected)
-            .Where(e => e.Domain == domain)
-            .Where(e => e.Embedding != null)
-            .ToListAsync(ct);
-    }
-
     public async Task<List<ExpertiseEntry>> ListSharedApprovedUpdatedAfterAsync(
         DateTime afterUpdatedAt, Guid afterId, int limit, CancellationToken ct)
     {

--- a/src/ExpertiseApi/Data/IExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/IExpertiseRepository.cs
@@ -91,8 +91,6 @@ internal interface IExpertiseRepository
 
     Task<ExpertiseEntry?> FindNearestInDomainAsync(string domain, Vector queryVector, double maxDistance, TenantContext ctx, CancellationToken ct = default);
 
-    Task<List<ExpertiseEntry>> FindAllEmbeddingsInDomainAsync(string domain, TenantContext ctx, CancellationToken ct = default);
-
     /// <summary>
     /// Up-sync feed (ADR-013): Approved, non-deprecated entries in the cross-tenant
     /// <c>shared</c> namespace strictly after the keyset cursor

--- a/src/ExpertiseApi/Services/DeduplicationService.cs
+++ b/src/ExpertiseApi/Services/DeduplicationService.cs
@@ -81,10 +81,6 @@ internal class DeduplicationService(IExpertiseRepository repo, IOptions<Deduplic
                 .GroupBy(e => e.Title, StringComparer.OrdinalIgnoreCase)
                 .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.OrdinalIgnoreCase);
 
-            // Bulk semantic: fetch all domain embeddings once, match in memory
-            List<ExpertiseEntry>? domainEntries = null;
-            List<float[]>? domainEntryArrays = null;
-
             foreach (var item in items)
             {
                 // Check exact match — any candidate sharing the title whose body also matches
@@ -98,40 +94,21 @@ internal class DeduplicationService(IExpertiseRepository repo, IOptions<Deduplic
                     }
                 }
 
-                // Check semantic match in memory
-                domainEntries ??= await repo.FindAllEmbeddingsInDomainAsync(domain, ctx, ct);
+                // Semantic match via the same HNSW-indexed, DB-side nearest-neighbour query
+                // the single-create path uses (#333 Finding 4). Replaces the former
+                // "load every domain embedding into memory and brute-force in C#" scan,
+                // which was O(batchSize x domainSize) and unbounded in memory as a domain
+                // grew. Bounded to one indexed query per item; sequential because the
+                // scoped DbContext is not thread-safe. Consolidating onto
+                // FindNearestInDomainAsync also removes the behaviour drift between the
+                // batch and single-create dedup paths. Trade: batch dedup is now
+                // approximate-NN (HNSW) like single-create already is — a miss lands as a
+                // Draft for curator review, per the DeduplicationOptions.SemanticThreshold
+                // risk posture.
+                var nearest = await repo.FindNearestInDomainAsync(
+                    domain, item.Embedding, opts.SemanticThreshold, ctx, ct);
 
-                // Precompute domain entry arrays once per domain group, skipping null embeddings
-                if (domainEntryArrays is null)
-                {
-                    domainEntries = domainEntries.Where(e => e.Embedding != null).ToList();
-                    domainEntryArrays = domainEntries.Select(e => e.Embedding!.ToArray()).ToList();
-                }
-
-                // Compute query vector once per item
-                var queryVec = item.Embedding.ToArray();
-
-                ExpertiseEntry? nearest = null;
-                double nearestDistance = double.MaxValue;
-
-                for (var i = 0; i < domainEntries.Count; i++)
-                {
-                    var distance = ExpertiseRepository.CosineDistance(domainEntryArrays[i], queryVec);
-
-                    if (distance is not null && distance.Value <= opts.SemanticThreshold && distance.Value < nearestDistance)
-                    {
-                        nearest = domainEntries[i];
-                        nearestDistance = distance.Value;
-                    }
-                }
-
-                if (nearest is not null)
-                {
-                    results[item.Index] = (true, nearest);
-                    continue;
-                }
-
-                results[item.Index] = (false, null);
+                results[item.Index] = nearest is not null ? (true, nearest) : (false, null);
             }
         }
 

--- a/tests/ExpertiseApi.Tests/Integration/BatchEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/BatchEndpointTests.cs
@@ -117,6 +117,43 @@ public class BatchEndpointTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Batch_AgainstPopulatedDomainCorpus_DedupsPerItem_WithoutUnboundedScan()
+    {
+        // #333 Finding 4: the batch dedup path used to load EVERY embedding in the domain
+        // into memory and brute-force cosine distance in C# (O(batchSize x domainSize),
+        // unbounded as a domain grows). It now issues one HNSW-indexed
+        // FindNearestInDomainAsync per item — the same DB-side query the single-create
+        // path uses. This drives that path against a domain corpus larger than any prior
+        // batch fixture to prove it stays correct and bounded with a populated index.
+        //
+        // The content-derived mock embedding generator is all-or-nothing (identical vs
+        // orthogonal), so a GRADED near-dup cannot be produced here — the semantic
+        // threshold itself is validated by the EXPERTISE_EVAL DedupThresholdEvalTests
+        // against the real model. This test proves the exact-match verdict and the
+        // per-item semantic MISS (a distinct item is not a false duplicate) both hold
+        // when the domain is well populated.
+        const string domain = "populated-corpus-domain";
+        for (var i = 0; i < 30; i++)
+            await SeedApproved(domain, $"corpus title {i}", $"corpus body number {i}");
+        var dupTarget = await SeedApproved(domain, "corpus duplicate anchor", "anchor body");
+
+        var client = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);
+        var response = await client.PostAsJsonAsync("/expertise/batch", new[]
+        {
+            Item(domain, "corpus duplicate anchor", "anchor body"), // exact dup of dupTarget
+            Item(domain, "genuinely new in corpus", "unrelated new body"), // distinct -> Created
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.MultiStatus);
+        var results = (await response.Content.ReadFromJsonAsync<List<BatchResult>>())!;
+        results.Should().HaveCount(2);
+        results[0].Status.Should().Be("Duplicate");
+        results[0].Id.Should().Be(dupTarget.Id);
+        results[1].Status.Should().Be("Created", "a distinct item is not a false semantic duplicate even in a populated domain");
+        results[1].Id.Should().NotBeNull();
+    }
+
+    [Fact]
     public async Task Batch_AllValidDistinctItems_Returns200()
     {
         var client = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);

--- a/tests/ExpertiseApi.Tests/Unit/DeduplicationServiceTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/DeduplicationServiceTests.cs
@@ -177,8 +177,8 @@ public class DeduplicationServiceTests
 
         _repo.FindExactMatchesAsync("shared", Arg.Any<IReadOnlyList<string>>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns(new List<ExpertiseEntry>());
-        _repo.FindAllEmbeddingsInDomainAsync("shared", Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
-            .Returns(new List<ExpertiseEntry>());
+        _repo.FindNearestInDomainAsync("shared", Arg.Any<Vector>(), Arg.Any<double>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
+            .Returns((ExpertiseEntry?)null);
 
         var results = await service.CheckBatchAsync(requests, vectors, _ctx);
 
@@ -193,15 +193,17 @@ public class DeduplicationServiceTests
         var requests = new List<CreateExpertiseRequest> { CreateRequest(title: "Unique Title") };
         var vectors = new List<Vector> { _testVector };
 
-        // No exact title match — entry title differs
+        // No exact title match — entry title differs. The batch path now delegates the
+        // semantic match to the same FindNearestInDomainAsync the single-create path uses
+        // (#333 Finding 4), which applies the threshold in SQL/HNSW; the unit test stubs
+        // its result and the repo's own threshold behaviour is covered by integration tests.
         var domainEntry = TestHelpers.SeedEntry(title: "Similar But Different Title");
-        // Use the same vector so cosine distance == 0, well below any sane threshold
         domainEntry.Embedding = _testVector;
 
         _repo.FindExactMatchesAsync("shared", Arg.Any<IReadOnlyList<string>>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns(new List<ExpertiseEntry>());
-        _repo.FindAllEmbeddingsInDomainAsync("shared", Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
-            .Returns([domainEntry]);
+        _repo.FindNearestInDomainAsync("shared", Arg.Any<Vector>(), Arg.Any<double>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
+            .Returns(domainEntry);
 
         var results = await service.CheckBatchAsync(requests, vectors, _ctx);
 
@@ -211,25 +213,18 @@ public class DeduplicationServiceTests
     }
 
     [Fact]
-    public async Task CheckBatchAsync_WithSemanticMatchAboveThreshold_ReturnsNotDuplicate()
+    public async Task CheckBatchAsync_WhenNearestIsBeyondThreshold_ReturnsNotDuplicate()
     {
-        var service = CreateService(threshold: 0.01); // very tight threshold
+        // The repo's nearest-neighbour query returns null when nothing is within the
+        // threshold; the service must treat that item as not-a-duplicate.
+        var service = CreateService();
         var requests = new List<CreateExpertiseRequest> { CreateRequest(title: "Unique Title") };
-
-        // Build a vector that is orthogonal to _testVector (cosine distance == 1)
-        var orthogonalValues = new float[512];
-        orthogonalValues[0] = 1.0f; // all other dims zero — orthogonal to random _testVector
-        var farVector = new Vector(orthogonalValues);
-
-        var vectors = new List<Vector> { farVector };
-
-        var domainEntry = TestHelpers.SeedEntry(title: "Similar But Different Title");
-        domainEntry.Embedding = _testVector; // very different direction
+        var vectors = new List<Vector> { _testVector };
 
         _repo.FindExactMatchesAsync("shared", Arg.Any<IReadOnlyList<string>>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns(new List<ExpertiseEntry>());
-        _repo.FindAllEmbeddingsInDomainAsync("shared", Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
-            .Returns([domainEntry]);
+        _repo.FindNearestInDomainAsync("shared", Arg.Any<Vector>(), Arg.Any<double>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
+            .Returns((ExpertiseEntry?)null);
 
         var results = await service.CheckBatchAsync(requests, vectors, _ctx);
 
@@ -251,8 +246,9 @@ public class DeduplicationServiceTests
         var existingEntry = TestHelpers.SeedEntry(title: "Duplicate", body: "Same body");
         _repo.FindExactMatchesAsync("shared", Arg.Any<IReadOnlyList<string>>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns([existingEntry]);
-        _repo.FindAllEmbeddingsInDomainAsync("shared", Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
-            .Returns(new List<ExpertiseEntry>());
+        // Item 0 is caught by exact-match; item 1 has no near neighbour.
+        _repo.FindNearestInDomainAsync("shared", Arg.Any<Vector>(), Arg.Any<double>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
+            .Returns((ExpertiseEntry?)null);
 
         var results = await service.CheckBatchAsync(requests, vectors, _ctx);
 


### PR DESCRIPTION
**PR 2 of 4** in the #333 series (Finding 4, part A — the dominant cost). Non-breaking, PATCH-level. Follows #471 (PR 1).

## Problem (Finding 4)

`DeduplicationService.CheckBatchAsync` loaded **every** embedding in a domain into memory once per batch and brute-forced cosine distance in C# — `O(batchSize × domainSize)`, with `FindAllEmbeddingsInDomainAsync` unbounded (no `LIMIT`). A single permitted batch against a large domain (e.g. `shared`, which accumulates across tenants + aggregator up-sync) pays the full unbounded cost regardless of request rate. All three design agents flagged this as Finding 4's dominant cost, not the embed count.

## Fix

Replace the load-all + in-memory scan with **one HNSW-indexed `FindNearestInDomainAsync` per item** — the exact DB-side query the single-create path already uses:
- Bounded to an indexed query per item; **O(1) memory** per query regardless of domain size.
- Sequential (the scoped `DbContext` isn't thread-safe); for the 100-item batch cap this is well within budget and far safer than materializing a whole domain's embeddings.
- **Unifies** the two dedup paths, removing a latent behaviour drift (batch was exact brute-force; single-create was approximate HNSW). Batch is now approximate-NN too — a miss lands as a Draft for curator review, consistent with the `SemanticThreshold` risk posture.

`FindAllEmbeddingsInDomainAsync` had no other caller and is removed from the repository + interface.

## Why not a bounded `Take(N)`

A `Take(N)` would sacrifice dedup completeness (a real near-dup past the window becomes undetectable). Per-item KNN is both bounded **and** complete, so no completeness-sacrificing config knob is needed.

## Tests

- Batch unit tests restubbed onto `FindNearestInDomainAsync`.
- New integration test drives the per-item path against a **31-entry domain corpus** (larger than any prior batch fixture), asserting exact-match and semantic-miss verdicts hold with a populated index.
- The graded semantic threshold stays covered by the `EXPERTISE_EVAL` `DedupThresholdEvalTests` (the content-derived integration mock is all-or-nothing, so a graded near-dup can't be produced there — documented in the test).
- Full suite 433 passed / 3 skipped; `dotnet format analyzers` clean. `DESIGN.md` dedup-scoping note updated.

## Series context

PR 1 #471 (fail-closed PII) merged. Next: PR 3 (batch rate policy), then a **v1.6.1** release, then PR 4 (Finding 1) opens the breaking **v2.0.0** tree. Follow-ups: #468 / #469 / #470.

Refs #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)