### PR TITLE
fix(validation): length caps on domain, source, sourceversion, and tags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,8 @@ curl http://localhost:5000/health
 
 # 5. Create an entry (under Hybrid mode in Development — accepts the API key from .env)
 # POSTs require an Idempotency-Key header per ADR-010 (hard-required since 2026-05-19).
-# Write guards: title max 200 chars, body max 16000 (400 beyond — embedding-window caps, #429/#436/ADR-017).
+# Write guards: title max 200 chars, body max 16000 (embedding-window caps, #429/#436/ADR-017);
+# domain/source max 128, sourceVersion max 64, per-tag max 64, tag count max 32 (#470). 400 beyond any cap.
 curl -X POST http://localhost:5000/expertise \
   -H "Authorization: Bearer dev-api-key-change-me" \
   -H "Idempotency-Key: $(uuidgen)" \

--- a/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
+++ b/src/ExpertiseApi/Endpoints/ExpertiseEndpoints.cs
@@ -229,8 +229,54 @@ internal static class ExpertiseEndpoints
               "Title shares the embedding window with Body; keep titles concise and put detail in the body."
             : null;
 
+    // Short-field caps (#470, #333 Finding 1 adjacent). Title/Body are bounded by the
+    // embedding-window derivations above; Domain/Source/SourceVersion/Tags previously had
+    // only a non-empty check, leaving an unbounded write surface that inflates the
+    // ResponseHygiene slow path (LargeBodyThreshold) and is a minor write-side DoS vector
+    // independent of the delimiter-injection concern Finding 1 closes. Caps sit far above
+    // any legitimate value (observed corpus: domains/sources are short slugs), so no real
+    // caller is affected — this ships as a non-breaking fix, not a MAJOR contract change.
+    private const int MaxDomainLength = 128;
+    private const int MaxSourceLength = 128;
+    private const int MaxSourceVersionLength = 64;
+    private const int MaxTagLength = 64;
+    private const int MaxTagCount = 32;
+
+    private static string? ShortFieldLengthError(string? value, string fieldName, int max) =>
+        value is { } v && v.Length > max
+            ? $"{fieldName} exceeds maximum length of {max} characters (got {v.Length})."
+            : null;
+
+    private static string? TagsLengthError(IReadOnlyList<string>? tags)
+    {
+        if (tags is null)
+            return null;
+        if (tags.Count > MaxTagCount)
+            return $"Tags exceed maximum count of {MaxTagCount} (got {tags.Count}).";
+        for (var i = 0; i < tags.Count; i++)
+        {
+            if (tags[i] is { Length: > MaxTagLength } tag)
+                return $"Tag at index {i} exceeds maximum length of {MaxTagLength} characters (got {tag.Length}).";
+        }
+        return null;
+    }
+
+    // Unified field-length gate shared by create, update, and batch so all three paths
+    // enforce the same caps. Each per-field helper no-ops on null, so it is safe for the
+    // all-optional UpdateExpertiseRequest shape.
+    private static string? FieldLengthError(
+        string? domain, string? title, string? body,
+        string? source, string? sourceVersion, IReadOnlyList<string>? tags) =>
+        TitleLengthError(title)
+            ?? BodyLengthError(body)
+            ?? ShortFieldLengthError(domain, "Domain", MaxDomainLength)
+            ?? ShortFieldLengthError(source, "Source", MaxSourceLength)
+            ?? ShortFieldLengthError(sourceVersion, "SourceVersion", MaxSourceVersionLength)
+            ?? TagsLengthError(tags);
+
     private static string? LengthError(CreateExpertiseRequest request) =>
-        TitleLengthError(request.Title) ?? BodyLengthError(request.Body);
+        FieldLengthError(request.Domain, request.Title, request.Body,
+            request.Source, request.SourceVersion, request.Tags);
 
     private static async Task<IResult> CreateEntry(
         CreateExpertiseRequest request,
@@ -287,7 +333,8 @@ internal static class ExpertiseEndpoints
     {
         var tenantContext = httpContext.RequireTenantContext();
 
-        if ((TitleLengthError(request.Title) ?? BodyLengthError(request.Body)) is { } lengthError)
+        if (FieldLengthError(request.Domain, request.Title, request.Body,
+                request.Source, request.SourceVersion, request.Tags) is { } lengthError)
             return Results.Problem(lengthError, statusCode: 400);
 
         var needsReembed = request.Title is not null || request.Body is not null;

--- a/tests/ExpertiseApi.Tests/Integration/ExpertiseEndpointTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/ExpertiseEndpointTests.cs
@@ -249,6 +249,103 @@ public class ExpertiseEndpointTests : IAsyncLifetime
         problem.Should().Contain("maximum length of 16000");
     }
 
+    // #470 short-field caps: Domain/Source/SourceVersion/Tags previously had only a
+    // non-empty check. The 400 cases below fail before embedding generation (no model
+    // needed); the at-limit case exercises the full create path.
+
+    [Fact]
+    public async Task CreateEntry_WithOverlongDomain_Returns400()
+    {
+        // 128 is MaxDomainLength in ExpertiseEndpoints.
+        var payload = new { domain = new string('d', 129), title = "Ok", body = "Body ok", entryType = "Pattern", severity = "Info", source = "test" };
+        var response = await _client.PostAsJsonAsync("/expertise", payload);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var problem = await response.Content.ReadAsStringAsync();
+        problem.Should().Contain("Domain exceeds maximum length of 128");
+    }
+
+    [Fact]
+    public async Task CreateEntry_WithOverlongSource_Returns400()
+    {
+        // 128 is MaxSourceLength in ExpertiseEndpoints.
+        var payload = new { domain = "shared", title = "Ok", body = "Body ok", entryType = "Pattern", severity = "Info", source = new string('s', 129) };
+        var response = await _client.PostAsJsonAsync("/expertise", payload);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var problem = await response.Content.ReadAsStringAsync();
+        problem.Should().Contain("Source exceeds maximum length of 128");
+    }
+
+    [Fact]
+    public async Task CreateEntry_WithOverlongSourceVersion_Returns400()
+    {
+        // 64 is MaxSourceVersionLength in ExpertiseEndpoints.
+        var payload = new { domain = "shared", title = "Ok", body = "Body ok", entryType = "Pattern", severity = "Info", source = "test", sourceVersion = new string('v', 65) };
+        var response = await _client.PostAsJsonAsync("/expertise", payload);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var problem = await response.Content.ReadAsStringAsync();
+        problem.Should().Contain("SourceVersion exceeds maximum length of 64");
+    }
+
+    [Fact]
+    public async Task CreateEntry_WithOverlongTag_Returns400()
+    {
+        // 64 is MaxTagLength in ExpertiseEndpoints.
+        var payload = new { domain = "shared", title = "Ok", body = "Body ok", entryType = "Pattern", severity = "Info", source = "test", tags = new[] { "fine", new string('x', 65) } };
+        var response = await _client.PostAsJsonAsync("/expertise", payload);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var problem = await response.Content.ReadAsStringAsync();
+        problem.Should().Contain("Tag at index 1 exceeds maximum length of 64");
+    }
+
+    [Fact]
+    public async Task CreateEntry_WithTooManyTags_Returns400()
+    {
+        // 32 is MaxTagCount in ExpertiseEndpoints.
+        var tags = Enumerable.Range(0, 33).Select(i => $"t{i}").ToArray();
+        var payload = new { domain = "shared", title = "Ok", body = "Body ok", entryType = "Pattern", severity = "Info", source = "test", tags };
+        var response = await _client.PostAsJsonAsync("/expertise", payload);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var problem = await response.Content.ReadAsStringAsync();
+        problem.Should().Contain("Tags exceed maximum count of 32");
+    }
+
+    [Fact]
+    public async Task UpdateEntry_WithOverlongSource_Returns400()
+    {
+        var entry = await SeedEntryViaRepo("shared", "Source patch target");
+
+        var response = await _client.PatchAsJsonAsync($"/expertise/{entry.Id}", new { source = new string('s', 129) });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var problem = await response.Content.ReadAsStringAsync();
+        problem.Should().Contain("Source exceeds maximum length of 128");
+    }
+
+    [Fact]
+    public async Task CreateEntry_WithShortFieldsAtLimit_Returns201()
+    {
+        // Every short field exactly at its cap must still succeed.
+        var payload = new
+        {
+            domain = new string('d', 128),
+            title = "At limit",
+            body = "Body ok",
+            entryType = "Pattern",
+            severity = "Info",
+            source = new string('s', 128),
+            sourceVersion = new string('v', 64),
+            tags = new[] { new string('x', 64) },
+        };
+        var response = await _client.PostAsJsonAsync("/expertise", payload);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
     private async Task<ExpertiseEntry> SeedEntryViaRepo(
         string domain = "shared",
         string title = "Test",


### PR DESCRIPTION
Closes #470.

## Problem

`Title`/`Body` have length caps (200 / 16000), but `Domain`, `Source`, `SourceVersion`, and each `Tags` element had **only a non-empty check** — an unbounded write surface that (a) inflates the `ResponseHygiene` `LargeBodyThreshold` (64 KB) slow-path hit rate and (b) is a minor write-side DoS vector, independent of the delimiter-injection concern #333 Finding 1 closes.

## Change

A shared `FieldLengthError` gate now backs create, update, **and** batch so all three paths enforce the same caps:

| Field | Cap |
|---|---|
| Domain | 128 |
| Source | 128 |
| SourceVersion | 64 |
| Tag (each) | 64 |
| Tag count | 32 |

Over-cap → `400` before embedding generation. `OriginAuthorPrincipal` is out of scope — already server-truncated to 256.

## Non-breaking (per maintainer decision)

Caps sit far above any legitimate value (domains/sources are short slugs; corpus max title is 142), so no real caller is affected — the change never 400s input any real client sends. Ships as a **non-breaking `fix` (→ v2.0.1)**, not the v3.0.0 tree. Validation is imperative (not `[MaxLength]` DTO attributes), so `openapi.json` is unchanged — no oasdiff breaking-change flag.

## Doc impact

- CLAUDE.md write-guards note updated with the new caps.
- No ADR (extends the existing Title/Body validation pattern).

## Verification

7 new integration tests (over-cap 400 per field + too-many-tags + at-limit 201), all pass locally against Testcontainers Postgres + the ONNX model. Existing Title/Body cap tests unchanged.