### PR TITLE
chore(release): promote dev to main (v2.0.0, retry)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,6 +352,8 @@ Scope shorthand (`read`, `draft`, `approve`, `admin`) expands to full scope stri
 
 CodeQL, Trivy, and Hadolint run in separate workflows — see [Security Scanning](#security-scanning).
 
+> **Breaking releases need a `BREAKING CHANGE:` footer, not just `!`.** `.releaserc` uses the default semantic-release **angular** preset, whose commit parser does **not** honor the `type(scope)!:` shorthand — a `fix!`/`feat!` header alone is silently ignored and produces *no release* (observed on the v2.0.0 promotion #476). A MAJOR bump requires an explicit `BREAKING CHANGE:` footer in the commit body. Tracked in #477 (switch to the `conventionalcommits` preset so `!` works as `rules/semver-tagging.md` documents).
+
 GHCR image: `ghcr.io/psmfd/agent-expertise-api` (multi-arch: amd64 + arm64).
 
 ### OpenAPI breaking-change gate


### PR DESCRIPTION
Re-promotion to release **v2.0.0**. The prior attempt (#476) produced no release because the angular preset ignored the `!` shorthand (#477); `dev` now carries an explicit `BREAKING CHANGE:` footer (#478) that the angular preset honors.

Merge with **a merge commit** to preserve the dev SHA for semantic-release.