### PR TITLE
fix(skill): keep bearer token out of curl argv in api_curl

### DIFF
--- a/.agents/skills/expertise-api/SKILL.md
+++ b/.agents/skills/expertise-api/SKILL.md
@@ -40,7 +40,7 @@ chmod 600 ~/.config/expertise-api/secrets.env
 
 The scripts source this file automatically when present, so env vars do not need to be exported per-shell.
 
-**Trust model.** The secrets file is sourced via POSIX `.` (dot), so anyone with write access to it can execute arbitrary code in the invoker's shell. Keep it `chmod 600` on a user-owned path. The bearer token is also passed to `curl` as a command-line `-H` argument and is therefore briefly visible in `ps auxww` / `/proc/<pid>/cmdline` to other local users on multi-user systems; this matches common `curl` usage but is worth noting if you share the workstation.
+**Trust model.** The secrets file is sourced via POSIX `.` (dot), so anyone with write access to it can execute arbitrary code in the invoker's shell. Keep it `chmod 600` on a user-owned path. The bearer token is passed to `curl` via a 600-perm `--config` temp file, never as a command-line argument, so it is not visible in `ps auxww` / `/proc/<pid>/cmdline` on multi-user systems (issue #486; same pattern as `expertise-apictl`, ADR-019).
 
 ## Toolkit
 

--- a/.agents/skills/expertise-api/scripts/lib/common.sh
+++ b/.agents/skills/expertise-api/scripts/lib/common.sh
@@ -19,6 +19,9 @@
 #   - api_curl ARGS...   Wrap curl with -sS, Bearer auth, and HTTP-status check.
 #                        Writes response body to stdout. On non-2xx, writes the
 #                        body to stderr along with the status line and exits 1.
+#                        The bearer travels via `curl --config` (a 600-perm
+#                        temp file), NEVER argv — `ps` on a shared host must
+#                        not see it (issue #486, pattern per ADR-019).
 #   - urlencode STR      RFC 3986 percent-encoding for query-string values.
 #   - require_cmd CMD    Fail loudly if a required CLI is missing.
 #
@@ -200,9 +203,64 @@ _resolve_idempotency_key() {
     uuidgen
 }
 
+# _validate_token_charset TOKEN
+# Charset guard before splicing the bearer into a curl config file value:
+# inside curl's double-quoted config values only \\ \" \t \n \r \v are
+# escapes, '#' starts a comment, and control bytes/whitespace would
+# truncate the header. Legitimate bearer tokens (JWT base64url,
+# LocalDev dev:{tenant}:{scopes}) contain none of these — fail loudly
+# rather than send a corrupted Authorization header. Mirrors apictl's
+# _resolve_api_token guard (ADR-019).
+_validate_token_charset() {
+    # shellcheck disable=SC1003  # '\' below is a one-character backslash pattern, not a quote escape
+    case "$1" in
+        *[![:graph:]]*|*'"'*|*'\'*|*'#'*)
+            echo "error: token contains characters never valid in a bearer token (whitespace, control byte, quote, backslash, or '#') — check your token source" >&2
+            exit 2
+            ;;
+    esac
+}
+
+# _make_auth_config [curl-args...]
+# Write the injected headers (Authorization, Accept, and — when the
+# caller's curl args specify a POST — Idempotency-Key) to a 600-perm
+# temp curl config file and echo its path. The bearer never touches
+# curl argv this way (issue #486): `ps` shows only `--config <path>`.
+# The file is registered in _API_CURL_TMP_FILES so the EXIT trap cleans
+# it up on abnormal exit; callers still `rm -f` it immediately after
+# the request. Called via normal command substitution (NOT process
+# substitution) so an `exit 2` from the token guard or
+# _resolve_idempotency_key propagates to the caller process.
+_make_auth_config() {
+    _validate_token_charset "$EXPERTISE_API_TOKEN"
+    local cfg
+    cfg="$(mktemp -t expertise-api-cfg.XXXXXX)"
+    _API_CURL_TMP_FILES+=("$cfg")
+    local idem_key=""
+    if _args_have_post_method "$@"; then
+        idem_key="$(_resolve_idempotency_key)"
+    fi
+    # mktemp creates the file 600; the umask subshell is belt-and-braces
+    # in case a hardened mktemp replacement honours the caller's umask.
+    ( umask 077
+      {
+          printf 'header = "Authorization: Bearer %s"\n' "$EXPERTISE_API_TOKEN"
+          printf 'header = "Accept: application/json"\n'
+          if [ -n "$idem_key" ]; then
+              printf 'header = "Idempotency-Key: %s"\n' "$idem_key"
+          fi
+      } > "$cfg"
+    )
+    printf '%s' "$cfg"
+}
+
 # api_curl PATH [curl-args...]
 # - PATH starts with '/' (e.g. /expertise/search?q=foo)
-# - Bearer token + Accept: application/json injected.
+# - Bearer token + Accept: application/json injected via a 600-perm
+#   `curl --config` temp file, never argv (issue #486, ADR-019).
+#   NEVER add -v/--trace* to these curl invocations (or pass them from
+#   a caller): curl verbose modes print the Authorization header in
+#   cleartext — the standing ADR-019 constraint.
 # - On POST (detected via '-X POST' / '--request POST'), an
 #   Idempotency-Key header is injected automatically. Default value is
 #   `uuidgen`; pre-set IDEMPOTENCY_KEY in the environment to pin a key
@@ -213,31 +271,18 @@ api_curl() {
     require_cmd curl
     local path="$1"; shift
     local url="${EXPERTISE_API_BASE_URL}${path}"
-    local body_file status
+    local body_file status cfg
     body_file="$(mktemp -t expertise-api.XXXXXX)"
     _API_CURL_TMP_FILES+=("$body_file")
+    cfg="$(_make_auth_config "$@")"
 
-    local idem_args=()
-    if _args_have_post_method "$@"; then
-        local _idem_key
-        _idem_key="$(_resolve_idempotency_key)"
-        idem_args=(-H "Idempotency-Key: ${_idem_key}")
-    fi
-
-    # ${idem_args[@]+"${idem_args[@]}"} expands to nothing when the
-    # array is empty, which is safe under `set -u` on bash 3.2 (macOS
-    # system bash) as well as bash 4.4+. The plain "${idem_args[@]}"
-    # form raises 'unbound variable' on bash < 4.4 when the array is
-    # empty, which would break every non-POST request on a developer
-    # workstation running /bin/bash.
     status="$(curl -sS \
         -o "$body_file" \
         -w '%{http_code}' \
-        -H "Authorization: Bearer ${EXPERTISE_API_TOKEN}" \
-        -H 'Accept: application/json' \
-        ${idem_args[@]+"${idem_args[@]}"} \
+        --config "$cfg" \
         "$@" \
-        "$url")"
+        "$url")" || { rm -f "$cfg"; return 1; }
+    rm -f "$cfg"
 
     case "$status" in
         2??)
@@ -262,25 +307,18 @@ api_curl_status() {
     require_cmd curl
     local path="$1"; shift
     local url="${EXPERTISE_API_BASE_URL}${path}"
-    local body_file status
+    local body_file status cfg
     body_file="$(mktemp -t expertise-api.XXXXXX)"
     _API_CURL_TMP_FILES+=("$body_file")
-
-    local idem_args=()
-    if _args_have_post_method "$@"; then
-        local _idem_key
-        _idem_key="$(_resolve_idempotency_key)"
-        idem_args=(-H "Idempotency-Key: ${_idem_key}")
-    fi
+    cfg="$(_make_auth_config "$@")"
 
     status="$(curl -sS \
         -o "$body_file" \
         -w '%{http_code}' \
-        -H "Authorization: Bearer ${EXPERTISE_API_TOKEN}" \
-        -H 'Accept: application/json' \
-        ${idem_args[@]+"${idem_args[@]}"} \
+        --config "$cfg" \
         "$@" \
-        "$url")"
+        "$url")" || { rm -f "$cfg"; return 1; }
+    rm -f "$cfg"
 
     printf '%s' "$status"
     cat "$body_file" >&2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,9 @@ jobs:
       - name: Run skill token-file resolution tests (#464)
         run: bash tests/skill/test-common-token-file.sh
 
+      - name: Run skill api_curl argv-hygiene tests (#486)
+        run: bash tests/skill/test-common-api-curl.sh
+
   install-script-guards:
     name: install/uninstall script guard tests (#242)
     runs-on: ubuntu-latest

--- a/scripts/expertise-apictl
+++ b/scripts/expertise-apictl
@@ -347,7 +347,7 @@ _api_http_init() {
 # Called as a plain command (never via $(...)) so both globals survive.
 # The bearer travels via `curl --config` (a 600-perm file under the 700-perm
 # workdir), NEVER argv — `ps` on a shared host must not see it (the skill's
-# api_curl still leaks it that way; #486). The config file is removed
+# api_curl uses the same pattern since #486). The config file is removed
 # immediately after each call; the EXIT trap is only the abnormal-exit
 # backstop. NEVER add -v/--trace* to this curl invocation: curl verbose modes
 # print the Authorization header in cleartext (standing ADR-019 constraint).

--- a/tests/skill/test-common-api-curl.sh
+++ b/tests/skill/test-common-api-curl.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# tests/skill/test-common-api-curl.sh
+#
+# Argv-hygiene tests for api_curl / api_curl_status in
+# .agents/skills/expertise-api/scripts/lib/common.sh (issue #486).
+#
+# A curl stub on PATH records its argv and snapshots the --config file it
+# was handed, then emits a canned HTTP status + body. Asserts that the
+# bearer token never appears in curl argv, that the injected headers
+# (Authorization, Accept, Idempotency-Key on POST) travel via the config
+# file, that the config file is removed after each call, and that the
+# unsafe-token charset guard fails closed before curl is ever invoked.
+# No network, no API.
+#
+# Usage: bash tests/skill/test-common-api-curl.sh
+# Exit codes: 0 all cases pass, 1 one or more cases fail.
+
+# shellcheck disable=SC2016  # deliberate: $1/$@ inside bash -c '…' must expand in the INNER shell
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+COMMON_SH="${REPO_ROOT}/.agents/skills/expertise-api/scripts/lib/common.sh"
+
+WORK_DIR="$(mktemp -d -t skill-argv-test.XXXXXX)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+errors=0
+ok()   { printf 'OK    [%s] %s\n' "$1" "$2"; }
+err()  { printf 'ERROR [%s] %s\n' "$1" "$2" >&2; errors=$((errors + 1)); }
+
+TOKEN="secret-bearer-token-486"
+
+# --- curl stub ---------------------------------------------------------------
+# Records argv (one line per element) to argv.<n>, snapshots the file named
+# by --config to cfg.<n>, honours -o FILE and -w '%{http_code}' the way the
+# real curl would for these invocations. STUB_STATUS/STUB_BODY control the
+# canned response; STUB_FAIL=1 exits 7 (transport failure) without output.
+STUB_DIR="$WORK_DIR/bin"
+mkdir -p "$STUB_DIR"
+cat > "$STUB_DIR/curl" <<'EOF'
+#!/usr/bin/env bash
+set -u
+n=0
+while [ -e "${STUB_STATE}/argv.$n" ]; do n=$((n + 1)); done
+printf '%s\n' "$@" > "${STUB_STATE}/argv.$n"
+out=""
+prev=""
+for arg in "$@"; do
+    case "$prev" in
+        --config) cp "$arg" "${STUB_STATE}/cfg.$n" ;;
+        -o)       out="$arg" ;;
+    esac
+    prev="$arg"
+done
+if [ "${STUB_FAIL:-0}" = "1" ]; then
+    exit 7
+fi
+[ -n "$out" ] && printf '%s' "${STUB_BODY:-{}}" > "$out"
+printf '%s' "${STUB_STATUS:-200}"
+EOF
+chmod +x "$STUB_DIR/curl"
+
+# run_api NAME FUNC PATH [curl-args...]
+# Runs FUNC from common.sh in a subshell with the stub curl first on PATH.
+# Streams: stdout -> $WORK_DIR/out, stderr -> $WORK_DIR/stderr; exit code
+# echoed. STUB_STATE is reset per call so argv/cfg indices start at 0.
+run_api() {
+    local name="$1" func="$2"; shift 2
+    local state="$WORK_DIR/state-$name"
+    mkdir -p "$state"
+    rm -f "$WORK_DIR/out" "$WORK_DIR/stderr"
+    set +e
+    env PATH="$STUB_DIR:$PATH" STUB_STATE="$state" \
+        STUB_STATUS="${STUB_STATUS:-200}" STUB_BODY="${STUB_BODY:-{}}" \
+        STUB_FAIL="${STUB_FAIL:-0}" \
+        EXPERTISE_API_BASE_URL="https://api.example.test" \
+        EXPERTISE_API_TOKEN="${TEST_TOKEN:-$TOKEN}" \
+        bash -c '. "$1"; shift; f="$1"; shift; "$f" "$@"' \
+        _ "$COMMON_SH" "$func" "$@" \
+        > "$WORK_DIR/out" 2> "$WORK_DIR/stderr"
+    local rc=$?
+    set -e
+    LAST_STATE="$state"
+    return "$rc"
+}
+
+# --- case 1: bearer absent from argv; --config present (GET) ------------------
+run_api get-hygiene api_curl "/expertise?limit=1" || true
+if grep -qx -- '--config' "$LAST_STATE/argv.0" \
+   && ! grep -q "$TOKEN" "$LAST_STATE/argv.0"; then
+    ok argv-no-bearer "GET: --config in argv, bearer literal absent"
+else
+    err argv-no-bearer "argv leaked the bearer or lacked --config: $(tr '\n' ' ' < "$LAST_STATE/argv.0")"
+fi
+
+# --- case 2: config file carries Authorization + Accept, no idem key on GET ---
+if grep -q "header = \"Authorization: Bearer ${TOKEN}\"" "$LAST_STATE/cfg.0" \
+   && grep -q 'header = "Accept: application/json"' "$LAST_STATE/cfg.0" \
+   && ! grep -q 'Idempotency-Key' "$LAST_STATE/cfg.0"; then
+    ok cfg-headers-get "config file has Authorization+Accept, no Idempotency-Key on GET"
+else
+    err cfg-headers-get "unexpected config content: $(tr '\n' ' ' < "$LAST_STATE/cfg.0")"
+fi
+
+# --- case 3: POST gets an Idempotency-Key via the config file -----------------
+run_api post-idem api_curl "/expertise" -X POST --data '{"x":1}' || true
+if grep -q 'header = "Idempotency-Key: ' "$LAST_STATE/cfg.0" \
+   && ! grep -q "$TOKEN" "$LAST_STATE/argv.0"; then
+    ok cfg-idem-post "POST: Idempotency-Key in config file, bearer still off argv"
+else
+    err cfg-idem-post "POST config/argv wrong: cfg=$(tr '\n' ' ' < "$LAST_STATE/cfg.0")"
+fi
+key1="$(sed -n 's/^header = "Idempotency-Key: \(.*\)"$/\1/p' "$LAST_STATE/cfg.0")"
+
+# --- case 4: a second POST mints a distinct Idempotency-Key -------------------
+run_api post-idem2 api_curl "/expertise" -X POST --data '{"x":2}' || true
+key2="$(sed -n 's/^header = "Idempotency-Key: \(.*\)"$/\1/p' "$LAST_STATE/cfg.0")"
+if [ -n "$key1" ] && [ -n "$key2" ] && [ "$key1" != "$key2" ]; then
+    ok idem-distinct "consecutive POSTs mint distinct Idempotency-Keys"
+else
+    err idem-distinct "keys not distinct: '$key1' vs '$key2'"
+fi
+
+# --- case 5: pinned IDEMPOTENCY_KEY is honoured --------------------------------
+state="$WORK_DIR/state-pinned"; mkdir -p "$state"
+set +e
+env PATH="$STUB_DIR:$PATH" STUB_STATE="$state" STUB_STATUS=200 STUB_BODY='{}' STUB_FAIL=0 \
+    EXPERTISE_API_BASE_URL="https://api.example.test" \
+    EXPERTISE_API_TOKEN="$TOKEN" IDEMPOTENCY_KEY="pinned-key-123" \
+    bash -c '. "$1"; api_curl /expertise -X POST --data "{}"' _ "$COMMON_SH" \
+    >/dev/null 2>&1
+set -e
+if grep -q 'header = "Idempotency-Key: pinned-key-123"' "$state/cfg.0"; then
+    ok idem-pinned "pre-set IDEMPOTENCY_KEY carried through the config file"
+else
+    err idem-pinned "pinned key missing from config: $(tr '\n' ' ' < "$state/cfg.0")"
+fi
+
+# --- case 6: unsafe token fails exit 2 before curl runs ------------------------
+TEST_TOKEN='bad#token'
+run_api unsafe-hash api_curl "/expertise" && rc=0 || rc=$?
+if [ "$rc" = "2" ] && grep -q "never valid in a bearer token" "$WORK_DIR/stderr" \
+   && [ ! -e "$LAST_STATE/argv.0" ]; then
+    ok unsafe-hash "token with '#' exits 2 and curl is never invoked"
+else
+    err unsafe-hash "expected exit 2 + no curl call, got rc=$rc, argv.0 $( [ -e "$LAST_STATE/argv.0" ] && echo present || echo absent )"
+fi
+
+TEST_TOKEN='bad token'
+run_api unsafe-space api_curl "/expertise" && rc=0 || rc=$?
+if [ "$rc" = "2" ] && [ ! -e "$LAST_STATE/argv.0" ]; then
+    ok unsafe-space "token with a space exits 2 and curl is never invoked"
+else
+    err unsafe-space "expected exit 2 + no curl call, got rc=$rc"
+fi
+unset TEST_TOKEN
+
+# --- case 7: config file removed after a successful call ----------------------
+run_api cleanup api_curl "/expertise?limit=1" || true
+cfg_path="$(grep -A1 -x -- '--config' "$LAST_STATE/argv.0" | tail -1)"
+if [ -n "$cfg_path" ] && [ ! -e "$cfg_path" ]; then
+    ok cfg-removed "config file deleted immediately after the request"
+else
+    err cfg-removed "config file still present (or path not captured): '$cfg_path'"
+fi
+
+# --- case 8: non-2xx still surfaces status + body on stderr, exit 1 -----------
+STUB_STATUS=404 STUB_BODY='{"title":"not found"}' run_api non2xx api_curl "/expertise/nope" && rc=0 || rc=$?
+if [ "$rc" = "1" ] && grep -q "HTTP 404" "$WORK_DIR/stderr" \
+   && grep -q "not found" "$WORK_DIR/stderr"; then
+    ok non2xx "404 path unchanged: exit 1, status + body on stderr"
+else
+    err non2xx "expected exit 1 + 404 body on stderr, got rc=$rc / $(tr '\n' ' ' < "$WORK_DIR/stderr")"
+fi
+
+# --- case 9: api_curl_status also keeps the bearer off argv --------------------
+STUB_STATUS=409 STUB_BODY='{"title":"conflict"}' run_api status-fn api_curl_status "/expertise" -X POST --data '{}' || true
+if ! grep -q "$TOKEN" "$LAST_STATE/argv.0" \
+   && grep -q "header = \"Authorization: Bearer ${TOKEN}\"" "$LAST_STATE/cfg.0" \
+   && grep -qx '409' "$WORK_DIR/out"; then
+    ok status-fn "api_curl_status: bearer off argv, status on stdout"
+else
+    err status-fn "api_curl_status leaked bearer or wrong status: out=$(cat "$WORK_DIR/out")"
+fi
+
+# --- case 10: transport failure removes the config file ------------------------
+STUB_FAIL=1 run_api transport-fail api_curl "/expertise" && rc=0 || rc=$?
+cfg_path="$(grep -A1 -x -- '--config' "$LAST_STATE/argv.0" | tail -1)"
+if [ "$rc" != "0" ] && [ -n "$cfg_path" ] && [ ! -e "$cfg_path" ]; then
+    ok transport-fail "curl transport failure: nonzero exit, config file removed"
+else
+    err transport-fail "expected nonzero + removed config, got rc=$rc, cfg '$cfg_path'"
+fi
+
+echo "=================================="
+if [ "$errors" -eq 0 ]; then
+    echo "PASS — 0 errors"
+    exit 0
+fi
+echo "FAIL — ${errors} errors"
+exit 1


### PR DESCRIPTION
## Summary

Closes #486. `api_curl` / `api_curl_status` in the skill's `common.sh` passed `-H "Authorization: Bearer $TOKEN"` as a curl argv element — readable via `ps -ef` / `/proc/<pid>/cmdline` by any local user for the life of each request. The bearer (plus `Accept` and the POST `Idempotency-Key`) now travels via a 600-perm `curl --config` temp file, the pattern ADR-019 established for `expertise-apictl`'s `_api_http`. `ps` now shows only `--config <path>`.

## Changes

- **`common.sh`**: new `_validate_token_charset` (rejects non-graph chars, `"`, `\`, `#` — the characters that break, escape, or comment-truncate a double-quoted curl config value — with a hard exit 2 before any request) and `_make_auth_config` (600-perm mktemp file + `umask 077` belt-and-braces, registered in the existing `_API_CURL_TMP_FILES` EXIT-trap array, `rm -f` immediately after each call). Caller-facing contracts unchanged: arbitrary curl args, POST idempotency-key injection, pinned `IDEMPOTENCY_KEY`, non-2xx status+body surfacing.
- **`tests/skill/test-common-api-curl.sh`** (new, 11 assertions): curl-stub-on-PATH harness records argv and snapshots the config file. Asserts bearer absent from argv, headers present in the config file, distinct + pinned idempotency keys, unsafe-token fail-closed with curl never invoked, config file removed after success and after transport failure, non-2xx regression. Passes on bash 3.2 (macOS system bash) and 5.3.
- **`ci.yml`**: wired as a step after the #464 token-file suite.
- **`SKILL.md`** trust model: removes the now-false "briefly visible in ps" caveat.
- **`expertise-apictl`**: drops the stale "the skill's api_curl still leaks it that way" comment.

Not touched: the pi extension sets the header via in-process `fetch()` (no argv), already safe.

## Doc impact

| Surface | Classification | Reason |
|---|---|---|
| SKILL.md trust model | in-scope | updated in this PR |
| ADR | not-a-thing | applies the pattern ADR-019 §2 already records and explicitly deferred to #486 |
| CLAUDE.md / README | not-a-thing | neither documents the header transport mechanism |

## Verification

- shellcheck clean (common.sh, test suite, apictl); actionlint/yamllint/markdownlint clean on touched hunks (linter agent: PASS)
- 11/11 new assertions + existing #464 suite on bash 3.2 and 5.3
- End-to-end `GET /expertise?limit=1` against the live local A2 service through the patched `api_curl` — authenticated, hygiene envelope intact
- `scripts/validate-pr.sh` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)