### PR TITLE
fix(ratelimit): dedicated batch rate policy for the batch endpoint

### DIFF
--- a/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
@@ -103,12 +103,13 @@ internal static class ExpertiseEndpoints
 
         group.MapPost("/batch", CreateBatch)
             .RequireAuthorization("WriteAccess")
-            .RequireRateLimiting("expertise-write")
+            .RequireRateLimiting("expertise-batch")
             .Accepts<List<CreateExpertiseRequest>>("application/json")
             .WithSummary("Batch ingest up to 100 entries with per-item failure isolation")
             .WithDescription("Returns 200 with `BatchEntryResult[]` when every item is Created, or 207 (Multi-Status) when any item is " +
-                             "Duplicate / Rejected / Failed. Embedding generation and deduplication are batched into a single ONNX call " +
-                             "and bulk DB query respectively, so partial failures in one phase do not roll back successful items.")
+                             "Duplicate / Rejected / Failed. Embedding generation is batched into a single ONNX call; deduplication " +
+                             "runs an HNSW-indexed nearest-neighbour query per item. Partial failures in one phase do not roll back " +
+                             "successful items. Rate-limited under a dedicated stricter policy than single writes (#333 Finding 4).")
             .Produces<List<BatchEntryResult>>(StatusCodes.Status200OK)
             .Produces<List<BatchEntryResult>>(StatusCodes.Status207MultiStatus)
             .ProducesProblem(StatusCodes.Status400BadRequest)

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -201,12 +201,13 @@ builder.Services.AddProblemDetails(options =>
 // produces the response body (and the customizer above fires).
 builder.Services.AddExceptionHandler<UnhandledExceptionLogger>();
 
-// Rate limiting (Part D C5). Three policies, per-principal partitioning with IP
+// Rate limiting (Part D C5). Four policies, per-principal partitioning with IP
 // fallback for unauthenticated paths. 429 responses route through the
 // IProblemDetailsService so the C4 customizer fires (correlation traceId, etc.)
 // and Retry-After is populated from the lease metadata.
 //   - expertise-read     fixed window 60/min  GET /expertise/* (non-semantic), GET /audit/*
-//   - expertise-write    fixed window 10/min  POST/PATCH/DELETE on writes
+//   - expertise-write    fixed window 10/min  POST/PATCH/DELETE on single writes
+//   - expertise-batch    fixed window  2/min  POST /expertise/batch (#333 Finding 4)
 //   - semantic-search    token bucket 10/min  /expertise/search/semantic (expensive: ONNX)
 // Health endpoints (/health/*) opt out via DisableRateLimiting in HealthEndpoints.
 builder.Services.AddRateLimiter(rateOptions =>
@@ -271,6 +272,25 @@ builder.Services.AddRateLimiter(rateOptions =>
             factory: _ => new FixedWindowRateLimiterOptions
             {
                 PermitLimit = 10,
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            }));
+
+    // #333 Finding 4: POST /expertise/batch previously shared "expertise-write"
+    // (10/min), so one principal could push up to 10 batches x 100 items = ~1,000
+    // embed-units/min through the single, process-wide ONNX inference lane
+    // (EmbeddingService.InferenceGate) — starving every other caller's single-item
+    // writes and semantic-search queries. The static InferenceGate bounds concurrent
+    // OVERLAP but not throughput fairness. A dedicated stricter window caps a batch
+    // caller at 2 x 100 = ~200 embed-units/min while still comfortably serving the
+    // aggregator up-sync worker (ADR-013), which pushes at most one batch per sync tick.
+    rateOptions.AddPolicy("expertise-batch", http =>
+        RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: PartitionKey(http),
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 2,
                 Window = TimeSpan.FromMinutes(1),
                 QueueLimit = 0,
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,

--- a/tests/ExpertiseApi.Tests/Integration/BatchEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/BatchEndpointTests.cs
@@ -154,6 +154,27 @@ public class BatchEndpointTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Batch_ExceedingBatchRatePolicy_Returns429_OnThirdRequest()
+    {
+        // #333 Finding 4: /expertise/batch has its own "expertise-batch" policy
+        // (fixed window, PermitLimit = 2/min) instead of sharing "expertise-write"
+        // (10/min), so a batch caller cannot push ~1,000 embed-units/min through the
+        // single ONNX lane. A fresh JwtApiFactory per test method gives a clean window,
+        // and one token = one partition (per-principal sub), so three sequential batch
+        // requests exhaust the 2-permit budget and the third is rejected.
+        var client = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);
+
+        var first = await client.PostAsJsonAsync("/expertise/batch", new[] { Item(UniqueDomain(), "b1", "body one") });
+        var second = await client.PostAsJsonAsync("/expertise/batch", new[] { Item(UniqueDomain(), "b2", "body two") });
+        var third = await client.PostAsJsonAsync("/expertise/batch", new[] { Item(UniqueDomain(), "b3", "body three") });
+
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
+        third.StatusCode.Should().Be(HttpStatusCode.TooManyRequests,
+            "the dedicated batch policy caps a principal at 2 batch requests per window");
+    }
+
+    [Fact]
     public async Task Batch_AllValidDistinctItems_Returns200()
     {
         var client = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);


### PR DESCRIPTION
**PR 3 of 4** in the #333 series (Finding 4, part B — throughput fairness). Non-breaking, PATCH-level. Follows #471, #472.

## Problem (Finding 4)

`POST /expertise/batch` (up to 100 items) shared the `expertise-write` fixed-window policy (10/min), so one principal could push up to **10 batches × 100 items = ~1,000 embed-units/min** through the single, process-wide ONNX inference lane (`EmbeddingService.InferenceGate`), starving every other caller's single-item writes and semantic-search queries. The `InferenceGate` added in the model swap bounds concurrent **overlap** but not throughput **fairness** across that shared single-flight resource.

## Fix

Add a dedicated `expertise-batch` fixed-window policy (**2/min**) and point the route at it. Worst case drops to 2 × 100 = ~200 embed-units/min — still comfortably above the aggregator up-sync worker's cadence (ADR-013 pushes at most one batch per interval tick). Declarative named policy, matching the existing `expertise-write`/`semantic-search` shape (not manual per-item permit accounting, which is the more precise but bigger follow-up #469).

## Test

Three sequential batch requests from one principal exhaust the 2-permit window; the third returns **429**. Deterministic: a fresh `JwtApiFactory` per test method gives a clean window, and one token = one partition (per-principal `sub`).

Full suite 434 passed / 3 skipped; `dotnet format analyzers` clean. Endpoint description updated (non-breaking prose; also corrects the now-per-item dedup wording).

## Series context

PRs #471 (fail-closed PII) and #472 (bounded batch dedup) merged. **After this merges, a v1.6.1 release is planned** (promote `dev → main`; these three `fix` commits + the earlier #465/#466/#467 aggregate to a PATCH bump), then PR 4 (Finding 1) opens the breaking **v2.0.0** tree. Follow-ups: #468 / #469 / #470.

Refs #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)