### PR TITLE
ci(release): use conventionalcommits preset so breaking shorthand releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,16 @@ jobs:
       - name: Semantic Release
         id: semantic
         uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
+        with:
+          # The conventionalcommits preset (configured in .releaserc) honors the
+          # `type(scope)!:` breaking shorthand; the default angular preset does NOT
+          # (it silently drops `!` and produced no release for v2.0.0 — #477). The
+          # preset lives in a separate package that @semantic-release/commit-analyzer@13
+          # does not bundle (it depends only on conventional-changelog-angular), so it
+          # MUST be pre-installed here or the release job fails to load the preset.
+          # Pinned to the major validated against commit-analyzer 13 (conventionalcommits 10).
+          extra_plugins: |
+            conventional-changelog-conventionalcommits@10
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,14 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      { "preset": "conventionalcommits" }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      { "preset": "conventionalcommits" }
+    ],
+    "@semantic-release/github"
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,7 +352,7 @@ Scope shorthand (`read`, `draft`, `approve`, `admin`) expands to full scope stri
 
 CodeQL, Trivy, and Hadolint run in separate workflows — see [Security Scanning](#security-scanning).
 
-> **Breaking releases need a `BREAKING CHANGE:` footer, not just `!`.** `.releaserc` uses the default semantic-release **angular** preset, whose commit parser does **not** honor the `type(scope)!:` shorthand — a `fix!`/`feat!` header alone is silently ignored and produces *no release* (observed on the v2.0.0 promotion #476). A MAJOR bump requires an explicit `BREAKING CHANGE:` footer in the commit body. Tracked in #477 (switch to the `conventionalcommits` preset so `!` works as `rules/semver-tagging.md` documents).
+> **Breaking releases: `!` shorthand works (via the conventionalcommits preset).** `.releaserc` configures `@semantic-release/commit-analyzer` + `@semantic-release/release-notes-generator` with the **conventionalcommits** preset, which honors the `type(scope)!:` breaking shorthand — a `feat!`/`fix!` header (or a `BREAKING CHANGE:` footer) triggers a MAJOR bump as `rules/semver-tagging.md` documents (#477). This preset ships in a separate package (`conventional-changelog-conventionalcommits`) that commit-analyzer does **not** bundle, so `release.yml` pre-installs it via the action's `extra_plugins` — do not remove that entry or the release job will fail to load the preset. **Historical note:** before #477 the default **angular** preset silently dropped `!` and produced *no release* on the v2.0.0 promotion (#476), forcing a re-cut with an explicit `BREAKING CHANGE:` footer. That workaround is no longer required.
 
 GHCR image: `ghcr.io/psmfd/agent-expertise-api` (multi-arch: amd64 + arm64).
 


### PR DESCRIPTION
Closes #477.

## Problem

The default **angular** preset in `@semantic-release/commit-analyzer` does **not** honor the `type(scope)!:` breaking shorthand. On the v2.0.0 promotion (#476) the commit `fix(security)!: …` computed **no release at all**, forcing a re-cut with an explicit `BREAKING CHANGE:` footer. This contradicts `rules/semver-tagging.md`, which documents `!` → MAJOR.

## Fix

- `.releaserc`: configure `commit-analyzer` + `release-notes-generator` with `{ "preset": "conventionalcommits" }`.
- `release.yml`: pre-install `conventional-changelog-conventionalcommits@10` via `extra_plugins`. **Required, not optional** — commit-analyzer 13 depends only on `conventional-changelog-angular`, so without it the preset fails to load and the release job fails outright.

## Empirical validation (commit-analyzer 13.0.1, off the release path)

| Commit | angular (before) | conventionalcommits (after) |
|---|---|---|
| `fix(security)!:` *(exact v2.0.0 commit)* | **null — no release** | **major** |
| `feat!:` / `feat(scope)!:` | null — no release | major |
| `feat:` / `fix:` | minor / patch | minor / patch |
| `BREAKING CHANGE:` footer | major | major |

## Scope

Typed `ci` → no version bump for this PR; enables correct bumps on future promotions. Effective from the first dev→main promotion that carries it.

## Doc impact

CLAUDE.md CI/CD note updated. No ADR (fixes tool config to match the documented `semver-tagging.md` convention).