### PR TITLE
chore(release): promote dev to main (v1.6.1)

### DIFF
--- a/.agents/skills/expertise-api/SKILL.md
+++ b/.agents/skills/expertise-api/SKILL.md
@@ -17,23 +17,26 @@ Do **not** invoke this skill for: API design questions, schema decisions, scope-
 
 ## Prerequisites
 
-The skill scripts require two environment variables. The skill will fail loudly if either is missing.
+The skill scripts require a base URL and a bearer token. The skill will fail loudly if either is missing.
 
 | Variable | Purpose | Example |
 | --- | --- | --- |
 | `EXPERTISE_API_BASE_URL` | Origin of the API. No trailing slash. | `https://expertise.example.com` |
-| `EXPERTISE_API_TOKEN` | Bearer token. JWT for OIDC mode, or `dev:{tenant}:{scopes}` for LocalDev. | `dev:teamA:expertise.read+expertise.write.draft` |
+| `EXPERTISE_API_TOKEN` | Bearer token. JWT for OIDC mode, or `dev:{tenant}:{scopes}` for LocalDev. Wins over `EXPERTISE_API_TOKEN_FILE` when both are set. | `dev:teamA:expertise.read+expertise.write.draft` |
+| `EXPERTISE_API_TOKEN_FILE` | Path to a file holding the token (trailing newline stripped). Used when `EXPERTISE_API_TOKEN` is unset. **Recommended** — keeps the bearer literal out of the env file. | `~/tokens/expertise.jwt` |
 
-If the user has not set them, prompt for the values once and offer to write them to `~/.config/expertise-api/secrets.env`:
+If the user has not set them, prompt for the values once and offer to write them to `~/.config/expertise-api/secrets.env`. Prefer the token-file form:
 
 ```sh
 mkdir -p ~/.config/expertise-api
 cat > ~/.config/expertise-api/secrets.env <<'EOF'
 EXPERTISE_API_BASE_URL=https://expertise.example.com
-EXPERTISE_API_TOKEN=...
+EXPERTISE_API_TOKEN_FILE=/path/to/token.jwt
 EOF
 chmod 600 ~/.config/expertise-api/secrets.env
 ```
+
+(Inlining `EXPERTISE_API_TOKEN=...` instead also works; the file indirection just avoids a secret literal that secret scanners and session guards would otherwise flag.)
 
 The scripts source this file automatically when present, so env vars do not need to be exported per-shell.
 

--- a/.agents/skills/expertise-api/references/DESIGN.md
+++ b/.agents/skills/expertise-api/references/DESIGN.md
@@ -186,7 +186,7 @@ When the principal authenticates successfully but no tenant maps (e.g. group not
 2. **Repository** — primary safeguard. Each method applies an explicit `WHERE Tenant IN (ctx.Tenant, "shared")`; `GetByIdAsync`, `UpdateAsync`, and `SoftDeleteAsync` use `Where(id) + FirstOrDefaultAsync` rather than `FindAsync` so the filter cannot be bypassed via the EF identity map.
 3. **EF global query filter** — `HasQueryFilter` on `ExpertiseEntry` reads `ITenantContextAccessor.Tenant` (HTTP-backed). Defense-in-depth: when a future query forgets the explicit `WHERE`, this still applies. Short-circuits to no filter when the accessor returns null (CLI / design-time / direct test seeding) — those paths rely on the explicit repository `WHERE` for correctness.
 4. **CLI bypass** — `reembed` and `rehash` commands call `IgnoreQueryFilters()` explicitly so they process every tenant.
-5. **Dedup tenant scoping** — `FindExactMatchAsync`, `FindExactMatchesAsync`, `FindNearestInDomainAsync`, and `FindAllEmbeddingsInDomainAsync` are tenant-scoped so a `409 Conflict` on `POST /expertise` cannot leak another tenant's entry contents in the response body.
+5. **Dedup tenant scoping** — `FindExactMatchAsync`, `FindExactMatchesAsync`, and `FindNearestInDomainAsync` are tenant-scoped so a `409 Conflict` on `POST /expertise` cannot leak another tenant's entry contents in the response body. Both the single-create and batch dedup paths use the HNSW-indexed `FindNearestInDomainAsync` for the semantic phase (#333 Finding 4 unified them; the former unbounded in-memory batch scan was removed).
 
 Cross-tenant operations return **404, not 403**, on `GET`, `PATCH`, and `DELETE` so existence is not disclosed.
 

--- a/.agents/skills/expertise-api/scripts/lib/common.sh
+++ b/.agents/skills/expertise-api/scripts/lib/common.sh
@@ -9,6 +9,13 @@
 # Provides:
 #   - load_secrets       Source ~/.config/expertise-api/secrets.env if present.
 #   - require_env        Fail loudly if EXPERTISE_API_BASE_URL/_TOKEN unset.
+#                        Resolves EXPERTISE_API_TOKEN_FILE indirection first
+#                        (issue #464): when EXPERTISE_API_TOKEN is empty and
+#                        EXPERTISE_API_TOKEN_FILE names a readable non-empty
+#                        file, the token is read from that file. Token-by-path
+#                        is the recommended contract for agent hosts — no
+#                        bearer literal sits in an env file for scanners or
+#                        session hooks to trip on.
 #   - api_curl ARGS...   Wrap curl with -sS, Bearer auth, and HTTP-status check.
 #                        Writes response body to stdout. On non-2xx, writes the
 #                        body to stderr along with the status line and exits 1.
@@ -46,14 +53,49 @@ load_secrets() {
     fi
 }
 
+# _resolve_token
+# Resolution ladder (issue #464), mirrored by the pi extension's
+# resolveToken() in .pi/extensions/expertise-api/index.ts:
+#   1. EXPERTISE_API_TOKEN set and non-empty       -> wins (explicit beats
+#      indirection, the standard *_FILE convention).
+#   2. EXPERTISE_API_TOKEN_FILE set                -> read the file; trailing
+#      newline/whitespace stripped. A missing, unreadable, or empty file is a
+#      hard exit 2 naming the path — never a silent fall-through to "not set",
+#      which would misdiagnose a bad path as absent configuration.
+#   3. Neither                                     -> leave unset; require_env
+#      reports both variables.
+_resolve_token() {
+    if [ -n "${EXPERTISE_API_TOKEN:-}" ]; then
+        return 0
+    fi
+    if [ -z "${EXPERTISE_API_TOKEN_FILE:-}" ]; then
+        return 0
+    fi
+    if [ ! -f "$EXPERTISE_API_TOKEN_FILE" ] || [ ! -r "$EXPERTISE_API_TOKEN_FILE" ]; then
+        echo "error: EXPERTISE_API_TOKEN_FILE points to a missing or unreadable file: ${EXPERTISE_API_TOKEN_FILE}" >&2
+        exit 2
+    fi
+    # $(cat ...) strips trailing newlines; the extra trim handles a file whose
+    # last line carries trailing spaces/tabs (e.g. hand-edited token files).
+    EXPERTISE_API_TOKEN="$(cat "$EXPERTISE_API_TOKEN_FILE")"
+    while [ "${EXPERTISE_API_TOKEN%[[:space:]]}" != "$EXPERTISE_API_TOKEN" ]; do
+        EXPERTISE_API_TOKEN="${EXPERTISE_API_TOKEN%[[:space:]]}"
+    done
+    if [ -z "$EXPERTISE_API_TOKEN" ]; then
+        echo "error: EXPERTISE_API_TOKEN_FILE is empty: ${EXPERTISE_API_TOKEN_FILE}" >&2
+        exit 2
+    fi
+}
+
 require_env() {
+    _resolve_token
     local missing=0
     if [ -z "${EXPERTISE_API_BASE_URL:-}" ]; then
         echo "error: EXPERTISE_API_BASE_URL is not set" >&2
         missing=1
     fi
     if [ -z "${EXPERTISE_API_TOKEN:-}" ]; then
-        echo "error: EXPERTISE_API_TOKEN is not set" >&2
+        echo "error: EXPERTISE_API_TOKEN is not set (set it, or point EXPERTISE_API_TOKEN_FILE at a token file)" >&2
         missing=1
     fi
     if [ "$missing" -ne 0 ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,9 @@ jobs:
       - name: Run model-download staleness tests (#456)
         run: bash tests/install/test-download-models.sh
 
+      - name: Run skill token-file resolution tests (#464)
+        run: bash tests/skill/test-common-token-file.sh
+
   install-script-guards:
     name: install/uninstall script guard tests (#242)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,10 +377,6 @@ jobs:
   install-smoke-macos:
     name: install.sh end-to-end smoke (macOS / launchd / postgres-17)
     runs-on: macos-latest
-    # Non-blocking until the upstream Homebrew postgresql@17 bottle is fixed (#366):
-    # the runner bottle has a share-dir path mismatch that fails initdb. The job
-    # still runs and reports; it just does not gate merges. REMOVE when #366 closes.
-    continue-on-error: true
     timeout-minutes: 15
     # E2 of #166 / closes #259. Sibling of install-smoke-linux above: same
     # harness (scripts/test/test-install-smoke.sh), different OS provisioning.
@@ -477,9 +473,6 @@ jobs:
   install-smoke-macos-system:
     name: "install.sh end-to-end smoke (macOS / LaunchDaemon / system scope / #145)"
     runs-on: macos-latest
-    # Non-blocking until the upstream Homebrew postgresql@17 bottle is fixed (#366).
-    # REMOVE when #366 closes.
-    continue-on-error: true
     timeout-minutes: 15
     # System-scope LaunchDaemon smoke (#145). GHA macOS runners have passwordless
     # sudo, so a real root install is exercisable here. Gated behind

--- a/.github/workflows/install-smoke-from-release.yml
+++ b/.github/workflows/install-smoke-from-release.yml
@@ -167,9 +167,6 @@ jobs:
   install-smoke-macos-from-release:
     name: install.sh --from-release smoke (macOS / launchd / postgres-17)
     runs-on: macos-latest
-    # Non-blocking until the upstream Homebrew postgresql@17 bottle is fixed (#366).
-    # REMOVE when #366 closes.
-    continue-on-error: true
     timeout-minutes: 15
     # macOS GHA runners have no Docker daemon. Unlike the Linux job there is
     # no privileged-container requirement so no fork-PR guard is needed —

--- a/.pi/extensions/expertise-api/README.md
+++ b/.pi/extensions/expertise-api/README.md
@@ -46,10 +46,14 @@ Same as the action skill. Set either via shell environment or
 mkdir -p ~/.config/expertise-api
 cat > ~/.config/expertise-api/secrets.env <<'EOF'
 EXPERTISE_API_BASE_URL=https://expertise.example.com
-EXPERTISE_API_TOKEN=...
+EXPERTISE_API_TOKEN_FILE=/path/to/token.jwt
 EOF
 chmod 600 ~/.config/expertise-api/secrets.env
 ```
+
+`EXPERTISE_API_TOKEN_FILE` (recommended) points at a file holding the token —
+no bearer literal in the env file. Setting `EXPERTISE_API_TOKEN=...` directly
+also works and wins when both are present (#464).
 
 The token reaches `fetch()` via an HTTP header — it is **not** visible in `ps`/`/proc` like the skill's `curl`-based path.
 

--- a/.pi/extensions/expertise-api/index.ts
+++ b/.pi/extensions/expertise-api/index.ts
@@ -10,8 +10,12 @@
  * this extension is the native pi path.
  *
  * Env contract (same as the skill):
- *   EXPERTISE_API_BASE_URL  Origin of the API (no trailing slash).
- *   EXPERTISE_API_TOKEN     Bearer token: OIDC JWT or LocalDev "dev:t:s+s".
+ *   EXPERTISE_API_BASE_URL    Origin of the API (no trailing slash).
+ *   EXPERTISE_API_TOKEN       Bearer token: OIDC JWT or LocalDev "dev:t:s+s".
+ *   EXPERTISE_API_TOKEN_FILE  Path to a file holding the token (issue #464).
+ *                             Used when EXPERTISE_API_TOKEN is unset/empty;
+ *                             recommended on agent hosts so no bearer literal
+ *                             sits in an env file.
  *
  * Auto-sources ~/.config/expertise-api/secrets.env (or
  * $EXPERTISE_API_SECRETS_FILE) on extension load.
@@ -158,14 +162,56 @@ function getBaseUrl(): string {
 	return normalised;
 }
 
-function getToken(): string {
-	const tok = process.env.EXPERTISE_API_TOKEN;
-	if (!tok || tok.trim() === "") {
-		throw new Error(
-			"EXPERTISE_API_TOKEN is not set. Export it or write it to ~/.config/expertise-api/secrets.env.",
-		);
+/**
+ * Resolve the bearer token (issue #464). Mirrors the skill's
+ * _resolve_token in .agents/skills/expertise-api/scripts/lib/common.sh:
+ *
+ *   1. EXPERTISE_API_TOKEN set and non-empty -> wins (explicit beats
+ *      indirection, the standard *_FILE convention).
+ *   2. EXPERTISE_API_TOKEN_FILE set -> read the file, trim trailing
+ *      whitespace. A missing, unreadable, or empty file throws naming the
+ *      path — never a silent fall-through to "not set", which would
+ *      misdiagnose a bad path as absent configuration.
+ *   3. Neither -> throw naming both variables.
+ *
+ * Re-read on every call (one API call each) so a rotated token file is
+ * picked up without restarting the extension. Exported (vs inlined into
+ * apiCall) so unit tests can assert the ladder without mocking fetch;
+ * `env` is injectable for the same reason and defaults to process.env.
+ */
+export function resolveToken(
+	env: Record<string, string | undefined> = process.env,
+): string {
+	const tok = env.EXPERTISE_API_TOKEN;
+	if (tok && tok.trim() !== "") {
+		return tok;
 	}
-	return tok;
+	let tokenFile = env.EXPERTISE_API_TOKEN_FILE;
+	if (tokenFile && tokenFile.trim() !== "") {
+		// secrets.env is shared with the shell skill, where `VAR=~/path` is a
+		// shell assignment and the tilde expands. This loader parses the file
+		// as plain text, so expand a leading `~/` here for parity — otherwise
+		// the same secrets.env works under the skill and fails under pi.
+		if (tokenFile.startsWith("~/")) {
+			tokenFile = path.join(os.homedir(), tokenFile.slice(2));
+		}
+		let contents: string;
+		try {
+			contents = fs.readFileSync(tokenFile, "utf8");
+		} catch {
+			throw new Error(
+				`EXPERTISE_API_TOKEN_FILE points to a missing or unreadable file: ${tokenFile}`,
+			);
+		}
+		const fileToken = contents.trimEnd();
+		if (fileToken === "") {
+			throw new Error(`EXPERTISE_API_TOKEN_FILE is empty: ${tokenFile}`);
+		}
+		return fileToken;
+	}
+	throw new Error(
+		"EXPERTISE_API_TOKEN is not set (set it, or point EXPERTISE_API_TOKEN_FILE at a token file). Write either to ~/.config/expertise-api/secrets.env.",
+	);
 }
 
 async function apiCall(
@@ -174,7 +220,7 @@ async function apiCall(
 	signal?: AbortSignal,
 ): Promise<ApiCallResult> {
 	const base: string = getBaseUrl();
-	const token: string = getToken();
+	const token: string = resolveToken();
 	const url: string = `${base}${pathAndQuery}`;
 	const headers: Headers = new Headers(init.headers ?? {});
 	headers.set("Authorization", `Bearer ${token}`);

--- a/.pi/extensions/expertise-api/package.json
+++ b/.pi/extensions/expertise-api/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "test": "node --import tsx --test apiCall.test.ts"
+    "test": "node --import tsx --test apiCall.test.ts resolveToken.test.ts"
   },
   "devDependencies": {
     "@earendil-works/pi-ai": "0.81.1",

--- a/.pi/extensions/expertise-api/resolveToken.test.ts
+++ b/.pi/extensions/expertise-api/resolveToken.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for resolveToken (issue #464).
+ *
+ * Runs via `node --test` (same harness as apiCall.test.ts). The env is
+ * injected as a plain object, so no process.env mutation and no fetch
+ * mocking is needed; the file cases use real temp files.
+ *
+ * Contract being asserted (mirrors the skill's _resolve_token in
+ * .agents/skills/expertise-api/scripts/lib/common.sh):
+ *   1. EXPERTISE_API_TOKEN set and non-empty wins over the file.
+ *   2. EXPERTISE_API_TOKEN_FILE is read when the token is unset/empty,
+ *      with trailing whitespace stripped.
+ *   3. Missing/unreadable file throws naming the path (no silent
+ *      fall-through to "not set").
+ *   4. Empty file throws.
+ *   5. Neither variable set throws naming both variables.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { resolveToken } from "./index.js";
+
+const workDir: string = fs.mkdtempSync(path.join(os.tmpdir(), "resolve-token-"));
+process.on("exit", () => {
+	fs.rmSync(workDir, { recursive: true, force: true });
+});
+
+test("resolveToken: reads the token from EXPERTISE_API_TOKEN_FILE", () => {
+	const tokenFile = path.join(workDir, "token1");
+	fs.writeFileSync(tokenFile, "file-token-value\n");
+	assert.equal(
+		resolveToken({ EXPERTISE_API_TOKEN_FILE: tokenFile }),
+		"file-token-value",
+	);
+});
+
+test("resolveToken: explicit EXPERTISE_API_TOKEN beats the file", () => {
+	const tokenFile = path.join(workDir, "token2");
+	fs.writeFileSync(tokenFile, "file-token-value\n");
+	assert.equal(
+		resolveToken({
+			EXPERTISE_API_TOKEN: "explicit-wins",
+			EXPERTISE_API_TOKEN_FILE: tokenFile,
+		}),
+		"explicit-wins",
+	);
+});
+
+test("resolveToken: whitespace-only EXPERTISE_API_TOKEN falls through to the file", () => {
+	const tokenFile = path.join(workDir, "token3");
+	fs.writeFileSync(tokenFile, "file-token-value\n");
+	assert.equal(
+		resolveToken({
+			EXPERTISE_API_TOKEN: "   ",
+			EXPERTISE_API_TOKEN_FILE: tokenFile,
+		}),
+		"file-token-value",
+	);
+});
+
+test("resolveToken: missing file throws naming the path", () => {
+	const missing = path.join(workDir, "does-not-exist");
+	assert.throws(
+		() => resolveToken({ EXPERTISE_API_TOKEN_FILE: missing }),
+		new RegExp(`missing or unreadable file: .*does-not-exist`),
+	);
+});
+
+test("resolveToken: empty file throws", () => {
+	const emptyFile = path.join(workDir, "empty");
+	fs.writeFileSync(emptyFile, "");
+	assert.throws(
+		() => resolveToken({ EXPERTISE_API_TOKEN_FILE: emptyFile }),
+		/EXPERTISE_API_TOKEN_FILE is empty/,
+	);
+});
+
+test("resolveToken: whitespace-only file content throws as empty", () => {
+	const blankFile = path.join(workDir, "blank");
+	fs.writeFileSync(blankFile, " \t\n");
+	assert.throws(
+		() => resolveToken({ EXPERTISE_API_TOKEN_FILE: blankFile }),
+		/EXPERTISE_API_TOKEN_FILE is empty/,
+	);
+});
+
+test("resolveToken: trailing whitespace stripped from file token", () => {
+	const paddedFile = path.join(workDir, "padded");
+	fs.writeFileSync(paddedFile, "padded-token \t\n\n");
+	assert.equal(
+		resolveToken({ EXPERTISE_API_TOKEN_FILE: paddedFile }),
+		"padded-token",
+	);
+});
+
+test("resolveToken: leading ~/ in the file path expands to the home directory", () => {
+	// Parity with the shell skill, where secrets.env is sourced and
+	// `VAR=~/path` tilde-expands. Uses a real file under os.homedir() so the
+	// expansion is exercised end-to-end, then cleans it up.
+	const relName = `.resolve-token-test-${process.pid}.jwt`;
+	const realPath = path.join(os.homedir(), relName);
+	fs.writeFileSync(realPath, "tilde-token\n");
+	try {
+		assert.equal(
+			resolveToken({ EXPERTISE_API_TOKEN_FILE: `~/${relName}` }),
+			"tilde-token",
+		);
+	} finally {
+		fs.rmSync(realPath, { force: true });
+	}
+});
+
+test("resolveToken: neither variable set throws naming both", () => {
+	assert.throws(
+		() => resolveToken({}),
+		/EXPERTISE_API_TOKEN is not set \(set it, or point EXPERTISE_API_TOKEN_FILE/,
+	);
+});

--- a/.pi/extensions/expertise-api/tsconfig.json
+++ b/.pi/extensions/expertise-api/tsconfig.json
@@ -15,5 +15,5 @@
     "allowImportingTsExtensions": false,
     "noEmit": true
   },
-  "include": ["index.ts", "apiCall.test.ts"]
+  "include": ["index.ts", "apiCall.test.ts", "resolveToken.test.ts"]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,12 +193,12 @@ Env contract used by every script in the skill:
 mkdir -p ~/.config/expertise-api
 cat > ~/.config/expertise-api/secrets.env <<'EOF'
 EXPERTISE_API_BASE_URL=https://expertise.example.com
-EXPERTISE_API_TOKEN=...
+EXPERTISE_API_TOKEN_FILE=/path/to/token.jwt
 EOF
 chmod 600 ~/.config/expertise-api/secrets.env
 ```
 
-The scripts source that file automatically when present — no per-shell exports needed.
+The scripts source that file automatically when present — no per-shell exports needed. `EXPERTISE_API_TOKEN_FILE` (recommended, #464) points at a file holding the token so no bearer literal sits in the env file; `EXPERTISE_API_TOKEN=...` inline also works and wins when both are set. Both the skill scripts and the pi extension honor the indirection.
 
 ## Native OS service install (Archetype A2)
 

--- a/README.md
+++ b/README.md
@@ -160,12 +160,12 @@ Env contract for all three harnesses:
 mkdir -p ~/.config/expertise-api
 cat > ~/.config/expertise-api/secrets.env <<'EOF'
 EXPERTISE_API_BASE_URL=https://expertise.example.com
-EXPERTISE_API_TOKEN=...
+EXPERTISE_API_TOKEN_FILE=/path/to/token.jwt
 EOF
 chmod 600 ~/.config/expertise-api/secrets.env
 ```
 
-The scripts source that file automatically, so env vars do not need to be exported per shell. See the skill's [`SKILL.md`](.agents/skills/expertise-api/SKILL.md) for the full toolkit (`search`, `search-semantic`, `get`, `create`, `approve`, `reject`) and `references/DESIGN.md` for the underlying scope hierarchy and approval state machine.
+The scripts source that file automatically, so env vars do not need to be exported per shell. `EXPERTISE_API_TOKEN_FILE` (recommended, #464) keeps the bearer literal out of the env file; setting `EXPERTISE_API_TOKEN=...` directly also works and wins when both are present. See the skill's [`SKILL.md`](.agents/skills/expertise-api/SKILL.md) for the full toolkit (`search`, `search-semantic`, `get`, `create`, `approve`, `reject`) and `references/DESIGN.md` for the underlying scope hierarchy and approval state machine.
 
 ### Response hygiene
 

--- a/adrs/017-embedding-model-swap.md
+++ b/adrs/017-embedding-model-swap.md
@@ -127,7 +127,8 @@ reembed — embeddings are regenerable, content is the source of truth) or full
 
 - `Deduplication:SemanticThreshold = 0.10` was calibrated to bge's distance
   geometry; it is re-derived against the jina space after the production
-  reembed (#457). Until then dedup under-fires only.
+  reembed (#457). Until then dedup under-fires only. *(Resolved — see
+  Amendment 1 below: retuned to 0.05 on 2026-07-24.)*
 - The eval gates (`RetrievalEvalTests`, window-aware `NeedleEvalTests`, #437
   PR-B) are the merge gate for this and any future retrieval change; they are
   `EXPERTISE_EVAL=1` opt-in, so running them is a release-checklist step, not
@@ -136,6 +137,37 @@ reembed — embeddings are regenerable, content is the source of truth) or full
   keyed on `download-models.sh` (added with #456's fix).
 - Helm/k8s resource sizing is NOT covered — tracked in #458; A2 native service
   remains the hosting model of record.
+
+## Amendment 1 (2026-07-24): `Deduplication:SemanticThreshold` retuned 0.10 → 0.05 (#457)
+
+The Consequences section deferred the dedup-threshold retune to #457, gated on
+the production reembed. Measured on the live corpus (604 approved embedded
+entries, within-domain nearest-neighbor cosine distances over the stored
+jina-v2-small vectors, pgvector `<=>`):
+
+- **True duplicates cluster at ≈ 0** — 131 entries with NN distance < 0.01,
+  130/131 with byte-identical bodies (accumulated while dedup under-fired,
+  e.g. during the swap's NULL-embedding window).
+- **Hand-labeled near-dups (retitles/light rewordings of the same fact)
+  extend to ≤ 0.048**; the valley 0.01–0.05 holds only 6 entries, all labeled
+  near-dup.
+- **The closest genuinely distinct same-domain neighbors begin at ≈ 0.051**,
+  with the distinct mass at 0.06–0.13 peaking around 0.10–0.13. The bge-era
+  0.10 default sits INSIDE that mass: 272/604 entries (45%) have a legitimate
+  distinct neighbor within 0.10, i.e. under jina geometry 0.10 would false-409
+  roughly half of comparable future submissions.
+- Synthetic pair measurement with the real model (`DedupThresholdEvalTests`)
+  agrees: light rewordings 0.016–0.048, moderate rewordings 0.052–0.065, full
+  paraphrases 0.13–0.16, distinct same-topic pairs ≥ 0.12.
+
+**Decision: 0.05** — the valley midpoint. Biased low deliberately: a false 409
+rejects a legitimate write (the costly, user-visible failure); a missed
+near-dup lands as a Draft in the curator review queue (noise). Moderate and
+full rewordings of the same fact are accepted under-fire — they are
+geometrically inseparable from distinct entries under this model. Changes to
+the threshold or model must re-run `EXPERTISE_EVAL=1
+dotnet test --filter DedupThresholdEval` and re-derive against the live corpus
+per the method above (recorded in #457).
 
 ## Related
 

--- a/docs/testing-and-coverage.md
+++ b/docs/testing-and-coverage.md
@@ -64,14 +64,15 @@ cannot drift from production.
 The test embedding generator seeds each vector from a **stable FNV hash of the input
 content** (not `string.GetHashCode`, which is randomized per process). Identical content
 yields the identical vector (cosine distance 0 → a real duplicate); distinct content yields
-a near-orthogonal vector (distance ≈ 1.0, far above the 0.10 dedup threshold → not a
+a near-orthogonal vector (distance ≈ 1.0, far above the 0.05 dedup threshold → not a
 duplicate). This replaced an earlier mock that returned the *same* vector for every input,
 which made semantic-dedup behaviour structurally unobservable and forced tests into
 per-test workarounds.
 
 **Limitation to remember:** hash-based vectors are all-or-nothing (identical vs orthogonal).
 They eliminate *false* collisions but do not model *graded* semantic similarity. Testing the
-0.10 threshold itself needs real embeddings and is out of scope for the mock.
+0.05 threshold itself needs real embeddings — that is `DedupThresholdEvalTests`
+(`EXPERTISE_EVAL=1` opt-in, #457), out of scope for the mock.
 
 ### 3. Frozen enum-name guard (`EnumContractTests`)
 

--- a/scripts/test/brew-install-postgres17.sh
+++ b/scripts/test/brew-install-postgres17.sh
@@ -3,14 +3,14 @@
 # brew-install-postgres17.sh — install PostgreSQL 17 + pgvector via Homebrew for the
 # macOS install-smoke CI jobs, self-healing a corrupt pre-cached bottle.
 #
-# BEST-EFFORT heal for the macOS install-smoke jobs. The `postgresql@17` bottle on
-# current macOS runner images fails at service start with:
+# BEST-EFFORT heal for the macOS install-smoke jobs, retained as defense-in-depth
+# after #366 closed. That upstream Homebrew bug (`postgresql@17` bottle share-dir
+# path mismatch on a keg-only formula — initdb failed with
 #     initdb: error: file "/opt/homebrew/share/postgresql@17/postgres.bki" does not exist
-# Diagnosed as an upstream Homebrew bug (share-dir path mismatch on a keg-only
-# formula; the file exists in the keg but initdb/server look in the unpopulated
-# top-level prefix). Tracked in #366 — the three macOS smoke jobs are
-# `continue-on-error: true` until it is fixed, so this heal not landing does not
-# block merges. Remove the continue-on-error (and revisit this heal) when #366 closes.
+# while the file existed inside the keg) recurred across runner-image updates
+# (arm64_sequoia, then arm64_tahoe) before Homebrew fixed the bottle, so the heal
+# stays in case a future image regresses. The three macOS smoke jobs are BLOCKING
+# again — a failure here fails the PR.
 #
 # The two heals below are retained because they DO fix adjacent variants and cost
 # nothing when they no-op:

--- a/src/ExpertiseApi/Data/ExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/ExpertiseRepository.cs
@@ -610,16 +610,6 @@ internal class ExpertiseRepository(
         return distance.Value <= maxDistance ? candidate : null;
     }
 
-    public async Task<List<ExpertiseEntry>> FindAllEmbeddingsInDomainAsync(string domain, TenantContext ctx, CancellationToken ct)
-    {
-        return await ApplyTenantFilter(db.ExpertiseEntries.AsQueryable(), ctx)
-            .Where(e => e.DeprecatedAt == null)
-            .Where(e => e.ReviewState != ReviewState.Rejected)
-            .Where(e => e.Domain == domain)
-            .Where(e => e.Embedding != null)
-            .ToListAsync(ct);
-    }
-
     public async Task<List<ExpertiseEntry>> ListSharedApprovedUpdatedAfterAsync(
         DateTime afterUpdatedAt, Guid afterId, int limit, CancellationToken ct)
     {

--- a/src/ExpertiseApi/Data/IExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/IExpertiseRepository.cs
@@ -91,8 +91,6 @@ internal interface IExpertiseRepository
 
     Task<ExpertiseEntry?> FindNearestInDomainAsync(string domain, Vector queryVector, double maxDistance, TenantContext ctx, CancellationToken ct = default);
 
-    Task<List<ExpertiseEntry>> FindAllEmbeddingsInDomainAsync(string domain, TenantContext ctx, CancellationToken ct = default);
-
     /// <summary>
     /// Up-sync feed (ADR-013): Approved, non-deprecated entries in the cross-tenant
     /// <c>shared</c> namespace strictly after the keyset cursor

--- a/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
@@ -103,12 +103,13 @@ internal static class ExpertiseEndpoints
 
         group.MapPost("/batch", CreateBatch)
             .RequireAuthorization("WriteAccess")
-            .RequireRateLimiting("expertise-write")
+            .RequireRateLimiting("expertise-batch")
             .Accepts<List<CreateExpertiseRequest>>("application/json")
             .WithSummary("Batch ingest up to 100 entries with per-item failure isolation")
             .WithDescription("Returns 200 with `BatchEntryResult[]` when every item is Created, or 207 (Multi-Status) when any item is " +
-                             "Duplicate / Rejected / Failed. Embedding generation and deduplication are batched into a single ONNX call " +
-                             "and bulk DB query respectively, so partial failures in one phase do not roll back successful items.")
+                             "Duplicate / Rejected / Failed. Embedding generation is batched into a single ONNX call; deduplication " +
+                             "runs an HNSW-indexed nearest-neighbour query per item. Partial failures in one phase do not roll back " +
+                             "successful items. Rate-limited under a dedicated stricter policy than single writes (#333 Finding 4).")
             .Produces<List<BatchEntryResult>>(StatusCodes.Status200OK)
             .Produces<List<BatchEntryResult>>(StatusCodes.Status207MultiStatus)
             .ProducesProblem(StatusCodes.Status400BadRequest)

--- a/src/ExpertiseApi/Hygiene/PiiDetector.cs
+++ b/src/ExpertiseApi/Hygiene/PiiDetector.cs
@@ -4,9 +4,10 @@ namespace ExpertiseApi.Hygiene;
 
 /// <summary>
 /// Regex-based PII redaction for free-text response fields. Each detector class is
-/// compiled once at construction. Patterns use <see cref="RegexOptions.NonBacktracking"/>
-/// for linear-time guarantee against ReDoS (.NET 7+); each pattern carries a per-match
-/// timeout as belt-and-suspenders.
+/// compiled once at construction. <strong>Every</strong> pattern uses
+/// <see cref="RegexOptions.NonBacktracking"/> for a linear-time guarantee against ReDoS
+/// (.NET 7+); each also carries a per-match timeout as belt-and-suspenders, and the
+/// timeout path fails <strong>closed</strong> (see <see cref="ApplyOne"/>).
 /// </summary>
 /// <remarks>
 /// <para>
@@ -42,14 +43,16 @@ internal static class PiiDetector
     ];
 
     // RegexOptions.NonBacktracking guarantees linear-time matching for the supported
-    // subset (no backreferences, no lookaround). Patterns that need lookaround are
-    // called out below and use a tight timeout as the fallback.
+    // subset (no backreferences, no lookaround). ALL detectors are NonBacktracking as
+    // of #333 Finding 2 — the AwsSecret lookbehind that previously forced a
+    // backtracking-capable option was rewritten to capture the secret in a group
+    // instead (see below), removing the only pattern that could ReDoS. There is no
+    // longer a lookaround/backtracking option constant: a future lookaround pattern
+    // must reintroduce one deliberately, and the fail-closed timeout path in ApplyOne
+    // remains the safety net for any pattern that ever times out.
     private const RegexOptions NbOpts = RegexOptions.Compiled | RegexOptions.NonBacktracking
                                        | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant;
-    private const RegexOptions LookaroundOpts = RegexOptions.Compiled | RegexOptions.IgnoreCase
-                                              | RegexOptions.CultureInvariant;
     private static readonly TimeSpan FastTimeout = TimeSpan.FromMilliseconds(50);
-    private static readonly TimeSpan SlowTimeout = TimeSpan.FromMilliseconds(100);
 
     // Email: RFC-loose, anchored to word boundaries. Linear under NonBacktracking.
     private static readonly Regex Email = new(
@@ -66,12 +69,19 @@ internal static class PiiDetector
         @"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b", NbOpts, FastTimeout);
 
     // AWS secret: requires a context word within 32 chars before the candidate (40-char
-    // base64-ish run). The lookbehind allows any non-alphanumeric separator (e.g. '=',
-    // ':', ' ', newline) between the context word and the secret. Tight timeout because
-    // of the lookbehind quantifier.
+    // base64-ish run). Rewritten for #333 Finding 2 to be NonBacktracking-safe: the
+    // former lookbehind (context) + lookahead (trailing boundary) forced a
+    // backtracking-capable option and a ReDoS-vulnerable 100ms timeout. Now the context
+    // word and separator are matched inline (consumed, not looked-behind) and the secret
+    // is pulled into capture group 1; ApplyOne redacts ONLY group 1, so the emitted text
+    // is byte-identical to the old lookbehind form ("aws_secret_access_key=<40>" ->
+    // "aws_secret_access_key=[REDACTED:aws-secret]"). The trailing boundary is consumed
+    // via (?:[^...]|$) — a lookahead is not permitted under NonBacktracking — and, being
+    // outside group 1, is re-emitted verbatim. Bounded {0,32}/{40} quantifiers keep it
+    // linear; it can no longer time out on adversarial padding.
     private static readonly Regex AwsSecret = new(
-        @"(?<=(?:aws[_-]?secret(?:[_-]?access[_-]?key)?|secret(?:[_-]?key)?)[^A-Za-z0-9/+]{0,32})[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])",
-        LookaroundOpts, SlowTimeout);
+        @"(?:aws[_-]?secret(?:[_-]?access[_-]?key)?|secret(?:[_-]?key)?)[^A-Za-z0-9/+]{0,32}([A-Za-z0-9/+=]{40})(?:[^A-Za-z0-9/+=]|$)",
+        NbOpts, FastTimeout);
 
     private static readonly Regex GithubPat = new(
         @"\b(?:ghp|gho|ghs|ghr|ghu)_[A-Za-z0-9]{36}\b", NbOpts, FastTimeout);
@@ -81,7 +91,7 @@ internal static class PiiDetector
         NbOpts, FastTimeout);
 
     private static readonly Regex UrlCredentials = new(
-        @"\b(?:https?|ftp)://[^\s/:@]+:[^\s/@]+@\S+", NbOpts, SlowTimeout);
+        @"\b(?:https?|ftp)://[^\s/:@]+:[^\s/@]+@\S+", NbOpts, FastTimeout);
 
     private static readonly Regex PrivateKeyHeader = new(
         @"-----BEGIN (?:RSA |EC |OPENSSH |PGP |DSA )?PRIVATE KEY-----", NbOpts, FastTimeout);
@@ -93,9 +103,25 @@ internal static class PiiDetector
         @"|\b(?:[A-F0-9]{1,4}:){7}[A-F0-9]{1,4}\b",
         NbOpts, FastTimeout);
 
+    // Detector run order. URL credentials FIRST so the user:pass@host segment is
+    // replaced before the email pattern would otherwise consume the @host tail.
+    private static readonly (Regex Pattern, string Class)[] Detectors =
+    [
+        (UrlCredentials, "url-credentials"),
+        (Email, "email"),
+        (AwsAccessKey, "aws-access-key"),
+        (AwsSecret, "aws-secret"),
+        (GithubPat, "github-pat"),
+        (Jwt, "jwt"),
+        (PrivateKeyHeader, "private-key-header"),
+        (Phone, "phone"),
+        (IpAddress, "ip-address"),
+    ];
+
     /// <summary>
     /// Apply all detectors to <paramref name="input"/>. Returns the redacted text and
-    /// per-class match counts (zero-count classes omitted).
+    /// per-class match counts (zero-count classes omitted). On a regex timeout the field
+    /// is fully suppressed (fail-closed) and the remaining detectors are skipped.
     /// </summary>
     public static PiiResult Redact(string input)
     {
@@ -105,43 +131,63 @@ internal static class PiiDetector
         var counts = new Dictionary<string, int>(StringComparer.Ordinal);
         var current = input;
 
-        // Order matters: URL credentials FIRST so the user:pass@host segment is replaced
-        // before the email pattern would otherwise consume the @host tail.
-        current = ApplyOne(current, UrlCredentials, "url-credentials", counts);
-        current = ApplyOne(current, Email, "email", counts);
-        current = ApplyOne(current, AwsAccessKey, "aws-access-key", counts);
-        current = ApplyOne(current, AwsSecret, "aws-secret", counts);
-        current = ApplyOne(current, GithubPat, "github-pat", counts);
-        current = ApplyOne(current, Jwt, "jwt", counts);
-        current = ApplyOne(current, PrivateKeyHeader, "private-key-header", counts);
-        current = ApplyOne(current, Phone, "phone", counts);
-        current = ApplyOne(current, IpAddress, "ip-address", counts);
+        foreach (var (pattern, className) in Detectors)
+        {
+            current = ApplyOne(current, pattern, className, counts, out var timedOut);
+            if (timedOut)
+                // Fail-closed: the field is already replaced with a suppression
+                // sentinel. Running the remaining detectors against that sentinel is
+                // moot, so short-circuit \u2014 nothing sensitive can survive a fully
+                // suppressed field.
+                break;
+        }
 
         return new PiiResult(current, counts);
     }
 
-    private static string ApplyOne(string input, Regex pattern, string className, Dictionary<string, int> counts)
+    /// <summary>
+    /// Apply one detector. When the pattern defines capture group 1, only that span is
+    /// redacted and the surrounding match text is preserved verbatim (used by AwsSecret,
+    /// whose match includes a context word that must survive); otherwise the whole match
+    /// is replaced. On <see cref="RegexMatchTimeoutException"/> the method fails CLOSED
+    /// (#333 Finding 2): it returns a whole-field suppression sentinel and sets
+    /// <paramref name="timedOut"/>, because a timeout yields no match positions and
+    /// returning the original would ship an unredacted secret to an LLM consumer.
+    /// </summary>
+    internal static string ApplyOne(
+        string input, Regex pattern, string className, Dictionary<string, int> counts, out bool timedOut)
     {
         var matchCount = 0;
         try
         {
-            var replaced = pattern.Replace(input, _ =>
+            var replaced = pattern.Replace(input, m =>
             {
                 matchCount++;
+                if (m.Groups.Count > 1 && m.Groups[1].Success)
+                {
+                    var g = m.Groups[1];
+                    var rel = g.Index - m.Index;
+                    return $"{m.Value[..rel]}[REDACTED:{className}]{m.Value[(rel + g.Length)..]}";
+                }
                 return $"[REDACTED:{className}]";
             });
             if (matchCount > 0)
                 counts[className] = matchCount;
+            timedOut = false;
             return replaced;
         }
         catch (RegexMatchTimeoutException)
         {
-            // Pattern took too long on adversarial input \u2014 leave the field unredacted
-            // and record a sentinel so the orchestrator can flag the response with a
-            // "redaction-timeout" entry in hygieneApplied. Not raising: returning the
-            // original is safer than throwing 500 from a read endpoint.
+            // Fail CLOSED: a timeout carries no match boundaries, so selective redaction
+            // is impossible. Suppress the WHOLE field rather than return the original
+            // (the pre-#333 behaviour, which shipped the unredacted value). Consumers
+            // reading a "{class}-timeout" key in hygieneApplied MUST treat the field as
+            // fully suppressed, not partially redacted. The NonBacktracking rewrite of
+            // every detector makes this path unreachable on today's patterns; it remains
+            // the safety net for any future pattern or pathological input.
             counts[$"{className}-timeout"] = 1;
-            return input;
+            timedOut = true;
+            return $"[REDACTED:{className}-timeout]";
         }
     }
 

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -201,12 +201,13 @@ builder.Services.AddProblemDetails(options =>
 // produces the response body (and the customizer above fires).
 builder.Services.AddExceptionHandler<UnhandledExceptionLogger>();
 
-// Rate limiting (Part D C5). Three policies, per-principal partitioning with IP
+// Rate limiting (Part D C5). Four policies, per-principal partitioning with IP
 // fallback for unauthenticated paths. 429 responses route through the
 // IProblemDetailsService so the C4 customizer fires (correlation traceId, etc.)
 // and Retry-After is populated from the lease metadata.
 //   - expertise-read     fixed window 60/min  GET /expertise/* (non-semantic), GET /audit/*
-//   - expertise-write    fixed window 10/min  POST/PATCH/DELETE on writes
+//   - expertise-write    fixed window 10/min  POST/PATCH/DELETE on single writes
+//   - expertise-batch    fixed window  2/min  POST /expertise/batch (#333 Finding 4)
 //   - semantic-search    token bucket 10/min  /expertise/search/semantic (expensive: ONNX)
 // Health endpoints (/health/*) opt out via DisableRateLimiting in HealthEndpoints.
 builder.Services.AddRateLimiter(rateOptions =>
@@ -271,6 +272,25 @@ builder.Services.AddRateLimiter(rateOptions =>
             factory: _ => new FixedWindowRateLimiterOptions
             {
                 PermitLimit = 10,
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            }));
+
+    // #333 Finding 4: POST /expertise/batch previously shared "expertise-write"
+    // (10/min), so one principal could push up to 10 batches x 100 items = ~1,000
+    // embed-units/min through the single, process-wide ONNX inference lane
+    // (EmbeddingService.InferenceGate) — starving every other caller's single-item
+    // writes and semantic-search queries. The static InferenceGate bounds concurrent
+    // OVERLAP but not throughput fairness. A dedicated stricter window caps a batch
+    // caller at 2 x 100 = ~200 embed-units/min while still comfortably serving the
+    // aggregator up-sync worker (ADR-013), which pushes at most one batch per sync tick.
+    rateOptions.AddPolicy("expertise-batch", http =>
+        RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: PartitionKey(http),
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 2,
                 Window = TimeSpan.FromMinutes(1),
                 QueueLimit = 0,
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,

--- a/src/ExpertiseApi/Services/DeduplicationService.cs
+++ b/src/ExpertiseApi/Services/DeduplicationService.cs
@@ -81,10 +81,6 @@ internal class DeduplicationService(IExpertiseRepository repo, IOptions<Deduplic
                 .GroupBy(e => e.Title, StringComparer.OrdinalIgnoreCase)
                 .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.OrdinalIgnoreCase);
 
-            // Bulk semantic: fetch all domain embeddings once, match in memory
-            List<ExpertiseEntry>? domainEntries = null;
-            List<float[]>? domainEntryArrays = null;
-
             foreach (var item in items)
             {
                 // Check exact match — any candidate sharing the title whose body also matches
@@ -98,40 +94,21 @@ internal class DeduplicationService(IExpertiseRepository repo, IOptions<Deduplic
                     }
                 }
 
-                // Check semantic match in memory
-                domainEntries ??= await repo.FindAllEmbeddingsInDomainAsync(domain, ctx, ct);
+                // Semantic match via the same HNSW-indexed, DB-side nearest-neighbour query
+                // the single-create path uses (#333 Finding 4). Replaces the former
+                // "load every domain embedding into memory and brute-force in C#" scan,
+                // which was O(batchSize x domainSize) and unbounded in memory as a domain
+                // grew. Bounded to one indexed query per item; sequential because the
+                // scoped DbContext is not thread-safe. Consolidating onto
+                // FindNearestInDomainAsync also removes the behaviour drift between the
+                // batch and single-create dedup paths. Trade: batch dedup is now
+                // approximate-NN (HNSW) like single-create already is — a miss lands as a
+                // Draft for curator review, per the DeduplicationOptions.SemanticThreshold
+                // risk posture.
+                var nearest = await repo.FindNearestInDomainAsync(
+                    domain, item.Embedding, opts.SemanticThreshold, ctx, ct);
 
-                // Precompute domain entry arrays once per domain group, skipping null embeddings
-                if (domainEntryArrays is null)
-                {
-                    domainEntries = domainEntries.Where(e => e.Embedding != null).ToList();
-                    domainEntryArrays = domainEntries.Select(e => e.Embedding!.ToArray()).ToList();
-                }
-
-                // Compute query vector once per item
-                var queryVec = item.Embedding.ToArray();
-
-                ExpertiseEntry? nearest = null;
-                double nearestDistance = double.MaxValue;
-
-                for (var i = 0; i < domainEntries.Count; i++)
-                {
-                    var distance = ExpertiseRepository.CosineDistance(domainEntryArrays[i], queryVec);
-
-                    if (distance is not null && distance.Value <= opts.SemanticThreshold && distance.Value < nearestDistance)
-                    {
-                        nearest = domainEntries[i];
-                        nearestDistance = distance.Value;
-                    }
-                }
-
-                if (nearest is not null)
-                {
-                    results[item.Index] = (true, nearest);
-                    continue;
-                }
-
-                results[item.Index] = (false, null);
+                results[item.Index] = nearest is not null ? (true, nearest) : (false, null);
             }
         }
 

--- a/src/ExpertiseApi/Services/DeduplicationService.cs
+++ b/src/ExpertiseApi/Services/DeduplicationService.cs
@@ -10,7 +10,15 @@ namespace ExpertiseApi.Services;
 internal class DeduplicationOptions
 {
     public bool Enabled { get; set; } = true;
-    public double SemanticThreshold { get; set; } = 0.10;
+
+    // Cosine-DISTANCE ceiling for the semantic near-duplicate check, calibrated
+    // per embedding model (#457, ADR-017 Amendment 1): under jina-v2-small the
+    // live corpus's true near-dups sit at <= 0.048 and its closest genuinely
+    // distinct same-domain neighbors begin at ~0.051, so 0.05 splits the valley.
+    // Biased LOW by design — a false 409 rejects a legitimate write, a miss
+    // merely lands as a Draft for curator review. Gate any change with
+    // EXPERTISE_EVAL=1 DedupThresholdEvalTests.
+    public double SemanticThreshold { get; set; } = 0.05;
 }
 
 internal class DeduplicationService(IExpertiseRepository repo, IOptions<DeduplicationOptions> options)

--- a/src/ExpertiseApi/appsettings.json
+++ b/src/ExpertiseApi/appsettings.json
@@ -69,7 +69,7 @@
   },
   "Deduplication": {
     "Enabled": true,
-    "SemanticThreshold": 0.10
+    "SemanticThreshold": 0.05
   },
   "Idempotency": {
     "_comment": "Part D C3 / ADR-010. RequireKey is hard-on by default since 2026-05-19 (PR closes Idempotency-Key Part D control). All POSTs to /expertise, /expertise/{id}/approve, /expertise/{id}/reject must carry an Idempotency-Key header; absence returns 400. The skill caller (#211) and pi extension caller (#212) generate keys automatically. Set to false only for short-lived debugging or a controlled rollback.",

--- a/tests/ExpertiseApi.Tests/Evaluation/DedupThresholdEvalTests.cs
+++ b/tests/ExpertiseApi.Tests/Evaluation/DedupThresholdEvalTests.cs
@@ -1,0 +1,196 @@
+using ExpertiseApi.Data;
+using ExpertiseApi.Services;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.SemanticKernel.Connectors.Onnx;
+using Xunit.Abstractions;
+
+namespace ExpertiseApi.Tests.Evaluation;
+
+/// <summary>
+/// Dedup semantic-threshold gate (#457). Embeds labeled entry pairs with the
+/// REAL pinned ONNX model and asserts the shipped
+/// <see cref="DeduplicationOptions.SemanticThreshold"/> default separates them:
+///
+/// <list type="bullet">
+///   <item><b>near-dup pairs</b> (same fact resubmitted with light rewording —
+///     the class dedup exists to catch) must land BELOW the threshold;</item>
+///   <item><b>distinct pairs</b> (different facts in the same topic area — the
+///     class a false 409 would wrongly reject) must land ABOVE it;</item>
+///   <item><b>moderate-to-full rewordings</b> (same fact, heavier rewrite) are
+///     REPORT-ONLY: per #457's risk profile dedup may under-fire (the miss
+///     lands as a Draft for curator review) but must not misfire.</item>
+/// </list>
+///
+/// Pair texts are class exemplars modeled on hand-labeled live-corpus
+/// neighbor pairs from the 2026-07-24 derivation (issue #457): under
+/// jina-v2-small, corpus near-dups clustered at distance ≤ 0.048 and the
+/// closest genuinely-distinct pairs began at ≈ 0.051, with the bulk of
+/// distinct neighbors at 0.06–0.13. The bge-era default of 0.10 sat inside
+/// the distinct mass (45% of corpus entries had a legitimate same-domain
+/// neighbor within 0.10) — hence the retune.
+///
+/// No database: this measures raw embedding geometry only.
+/// <code>
+/// EXPERTISE_EVAL=1 dotnet test --filter "FullyQualifiedName~DedupThresholdEval"
+/// </code>
+/// </summary>
+public sealed class DedupThresholdEvalTests(ITestOutputHelper output) : IAsyncLifetime
+{
+    private ServiceProvider? _onnxProvider;
+    private EmbeddingService _embedding = null!;
+
+    public Task InitializeAsync()
+    {
+        if (Environment.GetEnvironmentVariable("EXPERTISE_EVAL") != "1" || ModelFiles.ModelPath is null)
+            return Task.CompletedTask;
+
+        var services = new ServiceCollection();
+        services.AddBertOnnxEmbeddingGenerator(ModelFiles.ModelPath!, ModelFiles.VocabPath!,
+            EmbeddingModelInfo.CreateOnnxOptions());
+        _onnxProvider = services.BuildServiceProvider();
+        _embedding = new EmbeddingService(
+            _onnxProvider.GetRequiredService<IEmbeddingGenerator<string, Embedding<float>>>());
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        _onnxProvider?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private sealed record Pair(string Label, string TitleA, string BodyA, string TitleB, string BodyB);
+
+    // ---- Near-dup pairs: same fact, light rewording / retitle. ----
+    // The agent-resubmission class: an agent re-learns a fact and re-submits it
+    // with different phrasing. Modeled on real corpus dup pairs (e.g. the
+    // "VS Code Copilot hook parity" retitle at 0.031).
+    private static readonly IReadOnlyList<Pair> NearDupPairs =
+    [
+        new("neardup-pgbouncer",
+            "Npgsql with PgBouncer transaction mode needs No Reset On Close",
+            "When running Npgsql behind PgBouncer in transaction pooling mode, the connection string must set No Reset On Close=True. Without it Npgsql issues DISCARD ALL on connection return, which breaks under transaction pooling because the session state reset races other clients sharing the server connection.",
+            "PgBouncer transaction pooling requires No Reset On Close=True in the Npgsql connection string",
+            "Npgsql behind PgBouncer in transaction pool mode must include No Reset On Close=True. Otherwise Npgsql sends DISCARD ALL when a connection is returned, and under transaction pooling that reset conflicts with other clients that share the same server connection."),
+        new("neardup-docker-copy",
+            "Dockerfile COPY of the models directory fails silently when it is empty",
+            "A multi-stage Dockerfile COPY of src/models/ succeeds even when the directory was never populated, producing an image without model files. The failure only surfaces at container start when the API tries to load the ONNX model. CI must download models before docker build.",
+            "COPY of ONNX model files in the Dockerfile silently produces a broken image without pre-download",
+            "In a multi-stage build, COPY src/models/ does not fail when the directory is empty, so the image builds cleanly but is missing the ONNX model files. The error appears only at runtime when model load fails. Run the model download script before building the image in CI."),
+        new("neardup-ssh-socket",
+            "Debian 13 ssh.socket activation ignores Port changes in sshd_config on restart",
+            "On a fresh Debian 13 install SSH is socket-activated. Restarting ssh.service after editing Port in sshd_config does not change the listener, because the socket unit owns the bind. You must edit the socket unit or restart ssh.socket for a port change to take effect.",
+            "SSH port changes need ssh.socket restart on Debian 13 fresh installs",
+            "Debian 13 fresh installs use ssh.socket activation, so the listening port is bound by the socket unit. Editing Port in sshd_config and restarting only ssh.service leaves the old listener in place — restart ssh.socket (or override the socket unit) instead."),
+    ];
+
+    // ---- Report-only pairs: same fact, moderate-to-full rewording. ----
+    // Measured 2026-07-24 (jina-v2-small@6144): moderate rewordings land at
+    // 0.05–0.07 — the SAME band where the live corpus's closest genuinely
+    // distinct neighbors begin (0.051) — and full paraphrases at 0.13–0.16.
+    // No threshold separates these from distinct entries, so per #457's risk
+    // profile they are accepted under-fire (the miss lands as a Draft for
+    // curator review); this suite reports their drift but does not gate them.
+    private static readonly IReadOnlyList<Pair> ReportOnlyPairs =
+    [
+        new("moderate-set-e-counter",
+            "bash set -e aborts on ((counter++)) when the counter starts at zero",
+            "Under set -e, the arithmetic expression ((counter++)) returns the pre-increment value, so incrementing from 0 evaluates to 0 which is falsy and terminates the script. Use ((counter++)) || true or counter=$((counter + 1)) instead.",
+            "((counter++)) from zero kills scripts running under set -e",
+            "With errexit enabled, ((counter++)) yields the value before the increment; starting from 0 that is 0, bash treats it as failure, and the script exits. The safe forms are counter=$((counter + 1)) or appending || true to the arithmetic command."),
+        new("moderate-actions-cache",
+            "GitHub Actions cache key must hash the lockfile, not the manifest",
+            "Keying actions/cache on package.json misses dependency updates that only change package-lock.json, serving stale node_modules. Use hashFiles('**/package-lock.json') in the cache key so any resolved-dependency change busts the cache.",
+            "actions/cache keyed on package.json serves stale dependencies",
+            "A cache key built from package.json does not change when only package-lock.json moves, so dependency bumps restore an outdated node_modules. Build the key with hashFiles over the lockfile instead of the manifest."),
+        new("para-pgbouncer",
+            "Npgsql with PgBouncer transaction mode needs No Reset On Close",
+            "When running Npgsql behind PgBouncer in transaction pooling mode, the connection string must set No Reset On Close=True. Without it Npgsql issues DISCARD ALL on connection return, which breaks under transaction pooling because the session state reset races other clients sharing the server connection.",
+            "Session-reset commands from the .NET Postgres driver conflict with shared pooler connections",
+            "Our API pods started throwing prepared-statement errors after we introduced a connection pooler in transaction mode. Root cause: the driver's automatic cleanup command on connection release assumes it owns the session, but the pooler hands the same backend to many clients. The fix is a driver flag that disables the automatic session reset."),
+        new("para-ssh-socket",
+            "Debian 13 ssh.socket activation ignores Port changes in sshd_config on restart",
+            "On a fresh Debian 13 install SSH is socket-activated. Restarting ssh.service after editing Port in sshd_config does not change the listener, because the socket unit owns the bind. You must edit the socket unit or restart ssh.socket for a port change to take effect.",
+            "Why changing the SSH listening port appeared to do nothing on a new Trixie VM",
+            "Spent an hour debugging why the daemon kept answering on 22 after a config edit and service restart. Turns out systemd owns the listener through socket activation on new installs of this release, so the daemon config's port directive is not consulted for the bind — the systemd socket unit is."),
+    ];
+
+    // ---- Distinct pairs: same topic area, different fact (must NOT dedup). ----
+    // Modeled on real corpus neighbor pairs hand-labeled distinct (0.06–0.09).
+    private static readonly IReadOnlyList<Pair> DistinctPairs =
+    [
+        new("distinct-ado-networking",
+            "Azure DevOps hosted agents cannot reach Azure Private Endpoints",
+            "Microsoft-hosted ADO agents run outside your vnet and resolve private-endpoint hostnames to public IPs that refuse connections. Builds needing private resources must use self-hosted agents or vnet-injected pools.",
+            "Managed DevOps Pools support vnet injection for private endpoint access",
+            "Managed DevOps Pools can be injected into a subnet of your vnet, giving pipeline jobs direct line-of-sight to private endpoints without standing up self-hosted VMs. Configure the pool's network profile with the target subnet resource id."),
+        new("distinct-markdownlint",
+            "markdownlint MD060 flags compact pipe-table separators",
+            "markdownlint v0.40 introduced MD060 which fires on |---|---| style table separator rows, wanting padded | --- | --- | form. Existing docs with compact separators fail lint after the version bump.",
+            "markdownlint MD013 line-length ignores tables only when configured",
+            "MD013 counts table rows against the line-length limit unless the tables:false option is set for the rule. Wide comparison tables need that override or they fail lint at the default 80-character limit."),
+        new("distinct-bash-traps",
+            "set -u unbound-variable exits bypass ERR traps",
+            "An unbound variable expansion under set -u terminates the shell directly without running the ERR trap, so cleanup handlers keyed on ERR never fire for this failure class. Guard expansions with ${var:-} where cleanup must run.",
+            "ERR traps do not inherit into functions without set -E",
+            "A trap on ERR set at the top level does not fire for failures inside shell functions unless errtrace (set -E) is enabled, so function-level failures skip the handler even though the script-level command would have triggered it."),
+        new("distinct-kitty",
+            "kitten ssh is required for a working TTY on kitty terminals",
+            "Plain ssh from kitty sends the xterm-kitty TERM value that remote hosts lack a terminfo entry for, breaking full-screen programs. kitten ssh copies the terminfo to the remote host on connect.",
+            "kitty file transfer over nested SSH has low throughput",
+            "The transfer kitten works across nested SSH hops but its escape-sequence encoding caps throughput well below scp for large files; use it for small config files and fall back to scp or rsync for anything sizable."),
+        new("distinct-keda-ado",
+            "KEDA azure-pipelines scaler prefers poolName over poolID when both are set",
+            "When a ScaledObject sets both poolName and poolID, the scaler resolves the pool by name and silently ignores the id, which surprises configs that rotated pool names but pinned ids.",
+            "ADO agent pool ScaledJobs should target pool ID, not display name",
+            "Pool display names are mutable and org-unique only per project collection; jobs keyed on the name break when an admin renames the pool. Configure the numeric pool id, which is stable across renames."),
+    ];
+
+    [EvalFact]
+    public async Task PairDistances_SeparateAtTheShippedThreshold()
+    {
+        var threshold = new DeduplicationOptions().SemanticThreshold;
+
+        // Sanity pin: identical text must embed to (near-)zero distance.
+        var idText = EmbeddingService.BuildInputText(NearDupPairs[0].TitleA, NearDupPairs[0].BodyA);
+        var idVecs = await _embedding.GenerateBatchAsync([idText, idText]);
+        var selfDistance = ExpertiseRepository.CosineDistance(idVecs[0].ToArray(), idVecs[1].ToArray());
+        selfDistance.Should().NotBeNull().And.BeLessThan(0.001);
+
+        async Task<List<(string Label, double Distance)>> MeasureAsync(IReadOnlyList<Pair> pairs)
+        {
+            var texts = pairs.SelectMany(p => new[]
+            {
+                EmbeddingService.BuildInputText(p.TitleA, p.BodyA),
+                EmbeddingService.BuildInputText(p.TitleB, p.BodyB),
+            });
+            var vecs = await _embedding.GenerateBatchAsync(texts);
+            return pairs.Select((p, i) =>
+                (p.Label, ExpertiseRepository.CosineDistance(
+                    vecs[2 * i].ToArray(), vecs[2 * i + 1].ToArray())!.Value)).ToList();
+        }
+
+        var nearDups = await MeasureAsync(NearDupPairs);
+        var reportOnly = await MeasureAsync(ReportOnlyPairs);
+        var distincts = await MeasureAsync(DistinctPairs);
+
+        output.WriteLine($"SemanticThreshold under test: {threshold}");
+        output.WriteLine("");
+        output.WriteLine("class      | pair                     | distance | vs threshold");
+        output.WriteLine("-----------|--------------------------|----------|-------------");
+        foreach (var (label, d) in nearDups)
+            output.WriteLine($"near-dup   | {label,-24} | {d:F4}   | {(d < threshold ? "CAUGHT" : "MISSED")}");
+        foreach (var (label, d) in reportOnly)
+            output.WriteLine($"report     | {label,-24} | {d:F4}   | {(d < threshold ? "caught" : "missed (accepted under-fire)")}");
+        foreach (var (label, d) in distincts)
+            output.WriteLine($"distinct   | {label,-24} | {d:F4}   | {(d > threshold ? "PASSED THROUGH" : "FALSE 409")}");
+
+        // Gates. Near-dups must be caught; distincts must never false-409.
+        // Moderate/full rewordings are report-only (accepted under-fire, #457).
+        nearDups.Should().OnlyContain(p => p.Distance < threshold,
+            "light-rewording resubmissions are the class the semantic dedup threshold exists to catch");
+        distincts.Should().OnlyContain(p => p.Distance > threshold,
+            "a distinct same-topic entry rejected as a duplicate is a false 409 — the costly failure direction");
+    }
+}

--- a/tests/ExpertiseApi.Tests/Infrastructure/TestHelpers.cs
+++ b/tests/ExpertiseApi.Tests/Infrastructure/TestHelpers.cs
@@ -113,7 +113,7 @@ internal static class TestHelpers
     /// <summary>
     /// Deterministic, CONTENT-DERIVED embedding for tests (#353). Identical content yields
     /// the identical vector (cosine distance 0 → a real duplicate); different content yields
-    /// a near-orthogonal vector (cosine distance ≈ 1.0, far above the 0.10 dedup threshold →
+    /// a near-orthogonal vector (cosine distance ≈ 1.0, far above the dedup threshold →
     /// NOT a duplicate). Replaces the old content-independent mock that returned the same
     /// vector for every input — which made semantic-dedup behaviour structurally unobservable
     /// and forced two integration tests into per-test workarounds.

--- a/tests/ExpertiseApi.Tests/Integration/BatchEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/BatchEndpointTests.cs
@@ -154,6 +154,27 @@ public class BatchEndpointTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Batch_ExceedingBatchRatePolicy_Returns429_OnThirdRequest()
+    {
+        // #333 Finding 4: /expertise/batch has its own "expertise-batch" policy
+        // (fixed window, PermitLimit = 2/min) instead of sharing "expertise-write"
+        // (10/min), so a batch caller cannot push ~1,000 embed-units/min through the
+        // single ONNX lane. A fresh JwtApiFactory per test method gives a clean window,
+        // and one token = one partition (per-principal sub), so three sequential batch
+        // requests exhaust the 2-permit budget and the third is rejected.
+        var client = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);
+
+        var first = await client.PostAsJsonAsync("/expertise/batch", new[] { Item(UniqueDomain(), "b1", "body one") });
+        var second = await client.PostAsJsonAsync("/expertise/batch", new[] { Item(UniqueDomain(), "b2", "body two") });
+        var third = await client.PostAsJsonAsync("/expertise/batch", new[] { Item(UniqueDomain(), "b3", "body three") });
+
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
+        third.StatusCode.Should().Be(HttpStatusCode.TooManyRequests,
+            "the dedicated batch policy caps a principal at 2 batch requests per window");
+    }
+
+    [Fact]
     public async Task Batch_AllValidDistinctItems_Returns200()
     {
         var client = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);

--- a/tests/ExpertiseApi.Tests/Integration/BatchEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/BatchEndpointTests.cs
@@ -117,6 +117,43 @@ public class BatchEndpointTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Batch_AgainstPopulatedDomainCorpus_DedupsPerItem_WithoutUnboundedScan()
+    {
+        // #333 Finding 4: the batch dedup path used to load EVERY embedding in the domain
+        // into memory and brute-force cosine distance in C# (O(batchSize x domainSize),
+        // unbounded as a domain grows). It now issues one HNSW-indexed
+        // FindNearestInDomainAsync per item — the same DB-side query the single-create
+        // path uses. This drives that path against a domain corpus larger than any prior
+        // batch fixture to prove it stays correct and bounded with a populated index.
+        //
+        // The content-derived mock embedding generator is all-or-nothing (identical vs
+        // orthogonal), so a GRADED near-dup cannot be produced here — the semantic
+        // threshold itself is validated by the EXPERTISE_EVAL DedupThresholdEvalTests
+        // against the real model. This test proves the exact-match verdict and the
+        // per-item semantic MISS (a distinct item is not a false duplicate) both hold
+        // when the domain is well populated.
+        const string domain = "populated-corpus-domain";
+        for (var i = 0; i < 30; i++)
+            await SeedApproved(domain, $"corpus title {i}", $"corpus body number {i}");
+        var dupTarget = await SeedApproved(domain, "corpus duplicate anchor", "anchor body");
+
+        var client = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);
+        var response = await client.PostAsJsonAsync("/expertise/batch", new[]
+        {
+            Item(domain, "corpus duplicate anchor", "anchor body"), // exact dup of dupTarget
+            Item(domain, "genuinely new in corpus", "unrelated new body"), // distinct -> Created
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.MultiStatus);
+        var results = (await response.Content.ReadFromJsonAsync<List<BatchResult>>())!;
+        results.Should().HaveCount(2);
+        results[0].Status.Should().Be("Duplicate");
+        results[0].Id.Should().Be(dupTarget.Id);
+        results[1].Status.Should().Be("Created", "a distinct item is not a false semantic duplicate even in a populated domain");
+        results[1].Id.Should().NotBeNull();
+    }
+
+    [Fact]
     public async Task Batch_AllValidDistinctItems_Returns200()
     {
         var client = ClientWithScopes(AuthConstants.ReadScope, AuthConstants.WriteDraftScope);

--- a/tests/ExpertiseApi.Tests/Unit/DeduplicationServiceTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/DeduplicationServiceTests.cs
@@ -16,6 +16,17 @@ public class DeduplicationServiceTests
     private readonly Vector _testVector = TestHelpers.CreateTestVector();
     private readonly TenantContext _ctx = TestHelpers.CreateTenantContext();
 
+    [Fact]
+    public void SemanticThreshold_DefaultIsTheAdr017Amendment1Value()
+    {
+        // Pins the shipped default (#457, ADR-017 Amendment 1: derived against
+        // the jina-v2-small corpus geometry). Runs in normal CI — unlike the
+        // EXPERTISE_EVAL-gated DedupThresholdEvalTests — so an accidental
+        // default drift is caught without the opt-in eval pass. Change both
+        // together, re-deriving per the amendment's method.
+        new DeduplicationOptions().SemanticThreshold.Should().Be(0.05);
+    }
+
     private DeduplicationService CreateService(bool enabled = true, double threshold = 0.10)
     {
         var options = Options.Create(new DeduplicationOptions
@@ -184,7 +195,7 @@ public class DeduplicationServiceTests
 
         // No exact title match — entry title differs
         var domainEntry = TestHelpers.SeedEntry(title: "Similar But Different Title");
-        // Use the same vector so cosine distance == 0, well below the 0.10 threshold
+        // Use the same vector so cosine distance == 0, well below any sane threshold
         domainEntry.Embedding = _testVector;
 
         _repo.FindExactMatchesAsync("shared", Arg.Any<IReadOnlyList<string>>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())

--- a/tests/ExpertiseApi.Tests/Unit/DeduplicationServiceTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/DeduplicationServiceTests.cs
@@ -177,8 +177,8 @@ public class DeduplicationServiceTests
 
         _repo.FindExactMatchesAsync("shared", Arg.Any<IReadOnlyList<string>>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns(new List<ExpertiseEntry>());
-        _repo.FindAllEmbeddingsInDomainAsync("shared", Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
-            .Returns(new List<ExpertiseEntry>());
+        _repo.FindNearestInDomainAsync("shared", Arg.Any<Vector>(), Arg.Any<double>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
+            .Returns((ExpertiseEntry?)null);
 
         var results = await service.CheckBatchAsync(requests, vectors, _ctx);
 
@@ -193,15 +193,17 @@ public class DeduplicationServiceTests
         var requests = new List<CreateExpertiseRequest> { CreateRequest(title: "Unique Title") };
         var vectors = new List<Vector> { _testVector };
 
-        // No exact title match — entry title differs
+        // No exact title match — entry title differs. The batch path now delegates the
+        // semantic match to the same FindNearestInDomainAsync the single-create path uses
+        // (#333 Finding 4), which applies the threshold in SQL/HNSW; the unit test stubs
+        // its result and the repo's own threshold behaviour is covered by integration tests.
         var domainEntry = TestHelpers.SeedEntry(title: "Similar But Different Title");
-        // Use the same vector so cosine distance == 0, well below any sane threshold
         domainEntry.Embedding = _testVector;
 
         _repo.FindExactMatchesAsync("shared", Arg.Any<IReadOnlyList<string>>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns(new List<ExpertiseEntry>());
-        _repo.FindAllEmbeddingsInDomainAsync("shared", Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
-            .Returns([domainEntry]);
+        _repo.FindNearestInDomainAsync("shared", Arg.Any<Vector>(), Arg.Any<double>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
+            .Returns(domainEntry);
 
         var results = await service.CheckBatchAsync(requests, vectors, _ctx);
 
@@ -211,25 +213,18 @@ public class DeduplicationServiceTests
     }
 
     [Fact]
-    public async Task CheckBatchAsync_WithSemanticMatchAboveThreshold_ReturnsNotDuplicate()
+    public async Task CheckBatchAsync_WhenNearestIsBeyondThreshold_ReturnsNotDuplicate()
     {
-        var service = CreateService(threshold: 0.01); // very tight threshold
+        // The repo's nearest-neighbour query returns null when nothing is within the
+        // threshold; the service must treat that item as not-a-duplicate.
+        var service = CreateService();
         var requests = new List<CreateExpertiseRequest> { CreateRequest(title: "Unique Title") };
-
-        // Build a vector that is orthogonal to _testVector (cosine distance == 1)
-        var orthogonalValues = new float[512];
-        orthogonalValues[0] = 1.0f; // all other dims zero — orthogonal to random _testVector
-        var farVector = new Vector(orthogonalValues);
-
-        var vectors = new List<Vector> { farVector };
-
-        var domainEntry = TestHelpers.SeedEntry(title: "Similar But Different Title");
-        domainEntry.Embedding = _testVector; // very different direction
+        var vectors = new List<Vector> { _testVector };
 
         _repo.FindExactMatchesAsync("shared", Arg.Any<IReadOnlyList<string>>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns(new List<ExpertiseEntry>());
-        _repo.FindAllEmbeddingsInDomainAsync("shared", Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
-            .Returns([domainEntry]);
+        _repo.FindNearestInDomainAsync("shared", Arg.Any<Vector>(), Arg.Any<double>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
+            .Returns((ExpertiseEntry?)null);
 
         var results = await service.CheckBatchAsync(requests, vectors, _ctx);
 
@@ -251,8 +246,9 @@ public class DeduplicationServiceTests
         var existingEntry = TestHelpers.SeedEntry(title: "Duplicate", body: "Same body");
         _repo.FindExactMatchesAsync("shared", Arg.Any<IReadOnlyList<string>>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns([existingEntry]);
-        _repo.FindAllEmbeddingsInDomainAsync("shared", Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
-            .Returns(new List<ExpertiseEntry>());
+        // Item 0 is caught by exact-match; item 1 has no near neighbour.
+        _repo.FindNearestInDomainAsync("shared", Arg.Any<Vector>(), Arg.Any<double>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
+            .Returns((ExpertiseEntry?)null);
 
         var results = await service.CheckBatchAsync(requests, vectors, _ctx);
 

--- a/tests/ExpertiseApi.Tests/Unit/Hygiene/PiiDetectorTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/Hygiene/PiiDetectorTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using ExpertiseApi.Hygiene;
 
 namespace ExpertiseApi.Tests.Unit.Hygiene;
@@ -158,5 +159,74 @@ public class PiiDetectorTests
         result.Counts["email"].Should().Be(1);
         result.Counts["github-pat"].Should().Be(1);
         result.Text.Should().Contain("[REDACTED:email]").And.Contain("[REDACTED:github-pat]");
+    }
+
+    // --- AWS secret: capture-group redaction preserves surrounding context (#333 Finding 2) ---
+
+    [Fact]
+    public void AwsSecret_RedactsOnlyTheSecret_PreservingTheContextWord()
+    {
+        // The NonBacktracking rewrite consumes the context word into the match but pulls
+        // the secret into capture group 1; ApplyOne must redact ONLY the group, leaving
+        // the context prefix byte-identical to the pre-rewrite lookbehind behaviour.
+        var input = "aws_secret_access_key=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef01234567";
+        var result = PiiDetector.Redact(input);
+        result.Text.Should().Be("aws_secret_access_key=[REDACTED:aws-secret]");
+    }
+
+    [Fact]
+    public void AwsSecret_PreservesTrailingTextAfterTheSecret()
+    {
+        // The trailing boundary is consumed via (?:[^...]|$) (no lookahead under
+        // NonBacktracking) but sits outside group 1, so the separator and following
+        // text must be re-emitted verbatim.
+        var input = "secret ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef01234567 and then more";
+        var result = PiiDetector.Redact(input);
+        result.Text.Should().Be("secret [REDACTED:aws-secret] and then more");
+        result.Counts["aws-secret"].Should().Be(1);
+    }
+
+    [Fact]
+    public void AwsSecret_AtEndOfString_IsRedacted()
+    {
+        // The '$' alternative of the trailing boundary handles a secret flush against EOL.
+        var input = "secret=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef01234567";
+        var result = PiiDetector.Redact(input);
+        result.Text.Should().Be("secret=[REDACTED:aws-secret]");
+    }
+
+    // --- Fail-closed timeout handling (#333 Finding 2) ---
+
+    [Fact]
+    public void ApplyOne_OnRegexTimeout_SuppressesWholeField_AndSignalsTimeout()
+    {
+        // A catastrophic-backtracking pattern (NOT NonBacktracking) against non-matching
+        // input forces a RegexMatchTimeoutException deterministically at a 1ms budget.
+        // The production detectors can no longer reach this path (all NonBacktracking),
+        // so this exercises the fail-closed net directly through the internal seam.
+        var evil = new Regex("^(a+)+$", RegexOptions.None, TimeSpan.FromMilliseconds(1));
+        var adversarial = new string('a', 40) + "!";
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        var result = PiiDetector.ApplyOne(adversarial, evil, "aws-secret", counts, out var timedOut);
+
+        timedOut.Should().BeTrue();
+        result.Should().Be("[REDACTED:aws-secret-timeout]",
+            "fail-closed must replace the WHOLE field, never return the original unredacted value");
+        result.Should().NotContain(adversarial, "the original adversarial content must not survive");
+        counts.Should().ContainKey("aws-secret-timeout");
+    }
+
+    [Fact]
+    public void ApplyOne_NoTimeout_SignalsFalse()
+    {
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        var ok = new Regex("nomatch", RegexOptions.NonBacktracking, TimeSpan.FromMilliseconds(50));
+
+        var result = PiiDetector.ApplyOne("harmless text", ok, "email", counts, out var timedOut);
+
+        timedOut.Should().BeFalse();
+        result.Should().Be("harmless text");
+        counts.Should().BeEmpty();
     }
 }

--- a/tests/skill/test-common-token-file.sh
+++ b/tests/skill/test-common-token-file.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# tests/skill/test-common-token-file.sh
+#
+# Unit tests for the EXPERTISE_API_TOKEN_FILE resolution ladder in
+# .agents/skills/expertise-api/scripts/lib/common.sh (issue #464).
+#
+# Each case runs require_env in a subshell with a controlled environment and
+# asserts on the resolved token / exit code / stderr. No network, no API.
+#
+# Usage: bash tests/skill/test-common-token-file.sh
+# Exit codes: 0 all cases pass, 1 one or more cases fail.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+COMMON_SH="${REPO_ROOT}/.agents/skills/expertise-api/scripts/lib/common.sh"
+
+WORK_DIR="$(mktemp -d -t skill-token-test.XXXXXX)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+errors=0
+ok()   { printf 'OK    [%s] %s\n' "$1" "$2"; }
+err()  { printf 'ERROR [%s] %s\n' "$1" "$2" >&2; errors=$((errors + 1)); }
+
+# run_require_env NAME [VAR=VALUE ...]
+# Sources common.sh with a scrubbed env plus the given assignments, runs
+# require_env, and prints "<exit>|<resolved-token>" for the caller to assert.
+run_require_env() {
+    shift # NAME is for the caller's bookkeeping only
+    # shellcheck disable=SC2016  # deliberate: $? / $EXPERTISE_API_TOKEN must expand in the INNER shell
+    env -i HOME="$WORK_DIR" PATH="$PATH" "$@" bash -c '
+        . "'"$COMMON_SH"'"
+        require_env >/dev/null 2>"'"$WORK_DIR"'/stderr"
+        printf "%s|%s" "$?" "$EXPERTISE_API_TOKEN"
+    ' 2>>"$WORK_DIR/stderr" || printf '%s|' "$?"
+}
+
+BASE="EXPERTISE_API_BASE_URL=https://api.example.test"
+
+# --- case 1: file-only resolves the token -----------------------------------
+printf 'file-token-value\n' > "$WORK_DIR/token1"
+result="$(run_require_env case1 "$BASE" EXPERTISE_API_TOKEN_FILE="$WORK_DIR/token1")"
+if [ "$result" = "0|file-token-value" ]; then
+    ok token-file-resolves "token read from EXPERTISE_API_TOKEN_FILE"
+else
+    err token-file-resolves "expected '0|file-token-value', got '$result'"
+fi
+
+# --- case 2: explicit token beats the file ----------------------------------
+result="$(run_require_env case2 "$BASE" EXPERTISE_API_TOKEN=explicit-wins EXPERTISE_API_TOKEN_FILE="$WORK_DIR/token1")"
+if [ "$result" = "0|explicit-wins" ]; then
+    ok explicit-wins "EXPERTISE_API_TOKEN takes precedence over the file"
+else
+    err explicit-wins "expected '0|explicit-wins', got '$result'"
+fi
+
+# --- case 3: missing file is a hard exit 2 naming the path ------------------
+result="$(run_require_env case3 "$BASE" EXPERTISE_API_TOKEN_FILE="$WORK_DIR/does-not-exist")"
+if [ "$result" = "2|" ] && grep -q "missing or unreadable file: ${WORK_DIR}/does-not-exist" "$WORK_DIR/stderr"; then
+    ok missing-file "missing token file exits 2 and names the path"
+else
+    err missing-file "expected exit 2 + path in stderr, got '$result' / $(tr '\n' ' ' < "$WORK_DIR/stderr")"
+fi
+
+# --- case 4: empty file is a hard exit 2 -------------------------------------
+: > "$WORK_DIR/empty"
+result="$(run_require_env case4 "$BASE" EXPERTISE_API_TOKEN_FILE="$WORK_DIR/empty")"
+if [ "$result" = "2|" ] && grep -q "EXPERTISE_API_TOKEN_FILE is empty" "$WORK_DIR/stderr"; then
+    ok empty-file "empty token file exits 2"
+else
+    err empty-file "expected exit 2 + empty-file message, got '$result' / $(tr '\n' ' ' < "$WORK_DIR/stderr")"
+fi
+
+# --- case 5: neither variable set names both in the error --------------------
+result="$(run_require_env case5 "$BASE")"
+if [ "$result" = "2|" ] && grep -q "EXPERTISE_API_TOKEN is not set (set it, or point EXPERTISE_API_TOKEN_FILE" "$WORK_DIR/stderr"; then
+    ok neither-set "unset token errors naming both variables"
+else
+    err neither-set "expected exit 2 + both-variable message, got '$result' / $(tr '\n' ' ' < "$WORK_DIR/stderr")"
+fi
+
+# --- case 6: trailing newline and whitespace stripped -------------------------
+printf 'padded-token \t\n\n' > "$WORK_DIR/token-padded"
+result="$(run_require_env case6 "$BASE" EXPERTISE_API_TOKEN_FILE="$WORK_DIR/token-padded")"
+if [ "$result" = "0|padded-token" ]; then
+    ok trailing-trim "trailing whitespace/newlines stripped from file token"
+else
+    err trailing-trim "expected '0|padded-token', got '$result'"
+fi
+
+echo "=================================="
+if [ "$errors" -eq 0 ]; then
+    echo "PASS — 0 errors"
+    exit 0
+fi
+echo "FAIL — ${errors} errors"
+exit 1


### PR DESCRIPTION
Promotion of `dev` → `main` to release **v1.6.1** (semantic-release will derive the PATCH bump from the aggregated Conventional Commits below and tag on merge).

## Contents since v1.6.0

| PR | Type | Summary |
|----|------|---------|
| #465 | fix | skill supports `EXPERTISE_API_TOKEN_FILE` token indirection |
| #466 | fix | dedup `SemanticThreshold` retuned to 0.05 for the jina space (ADR-017 Amdt 1) |
| #467 | ci | macOS install-smoke jobs blocking again (#366 revert-trigger met) |
| #471 | fix | fail-closed PII redaction + lookbehind-free `AwsSecret` (#333 Finding 2) |
| #472 | fix | bounded batch dedup via per-item HNSW (#333 Finding 4a) |
| #473 | fix | dedicated batch rate policy (#333 Finding 4b) |

## Notes

- All `fix`/`ci` — a **PATCH** bump (v1.6.1). No breaking changes; OpenAPI breaking-change gate passed on every PR.
- The #333 security series (Findings 2 + 4) ships here; Finding 1 (breaking response-envelope change) is deliberately held for the next tree and opens **v2.0.0**.
- **Merge with a merge commit** (not squash) to preserve the `dev` squash SHAs for semantic-release (github-flow / semver-tagging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)