### PR TITLE
fix(release): trigger the v2 major bump via a breaking-change footer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,6 +352,8 @@ Scope shorthand (`read`, `draft`, `approve`, `admin`) expands to full scope stri
 
 CodeQL, Trivy, and Hadolint run in separate workflows — see [Security Scanning](#security-scanning).
 
+> **Breaking releases need a `BREAKING CHANGE:` footer, not just `!`.** `.releaserc` uses the default semantic-release **angular** preset, whose commit parser does **not** honor the `type(scope)!:` shorthand — a `fix!`/`feat!` header alone is silently ignored and produces *no release* (observed on the v2.0.0 promotion #476). A MAJOR bump requires an explicit `BREAKING CHANGE:` footer in the commit body. Tracked in #477 (switch to the `conventionalcommits` preset so `!` works as `rules/semver-tagging.md` documents).
+
 GHCR image: `ghcr.io/psmfd/agent-expertise-api` (multi-arch: amd64 + arm64).
 
 ### OpenAPI breaking-change gate


### PR DESCRIPTION
## Why

The v2.0.0 promotion (#476) merged the breaking response-envelope change (#475, `fix(security)!`) to `main`, but semantic-release computed **"no release"** — the default **angular** preset does not honor the `!` header shorthand (issue #477), so `fix(security)!:` wasn't even recognized as a `fix`. No v2.0.0 tag was cut.

## What

- Documents the gotcha in CLAUDE.md's CI/CD section (breaking releases need a `BREAKING CHANGE:` footer, not `!`; root cause tracked in #477).
- Carries the explicit footer below so, once promoted, semantic-release cuts **v2.0.0** (the angular preset **does** honor the footer).

**Merge note:** this PR must be squash-merged with the `BREAKING CHANGE:` footer preserved in the dev commit body (the merge command sets it explicitly), so the subsequent `dev → main` promotion triggers the MAJOR bump.

BREAKING CHANGE: the /expertise/* response schema changes shape for the caller-supplied free-text fields domain, tags, source, and sourceVersion (string / string[] -> HygienizedField object / array of objects), per ADR-008 Amendment 1 (#333 Finding 1, #475). Consumers must read the nested `.value`.