### PR TITLE
test(dedup): replace null cast to clear cs/useless-upcast alerts

### DIFF
--- a/tests/ExpertiseApi.Tests/Unit/DeduplicationServiceTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/DeduplicationServiceTests.cs
@@ -178,7 +178,7 @@ public class DeduplicationServiceTests
         _repo.FindExactMatchesAsync("shared", Arg.Any<IReadOnlyList<string>>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns(new List<ExpertiseEntry>());
         _repo.FindNearestInDomainAsync("shared", Arg.Any<Vector>(), Arg.Any<double>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
-            .Returns((ExpertiseEntry?)null);
+            .Returns(default(ExpertiseEntry));
 
         var results = await service.CheckBatchAsync(requests, vectors, _ctx);
 
@@ -224,7 +224,7 @@ public class DeduplicationServiceTests
         _repo.FindExactMatchesAsync("shared", Arg.Any<IReadOnlyList<string>>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
             .Returns(new List<ExpertiseEntry>());
         _repo.FindNearestInDomainAsync("shared", Arg.Any<Vector>(), Arg.Any<double>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
-            .Returns((ExpertiseEntry?)null);
+            .Returns(default(ExpertiseEntry));
 
         var results = await service.CheckBatchAsync(requests, vectors, _ctx);
 
@@ -248,7 +248,7 @@ public class DeduplicationServiceTests
             .Returns([existingEntry]);
         // Item 0 is caught by exact-match; item 1 has no near neighbour.
         _repo.FindNearestInDomainAsync("shared", Arg.Any<Vector>(), Arg.Any<double>(), Arg.Any<TenantContext>(), Arg.Any<CancellationToken>())
-            .Returns((ExpertiseEntry?)null);
+            .Returns(default(ExpertiseEntry));
 
         var results = await service.CheckBatchAsync(requests, vectors, _ctx);
 


### PR DESCRIPTION
## What

The three `FindNearestInDomainAsync` stubs in `DeduplicationServiceTests` used `(ExpertiseEntry?)null` only to give NSubstitute's `.Returns` overload a typed argument for `T` inference. CodeQL flags the cast as `cs/useless-upcast` — code-scanning alerts **#155 / #156 / #157**, all introduced by #472 (the batch-dedup test rewrite).

## Change

`(ExpertiseEntry?)null` → `default(ExpertiseEntry)` at all three sites. Same typed-null semantics, no cast expression → alerts clear at source.

`.ReturnsNull()` was tried first and rejected: its `where T : class` constraint rejects `ExpertiseEntry?` and emits **CS8634** (3 new warnings on a 0-warning baseline) — a worse trade than the alerts it fixed.

## Doc impact

None (test idiom). No ADR (pattern-following).

## Verification

`dotnet test --filter DeduplicationServiceTests` → 13/13 pass, no new warnings.