### PR TITLE
feat(integrity): keyed hmac integrity hash with rekey migration (ADR-020)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,9 @@ dotnet run --project src/ExpertiseApi -- reembed [--batch-size 50]
 
 # Backfill IntegrityHash for entries created before the secure-rebuild data model
 # (entries with IntegrityHash = NULL). Idempotent — only touches null rows.
-dotnet run --project src/ExpertiseApi -- rehash [--batch-size 50]
+# --force recomputes EVERY row: the one-time rekey migration after configuring or
+# rotating Integrity:HmacKey (ADR-020) — run it once before trusting verification.
+dotnet run --project src/ExpertiseApi -- rehash [--batch-size 50] [--force]
 
 # Export all entries (every tenant + review state) + audit log as NDJSON with an
 # RFC 6962 Merkle manifest (ADR-012). Plain files only — signing/encryption is
@@ -475,7 +477,7 @@ The `ExpertiseEntry` entity carries the original content fields (`Domain`, `Tags
 | `Visibility` | `enum { Private, Shared }` | Stored as string. Defaults to `Private`. Setting `Shared` on create requires `expertise.write.approve`. Changing `Visibility` via PATCH (either direction) requires `expertise.write.approve`; no-op (PATCH supplies the current value) does not escalate. |
 | `AuthorPrincipal` | `string`, required | OIDC `sub` of the writer. Server-set. Migration backfills `pre-rebuild`. |
 | `AuthorAgent` | `string?` | Agent name when written via an agent. Distinct from `AuthorPrincipal`. |
-| `IntegrityHash` | `string?` | SHA-256 hex over canonical JSON of `{tenant, title, body, entryType, severity}`. Backfilled by the `rehash` CLI. |
+| `IntegrityHash` | `string?` | Canonical content hash over `{tenant, title, body, entryType, severity}`. Keyed format `{keyId}:{hex}` = HMAC-SHA256 under `Integrity:HmacKey(File)` (ADR-020, unforgeable by a DB-only writer); bare 64-hex = legacy unkeyed SHA-256 (soft-require phase, flip tracked in #490). Backfilled by `rehash`; rekeyed by `rehash --force`. |
 | `ReviewState` | `enum { Draft, Approved, Rejected }` | Stored as string. Defaults to `Draft`. |
 | `ReviewedBy`, `ReviewedAt`, `RejectionReason` | `string?`, `DateTime?`, `string?` | Approval/rejection metadata, server-set on `/approve` or `/reject` (later PR). |
 | `OriginInstanceId` | `string?` | ADR-013 up-sync attribution. Server-set on the hub from the authenticated client's `Sync:KnownInstances` mapping — never from the request body. Excluded from canonical hash and dedup equality. |

--- a/adrs/020-integrity-verification.md
+++ b/adrs/020-integrity-verification.md
@@ -1,0 +1,90 @@
+# Keyed IntegrityHash and audit-log checkpoint chain (verification path for #468)
+
+- Status: accepted
+- Date: 2026-07-25
+
+## Context and Problem Statement
+
+`IntegrityHash` is an unsalted SHA-256 over canonical JSON of `{tenant, title, body, entryType, severity}` (`IntegrityHashService`), stored in the same mutable row it describes. The audit log's `BeforeHash`/`AfterHash` reuse the same computation. Nothing ever recomputes or compares any of these hashes — the `rehash` CLI only backfills nulls. The #333 OWASP-AI review (Finding 3, deferred to #468) called this out as decorative tamper-evidence: any actor who can write the row can trivially recompute a matching hash, and deleting an audit row is undetectable. Triage decided to build a real verification path, not downgrade the claim.
+
+The design must answer three questions: (1) what makes the hash unforgeable by a database-only writer; (2) what makes audit-row deletion detectable; (3) where verification runs. A constraint discovered during design: deduplication does **not** compare hash values (`DeduplicationService` does a literal title+body string compare; no `WHERE IntegrityHash = …` query exists anywhere), so the hash *primitive* can change freely as long as the 5-field canonical set — which `BackupRecordHash`'s doc contract references — stays fixed.
+
+## Threat model (stated honestly)
+
+These mechanisms detect **post-commit tampering by database-only writers**: SQL injection through the app's DB credential, a stolen DB credential, a rogue DBA in a deployment where DB and app-host access are separated (Compose/Helm), or a popped Postgres container on an A2 host. They do **not** defend against:
+
+- **A compromised app process** — it holds the HMAC key to compute legitimate writes, so it can forge consistently from the moment of compromise. HMAC/chaining prove *content has not changed since commit*, never that the commit was truthful.
+- **Host root** on a single-host A2 install — root reads the key file and rewrites any local anchor. The only mitigation is an anchor that has already left the host (the ADR-012 signed backup manifest, when copied off-host).
+
+On A2 the operator *is* the DB admin; the meaningful A2 attacker is one who reaches the DB without reaching the host (SQLi, container escape into Postgres only). In Helm/Compose deployments where the key is a secret mounted only into the API workload, HMAC delivers its full value: a DB-side writer was never issued the key and cannot forge a matching MAC.
+
+## Considered Options
+
+### 1. Hash strength
+
+- **A. Keyed HMAC-SHA256, replacing the primitive in place** — same field, same canonical JSON, output `k<id>:<hex>`.
+- **B. Additive `ContentMac` columns beside the existing hash** — no change to existing values.
+- **C. Row-to-row chaining of entries** — rejected outright: entries are mutable (PATCH), chaining fits append-only data only.
+
+### 2. Audit-log deletion detection
+
+- **A. Strict per-row chain** (`PrevHash`/`RowHash` computed inside every mutating transaction).
+- **B. Checkpoint (epoch) chain** — periodic checkpoint rows, each holding an RFC 6962 Merkle root over the audit-row range since the previous checkpoint plus the previous checkpoint's hash.
+- **C. Rely on the ADR-012 backup Merkle manifest alone.**
+
+### 3. Where verification runs
+
+- **A. Operator CLI (`verify`) scheduled by an OS timer / CronJob.**
+- **B. In-process `BackgroundService` sweep.**
+- **C. On-read verification (fail-closed per response).**
+
+## Decision Outcome
+
+**1A — keyed HMAC in place.** `IntegrityHashService` computes `HMACSHA256(key, canonicalBytes)` over the *identical* 5-field canonical JSON, stored as `{keyId}:{lowercase hex}` in the existing `IntegrityHash` column and audit `BeforeHash`/`AfterHash`. Chosen over 1B because dedup never hash-compares (verified in code), the response field stays a plain string (zero OpenAPI change), and no new columns or dual bookkeeping are needed. The key-id prefix makes rotation cheap: retired keys stay resolvable for verification; a bare 64-hex value (no colon) is recognized as the legacy unkeyed format.
+
+**2B — checkpoint chain.** A strict per-row chain (2A) forces every mutating transaction to read the current chain tip — a global write-serialization point that is fragile under PgBouncer transaction pooling and multi-replica Helm, and couples every endpoint's write path to the integrity feature. The checkpoint chain reuses the existing `MerkleTree` (RFC 6962, ADR-012) over `Id`-ranges of audit rows, adds zero write-path contention, and detects any edit or deletion inside a sealed range (the recomputed root diverges). Accepted cost: rows newer than the latest checkpoint are not yet committed to the chain — the detection gap equals the verification cadence and is monitored via checkpoint-staleness metrics. 2C alone is insufficient: backups are operator-cadence and heavier; the live chain gives per-sweep detection independent of backup timing. The two compose: checkpoints are included in backups, so the signed, off-host manifest (ADR-012 Amendment 1) anchors the chain head against a local rewrite.
+
+**3A — CLI + OS timer.** `dotnet run -- verify` (wrapped as `expertise-apictl verify`) recomputes every entry MAC (cursor-paged, `AsNoTracking`, cross-tenant via `IgnoreQueryFilters`), verifies every sealed checkpoint by recomputing its Merkle root and chain link, then seals a new checkpoint through the latest audit row. Exit 0 clean / 1 mismatch / 2 precondition. Scheduling is an OS concern (systemd timer / launchd on A2, CronJob on k8s), matching how `backup` and `reembed` already run. The verification logic lives in an `IntegrityVerificationService` so 3B remains a future option without rework. 3C is rejected as a default: it puts recompute cost and a fail-closed failure mode on the read-hot path to catch what the sweep already catches within one interval; a narrowly scoped opt-in admin endpoint may be added later if a use case appears.
+
+### Key management
+
+- Config: `Integrity:HmacKey` (inline base64) / `Integrity:HmacKeyFile` (path to a base64 key file) — inline wins when both are set, mirroring the `EXPERTISE_API_TOKEN`/`_FILE` idiom (#464). `Integrity:ActiveKeyId` (default `k1`) names the key; `Integrity:RetiredKeys` (id → base64, added with `verify` in PR 2) keeps old keys resolvable for verification after rotation.
+- Key material: 256-bit minimum (decoded length ≥ 32 bytes). Loaded once at startup into a singleton (`IIntegrityKeyProvider`); never hot-reloaded.
+- **Fail-closed when configured**: a configured-but-unusable key (missing/unreadable file, invalid base64, short key, malformed key id) aborts boot — the ADR-015 JWKS posture. Silent fallback would quietly write forgeable hashes.
+- **Soft-require when unconfigured** (phased rollout, the ADR-010 precedent): no key configured → legacy unkeyed SHA-256 plus a loud startup warning and an `expertise_integrity_unkeyed` gauge (1/0). `install.sh` generates a key automatically on A2, so native installs are keyed from the first post-upgrade boot; Compose/Helm operators add the secret at their own pace. The flip to hard-require outside Development is tracked in #490 and gated on fleet observability showing the gauge at zero.
+- Per archetype: A2 — `install.sh`-generated file under `~/.config/expertise-api/` (600/700 perms) referenced via `Integrity__HmacKeyFile` in the service environment; Compose — `INTEGRITY__HMACKEY` in the gitignored `.env`; Helm — a key in the existing `auth.secretName` Secret via the established `envFrom` path (zero new chart plumbing).
+
+### Migration and operational notes
+
+- **One-time rekey**: `rehash --force` recomputes every row unconditionally (not just nulls). It ships in the same PR as the HMAC switch — without it, the first `verify` after an upgrade reports a false 100% mismatch. The upgrade runbook orders it: upgrade → key present → `rehash --force` → schedule `verify`.
+- **Restore** (`restore` CLI) copies `IntegrityHash` verbatim from the backup payload; after restoring a backup taken under a different key (or pre-HMAC), run `rehash --force` before trusting `verify` output. Restore's own tamper detection is unaffected — it verifies `BackupRecordHash` + Merkle roots, which remain unkeyed by design (the backup manifest is signed; ADR-012).
+- Audit `BeforeHash`/`AfterHash` written before the switch remain legacy-format; `verify` treats the format prefix as authoritative per value and reports (metric-labelled, non-fatal) how many legacy values remain.
+- MAC comparison uses `CryptographicOperations.FixedTimeEquals`; hashing uses the static `HMACSHA256.HashData`/`SHA256.HashData` one-shots.
+
+### Delivery phasing
+
+- **PR 1**: this ADR; keyed `IntegrityHashService` + `IntegrityKeyProvider` + startup guard + unkeyed gauge; `rehash --force`; tests.
+- **PR 2**: `AuditCheckpoints` table + migration; `IntegrityVerificationService` + `verify` CLI + `expertise-apictl verify`; `expertise_integrity_verify_runs_total{result}` / `expertise_integrity_mismatches_total{kind}` metrics; tamper-detection integration tests; checkpoint export in `backup`.
+- **PR 3**: deployment surfaces — `install.sh` keygen, Compose/Helm docs and secret wiring, timer/CronJob templates, upgrade runbook.
+
+### Rejected / deferred hardening (recorded so they are decisions, not omissions)
+
+- **On-read verification** — rejected as default (cost/blast-radius, above).
+- **RFC 3161 timestamping of checkpoint heads** — genuinely defeats host-root for pre-timestamp state, but adds a network dependency and token handling disproportionate to a first cut. Revisit only on demand.
+- **Postgres-native mechanisms** (`pgcrypto` `hmac()`, logical decoding) — pushes key material into SQL text and breaks the portable, Testcontainers-testable app-level pattern.
+- **`REVOKE UPDATE, DELETE ON "ExpertiseAuditLog"` from the app role** — cheap defense-in-depth against SQLi-class writers, but the single-role A2 install (app role owns the schema and can re-grant) blunts it; noted for operators who run split-role deployments, not implemented here.
+- **ASP.NET Core Data Protection API as the key mechanism** — wrong primitive: nondeterministic protect/unprotect with auto-rotating key ring, no stable MAC surface (first-party DP docs).
+
+### Consequences
+
+- Good, because a database-only writer can no longer forge `IntegrityHash` (keyed), and deletion or edit of any checkpointed audit row is detectable on the next sweep.
+- Good, because the write path is untouched: no new locks, no serialization point, no API-shape change, dedup unaffected.
+- Good, because rollout is non-breaking (soft-require + auto-keying on A2) with a tracked flip (#490).
+- Bad, because a detection gap exists for audit rows newer than the last checkpoint (bounded by sweep cadence) and for anything a compromised app process writes after compromise — both stated in the threat model above.
+- Bad, because the API host now holds a symmetric secret (a bounded exception to ADR-015's no-server-keys posture; the backup signing key set the precedent in ADR-012 Amendment 1).
+
+## Related
+
+- #468 (this issue), #333 Finding 3 (origin), #490 (hard-require flip)
+- ADR-012 (backup Merkle manifest — the off-host anchor), ADR-015 (fail-closed key loading posture), ADR-010 (soft→hard require precedent)
+- `Services/IntegrityHashService.cs`, `Services/BackupRecordHash.cs`, `Services/MerkleTree.cs`

--- a/src/ExpertiseApi/Cli/RehashCommand.cs
+++ b/src/ExpertiseApi/Cli/RehashCommand.cs
@@ -14,12 +14,19 @@ internal static class RehashCommand
         using var scope = app.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
         var logger = scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Rehash");
+        var integrityKeys = scope.ServiceProvider.GetRequiredService<IIntegrityKeyProvider>();
 
         var batchSize = GetBatchSize(args);
+        // --force: recompute EVERY row, not just nulls — the one-time rekey migration
+        // after configuring (or rotating) Integrity:HmacKey (ADR-020). Without it the
+        // first `verify` run after a key change reports a false mass mismatch.
+        var force = Array.Exists(args, a => a.Equals("--force", StringComparison.OrdinalIgnoreCase));
         var processed = 0;
         Guid? lastId = null;
 
-        logger.LogInformation("Starting rehash with batch size {BatchSize}", batchSize);
+        logger.LogInformation(
+            "Starting rehash with batch size {BatchSize} (force={Force}, keyed={Keyed})",
+            batchSize, force, integrityKeys.ActiveKey is not null);
 
         while (true)
         {
@@ -27,9 +34,12 @@ internal static class RehashCommand
             // See ReembedCommand for rationale.
             var query = db.ExpertiseEntries
                 .IgnoreQueryFilters()
-                .Where(e => e.IntegrityHash == null)
-                .OrderBy(e => e.Id)
                 .AsQueryable();
+
+            if (!force)
+                query = query.Where(e => e.IntegrityHash == null);
+
+            query = query.OrderBy(e => e.Id);
 
             if (lastId is not null)
                 query = query.Where(e => e.Id > lastId.Value);
@@ -40,7 +50,7 @@ internal static class RehashCommand
 
             foreach (var entry in entries)
             {
-                entry.IntegrityHash = IntegrityHashService.Compute(entry);
+                entry.IntegrityHash = IntegrityHashService.Compute(entry, integrityKeys.ActiveKey);
             }
 
             await db.SaveChangesAsync();

--- a/src/ExpertiseApi/Data/ExpertiseRepository.cs
+++ b/src/ExpertiseApi/Data/ExpertiseRepository.cs
@@ -14,7 +14,8 @@ namespace ExpertiseApi.Data;
 internal class ExpertiseRepository(
     ExpertiseDbContext db,
     IHttpContextAccessor httpContextAccessor,
-    ILogger<ExpertiseRepository> logger) : IExpertiseRepository
+    ILogger<ExpertiseRepository> logger,
+    IIntegrityKeyProvider integrityKeys) : IExpertiseRepository
 {
     /// <summary>
     /// Builds the tenant predicate per ADR-001: a row is visible if its <c>Tenant</c>
@@ -199,7 +200,7 @@ internal class ExpertiseRepository(
 
         entry.CreatedAt = DateTime.UtcNow;
         entry.UpdatedAt = DateTime.UtcNow;
-        entry.IntegrityHash = IntegrityHashService.Compute(entry);
+        entry.IntegrityHash = IntegrityHashService.Compute(entry, integrityKeys.ActiveKey);
 
         db.ExpertiseEntries.Add(entry);
         db.ExpertiseAuditLogs.Add(BuildAuditRow(AuditAction.Created, entry, ctx, beforeHash: null, afterHash: entry.IntegrityHash));
@@ -228,7 +229,7 @@ internal class ExpertiseRepository(
         if (entry.Tenant == "shared" && !ctx.Scopes.Contains(AuthConstants.WriteApproveScope))
             return (WriteOutcome.InsufficientScope, null);
 
-        var beforeHash = entry.IntegrityHash ?? IntegrityHashService.Compute(entry);
+        var beforeHash = entry.IntegrityHash ?? IntegrityHashService.Compute(entry, integrityKeys.ActiveKey);
         var beforeVisibility = entry.Visibility;
 
         await applyUpdates(entry);
@@ -253,7 +254,7 @@ internal class ExpertiseRepository(
         }
 
         entry.UpdatedAt = DateTime.UtcNow;
-        entry.IntegrityHash = IntegrityHashService.Compute(entry);
+        entry.IntegrityHash = IntegrityHashService.Compute(entry, integrityKeys.ActiveKey);
 
         // ADR-003 state-regression rule: a write.draft-only caller editing an Approved
         // or Rejected entry resets it to Draft (forces re-review); write.approve callers
@@ -297,7 +298,7 @@ internal class ExpertiseRepository(
         if (entry.Tenant == "shared" && !ctx.Scopes.Contains(AuthConstants.WriteApproveScope))
             return WriteOutcome.InsufficientScope;
 
-        var hash = entry.IntegrityHash ?? IntegrityHashService.Compute(entry);
+        var hash = entry.IntegrityHash ?? IntegrityHashService.Compute(entry, integrityKeys.ActiveKey);
         entry.DeprecatedAt = DateTime.UtcNow;
         entry.UpdatedAt = DateTime.UtcNow;
 
@@ -361,7 +362,7 @@ internal class ExpertiseRepository(
         if (entry.ReviewState != ReviewState.Draft)
             return (WriteOutcome.InvalidState, null);
 
-        var hash = entry.IntegrityHash ?? IntegrityHashService.Compute(entry);
+        var hash = entry.IntegrityHash ?? IntegrityHashService.Compute(entry, integrityKeys.ActiveKey);
         entry.ReviewState = ReviewState.Approved;
         entry.Visibility = visibility;
         entry.ReviewedBy = reviewer;
@@ -401,7 +402,7 @@ internal class ExpertiseRepository(
         if (entry.ReviewState != ReviewState.Draft)
             return (WriteOutcome.InvalidState, null);
 
-        var hash = entry.IntegrityHash ?? IntegrityHashService.Compute(entry);
+        var hash = entry.IntegrityHash ?? IntegrityHashService.Compute(entry, integrityKeys.ActiveKey);
         entry.ReviewState = ReviewState.Rejected;
         entry.ReviewedBy = reviewer;
         entry.ReviewedAt = DateTime.UtcNow;

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -355,6 +355,14 @@ builder.Services.AddHealthChecks()
         name: "migrations",
         tags: readyTag);
 
+// ADR-020: integrity HMAC key. Loaded eagerly so a configured-but-unusable key
+// (missing file, bad base64, short key) aborts boot — fail-closed, the ADR-015
+// posture. An entirely unconfigured key is the sanctioned soft-require state
+// (legacy unkeyed SHA-256 + warning below + expertise_integrity_unkeyed gauge);
+// the hard-require flip is tracked in #490.
+var integrityKeyProvider = ExpertiseApi.Services.IntegrityKeyProvider.Load(builder.Configuration);
+builder.Services.AddSingleton<ExpertiseApi.Services.IIntegrityKeyProvider>(integrityKeyProvider);
+
 builder.Services.AddScoped<IExpertiseRepository, ExpertiseRepository>();
 builder.Services.AddScoped<ITenantContextAccessor, HttpTenantContextAccessor>();
 builder.Services.AddExpertiseAuth(builder.Configuration, builder.Environment);
@@ -499,6 +507,14 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
 });
 
 var app = builder.Build();
+
+if (integrityKeyProvider.ActiveKey is null)
+{
+    app.Logger.LogWarning(
+        "Integrity:HmacKey(File) is not configured — IntegrityHash values are legacy unkeyed "
+        + "SHA-256, forgeable by any database-level writer. Configure a key per ADR-020 and run "
+        + "`rehash --force` once. Hard-require flip tracked in #490.");
+}
 
 // Top-level Serilog flush guard — wraps ALL post-Build() paths (one-shot CLI
 // verbs AND the long-running web host) so the Console sink's async buffer is

--- a/src/ExpertiseApi/Services/IntegrityHashService.cs
+++ b/src/ExpertiseApi/Services/IntegrityHashService.cs
@@ -1,15 +1,55 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 using System.Text.Json;
 using ExpertiseApi.Models;
 
 namespace ExpertiseApi.Services;
 
+/// <summary>
+/// Canonical content hash for <see cref="ExpertiseEntry"/> rows and audit
+/// BeforeHash/AfterHash values. The canonical field set is exactly
+/// <c>{tenant, title, body, entryType, severity}</c> — a deliberate contract shared with
+/// <see cref="BackupRecordHash"/>'s doc comment; never widen it here.
+/// <para>
+/// ADR-020: when an <see cref="IntegrityKey"/> is supplied the value is
+/// <c>{keyId}:{lowercase-hex HMAC-SHA256}</c>, unforgeable by a database-only writer.
+/// With a <c>null</c> key the value is the legacy bare-hex unkeyed SHA-256 (soft-require
+/// phase; hard-require flip tracked in #490). The format prefix — colon present or
+/// absent — tells verification which computation a stored value used.
+/// </para>
+/// </summary>
 internal static class IntegrityHashService
 {
-    [SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase",
-        Justification = "Output is hex-encoded SHA-256 (0-9, a-f only). The Turkish-locale gotcha that motivates the rule cannot apply to ASCII hex characters.")]
     public static string Compute(
+        string tenant,
+        string title,
+        string body,
+        EntryType entryType,
+        Severity severity) =>
+        Compute(tenant, title, body, entryType, severity, key: null);
+
+    public static string Compute(ExpertiseEntry entry) =>
+        Compute(entry.Tenant, entry.Title, entry.Body, entry.EntryType, entry.Severity, key: null);
+
+    public static string Compute(ExpertiseEntry entry, IntegrityKey? key) =>
+        Compute(entry.Tenant, entry.Title, entry.Body, entry.EntryType, entry.Severity, key);
+
+    public static string Compute(
+        string tenant,
+        string title,
+        string body,
+        EntryType entryType,
+        Severity severity,
+        IntegrityKey? key)
+    {
+        var canonical = CanonicalBytes(tenant, title, body, entryType, severity);
+
+        if (key is null)
+            return Convert.ToHexStringLower(SHA256.HashData(canonical));
+
+        return $"{key.KeyId}:{Convert.ToHexStringLower(HMACSHA256.HashData(key.Key, canonical))}";
+    }
+
+    private static byte[] CanonicalBytes(
         string tenant,
         string title,
         string body,
@@ -29,10 +69,6 @@ internal static class IntegrityHashService
             writer.WriteEndObject();
         }
 
-        var hash = SHA256.HashData(stream.ToArray());
-        return Convert.ToHexString(hash).ToLowerInvariant();
+        return stream.ToArray();
     }
-
-    public static string Compute(ExpertiseEntry entry) =>
-        Compute(entry.Tenant, entry.Title, entry.Body, entry.EntryType, entry.Severity);
 }

--- a/src/ExpertiseApi/Services/IntegrityKeyProvider.cs
+++ b/src/ExpertiseApi/Services/IntegrityKeyProvider.cs
@@ -101,16 +101,7 @@ internal sealed class IntegrityKeyProvider : IIntegrityKeyProvider
         return new IntegrityKeyProvider(new IntegrityKey(keyId, key));
     }
 
-    private static bool IsValidKeyId(string keyId)
-    {
-        if (keyId.Length is < 1 or > 32)
-            return false;
-        foreach (var c in keyId)
-        {
-            if (!char.IsAsciiLetterOrDigit(c) && c is not ('.' or '_' or '-'))
-                return false;
-        }
-
-        return true;
-    }
+    private static bool IsValidKeyId(string keyId) =>
+        keyId.Length is >= 1 and <= 32
+        && keyId.All(static c => char.IsAsciiLetterOrDigit(c) || c is '.' or '_' or '-');
 }

--- a/src/ExpertiseApi/Services/IntegrityKeyProvider.cs
+++ b/src/ExpertiseApi/Services/IntegrityKeyProvider.cs
@@ -1,0 +1,116 @@
+using Prometheus;
+
+namespace ExpertiseApi.Services;
+
+/// <summary>
+/// Active HMAC key for <see cref="IntegrityHashService"/> (ADR-020). <c>KeyId</c> is the
+/// short identifier prefixed onto stored values (<c>{keyId}:{hex}</c>) so rotation can
+/// keep retired keys resolvable for verification; <c>Key</c> is the raw material
+/// (256-bit minimum, base64-decoded from config).
+/// </summary>
+internal sealed record IntegrityKey(string KeyId, byte[] Key);
+
+internal interface IIntegrityKeyProvider
+{
+    /// <summary>
+    /// The key used for all new IntegrityHash / audit BeforeHash/AfterHash computations,
+    /// or <c>null</c> when the instance runs unkeyed (legacy SHA-256; soft-require phase
+    /// per ADR-020, hard-require flip tracked in #490).
+    /// </summary>
+    IntegrityKey? ActiveKey { get; }
+}
+
+/// <summary>
+/// Loads the ADR-020 integrity HMAC key once at startup. Fail-closed when configured:
+/// a key that is present in config but unusable (missing file, invalid base64, too
+/// short, malformed key id) aborts boot — the ADR-015 posture — because silently
+/// falling back to the unkeyed hash would quietly write forgeable values. An entirely
+/// unconfigured key is the sanctioned soft-require state: legacy unkeyed hashing plus
+/// the <c>expertise_integrity_unkeyed</c> gauge and a startup warning.
+/// </summary>
+internal sealed class IntegrityKeyProvider : IIntegrityKeyProvider
+{
+    private static readonly Gauge UnkeyedGauge = Metrics.CreateGauge(
+        "expertise_integrity_unkeyed",
+        "1 when this instance computes legacy unkeyed integrity hashes (no Integrity:HmacKey configured), 0 when keyed (ADR-020).");
+
+    public IntegrityKey? ActiveKey { get; }
+
+    /// <summary>An always-unkeyed provider for tests and contexts with no configuration.</summary>
+    public static IntegrityKeyProvider Unkeyed { get; } = new(null);
+
+    private IntegrityKeyProvider(IntegrityKey? activeKey) => ActiveKey = activeKey;
+
+    public static IntegrityKeyProvider Load(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var inline = configuration["Integrity:HmacKey"];
+        var keyFile = configuration["Integrity:HmacKeyFile"];
+        var keyId = configuration["Integrity:ActiveKeyId"];
+        keyId = string.IsNullOrWhiteSpace(keyId) ? "k1" : keyId.Trim();
+
+        // Inline wins when both are set — the EXPERTISE_API_TOKEN / _FILE idiom (#464).
+        string material;
+        string source;
+        if (!string.IsNullOrWhiteSpace(inline))
+        {
+            material = inline.Trim();
+            source = "Integrity:HmacKey";
+        }
+        else if (!string.IsNullOrWhiteSpace(keyFile))
+        {
+            if (!File.Exists(keyFile))
+            {
+                throw new InvalidOperationException(
+                    $"Integrity:HmacKeyFile points to a missing file: {keyFile} (ADR-020 fail-closed).");
+            }
+
+            material = File.ReadAllText(keyFile).Trim();
+            source = $"Integrity:HmacKeyFile ({keyFile})";
+        }
+        else
+        {
+            UnkeyedGauge.Set(1);
+            return Unkeyed;
+        }
+
+        if (!IsValidKeyId(keyId))
+        {
+            throw new InvalidOperationException(
+                $"Integrity:ActiveKeyId '{keyId}' is invalid — 1-32 chars of [A-Za-z0-9._-], no ':' (it prefixes stored hash values).");
+        }
+
+        byte[] key;
+        try
+        {
+            key = Convert.FromBase64String(material);
+        }
+        catch (FormatException ex)
+        {
+            throw new InvalidOperationException($"{source} is not valid base64 (ADR-020 fail-closed).", ex);
+        }
+
+        if (key.Length < 32)
+        {
+            throw new InvalidOperationException(
+                $"{source} must decode to at least 32 bytes (256-bit); got {key.Length} (ADR-020 fail-closed).");
+        }
+
+        UnkeyedGauge.Set(0);
+        return new IntegrityKeyProvider(new IntegrityKey(keyId, key));
+    }
+
+    private static bool IsValidKeyId(string keyId)
+    {
+        if (keyId.Length is < 1 or > 32)
+            return false;
+        foreach (var c in keyId)
+        {
+            if (!char.IsAsciiLetterOrDigit(c) && c is not ('.' or '_' or '-'))
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/src/ExpertiseApi/appsettings.json
+++ b/src/ExpertiseApi/appsettings.json
@@ -81,6 +81,12 @@
   "Metrics": {
     "Enabled": true
   },
+  "Integrity": {
+    "_comment": "ADR-020 keyed IntegrityHash (#468). Supply a 256-bit base64 key via HmacKeyFile (path — recommended) or HmacKey (inline; wins if both set, mirroring EXPERTISE_API_TOKEN/_FILE). Configured-but-unusable key fails boot; unconfigured falls back to legacy unkeyed SHA-256 with a startup warning and the expertise_integrity_unkeyed gauge (soft-require until #490). After configuring or rotating the key, run `dotnet run -- rehash --force` once — otherwise verification reports a false mass mismatch. ActiveKeyId prefixes stored values ({keyId}:{hex}) so rotation keeps old values attributable.",
+    "HmacKey": "",
+    "HmacKeyFile": "",
+    "ActiveKeyId": "k1"
+  },
   "Sync": {
     "_comment": "ADR-013 aggregator up-sync. SPOKE role: set Enabled=true plus HubUrl/TokenEndpoint/ClientId (client_credentials against the shared IdP; supply Sync__ClientSecret via environment, never here). The spoke's hub credential must carry expertise.write.draft ONLY — the draft-only scope is the knowledge-supply-chain control. HUB role: leave Enabled=false and populate KnownInstances (authenticated client id -> origin instance id) so synced entries get server-side OriginInstanceId attribution. Startup guard fails boot when Enabled=true with missing/invalid connection fields.",
     "Enabled": false,

--- a/tests/ExpertiseApi.Tests/Evaluation/NeedleEvalTests.cs
+++ b/tests/ExpertiseApi.Tests/Evaluation/NeedleEvalTests.cs
@@ -81,7 +81,7 @@ public sealed class NeedleEvalTests(PostgresFixture postgres, ITestOutputHelper 
             .UseNpgsql(postgres.ConnectionString, o => o.UseVector())
             .Options;
         _db = new ExpertiseDbContext(options, new NoOpTenantContextAccessor());
-        _repo = new ExpertiseRepository(_db, new HttpContextAccessor(), NullLogger<ExpertiseRepository>.Instance);
+        _repo = new ExpertiseRepository(_db, new HttpContextAccessor(), NullLogger<ExpertiseRepository>.Instance, IntegrityKeyProvider.Unkeyed);
 
         await _db.ExpertiseEntries.Where(e => e.Tenant == EvalTenant).ExecuteDeleteAsync();
     }

--- a/tests/ExpertiseApi.Tests/Evaluation/RetrievalEvalTests.cs
+++ b/tests/ExpertiseApi.Tests/Evaluation/RetrievalEvalTests.cs
@@ -71,7 +71,7 @@ public sealed class RetrievalEvalTests(PostgresFixture postgres, ITestOutputHelp
             .UseNpgsql(postgres.ConnectionString, o => o.UseVector())
             .Options;
         _db = new ExpertiseDbContext(options, new NoOpTenantContextAccessor());
-        _repo = new ExpertiseRepository(_db, new HttpContextAccessor(), NullLogger<ExpertiseRepository>.Instance);
+        _repo = new ExpertiseRepository(_db, new HttpContextAccessor(), NullLogger<ExpertiseRepository>.Instance, IntegrityKeyProvider.Unkeyed);
 
         await _db.ExpertiseEntries.Where(e => e.Tenant == EvalTenant).ExecuteDeleteAsync();
     }

--- a/tests/ExpertiseApi.Tests/Integration/CliMaintenanceCommandTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/CliMaintenanceCommandTests.cs
@@ -7,6 +7,7 @@ using ExpertiseApi.Tests.Infrastructure;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -162,6 +163,52 @@ public class CliMaintenanceCommandTests : IAsyncLifetime
         after.Should().Equal(before, "rehash only touches IntegrityHash == null rows");
     }
 
+    [Fact]
+    public async Task Rehash_Force_RekeysEveryRow_IncludingPopulatedLegacyHashes()
+    {
+        // ADR-020: after configuring Integrity:HmacKey, `rehash --force` is the one-time
+        // rekey migration — it must rewrite rows whose IntegrityHash is already populated
+        // (legacy unkeyed), which the default null-only filter deliberately skips.
+        var ids = new List<Guid>();
+        for (var i = 0; i < 3; i++)
+        {
+            await using var db = NewContext();
+            var entry = TestHelpers.SeedEntry(domain: "rekey", title: $"f {i}", body: $"b {i}");
+            entry.IntegrityHash = IntegrityHashService.Compute(entry); // populated, legacy format
+            db.ExpertiseEntries.Add(entry);
+            await db.SaveChangesAsync();
+            ids.Add(entry.Id);
+        }
+
+        var keyed = IntegrityKeyProvider.Load(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Integrity:HmacKey"] = Convert.ToBase64String(Enumerable.Repeat((byte)0x42, 32).ToArray()),
+            })
+            .Build());
+
+        // Without --force, populated rows are untouched even when a key is configured.
+        await using (var app = BuildApp(keyed))
+            await RehashCommand.RunAsync(app, ["rehash"]);
+        (await SnapshotHashes(ids)).Should().OnlyContain(h => !h.Contains(':'),
+            "a non-forced run must never rewrite populated hashes");
+
+        // With --force, every row is rekeyed to the {keyId}:{hex} format.
+        await using (var app = BuildApp(keyed))
+            await RehashCommand.RunAsync(app, ["rehash", "--force", "--batch-size", "2"]);
+
+        await using var verify = NewContext();
+        foreach (var id in ids)
+        {
+            var entry = await verify.ExpertiseEntries.IgnoreQueryFilters().AsNoTracking()
+                .SingleAsync(x => x.Id == id);
+            entry.IntegrityHash.Should().Be(
+                IntegrityHashService.Compute(entry, keyed.ActiveKey),
+                "--force must recompute with the active key");
+            entry.IntegrityHash.Should().StartWith("k1:");
+        }
+    }
+
     // ---- Helpers ----------------------------------------------------------
 
     private async Task<List<string>> SnapshotHashes(IEnumerable<Guid> ids)
@@ -183,10 +230,11 @@ public class CliMaintenanceCommandTests : IAsyncLifetime
         return new ExpertiseDbContext(options, new NoOpTenantContextAccessor());
     }
 
-    private WebApplication BuildApp()
+    private WebApplication BuildApp(IIntegrityKeyProvider? integrityKeys = null)
     {
         var builder = WebApplication.CreateBuilder();
         builder.Logging.ClearProviders();
+        builder.Services.AddSingleton(integrityKeys ?? IntegrityKeyProvider.Unkeyed);
         builder.Services.AddSingleton<ITenantContextAccessor, NoOpTenantContextAccessor>();
         builder.Services.AddDbContext<ExpertiseDbContext>(o =>
             o.UseNpgsql(_container.GetConnectionString(), x => x.UseVector()));

--- a/tests/ExpertiseApi.Tests/Integration/SyncWorkerTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/SyncWorkerTests.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using ExpertiseApi.Auth;
 using ExpertiseApi.Data;
 using ExpertiseApi.Models;
+using ExpertiseApi.Services;
 using ExpertiseApi.Services.Sync;
 using ExpertiseApi.Tests.Infrastructure;
 using Microsoft.AspNetCore.Builder;
@@ -252,6 +253,7 @@ public class SyncWorkerTests : IAsyncLifetime
         services.AddLogging(l => l.ClearProviders());
         services.AddHttpContextAccessor();
         services.AddSingleton<ITenantContextAccessor, NoOpTenantContextAccessor>();
+        services.AddSingleton<IIntegrityKeyProvider>(IntegrityKeyProvider.Unkeyed);
         services.AddDbContext<ExpertiseDbContext>(o =>
             o.UseNpgsql(_container.GetConnectionString(), n => n.UseVector()));
         services.AddScoped<IExpertiseRepository, ExpertiseRepository>();

--- a/tests/ExpertiseApi.Tests/Unit/IntegrityHashServiceTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/IntegrityHashServiceTests.cs
@@ -110,6 +110,82 @@ public class IntegrityHashServiceTests
         IntegrityHashService.Compute(entry1).Should().Be(IntegrityHashService.Compute(entry2));
     }
 
+    // --- ADR-020 keyed (HMAC) path ------------------------------------------------
+
+    private static IntegrityKey TestKey(string keyId = "k1", byte fill = 0x42)
+    {
+        var key = new byte[32];
+        Array.Fill(key, fill);
+        return new IntegrityKey(keyId, key);
+    }
+
+    [Fact]
+    public void Compute_Keyed_HasKeyIdPrefixAndHexMac()
+    {
+        var value = IntegrityHashService.Compute(
+            "team-alpha", "Title", "Body", EntryType.Pattern, Severity.Info, TestKey());
+
+        value.Should().MatchRegex("^k1:[0-9a-f]{64}$");
+    }
+
+    [Fact]
+    public void Compute_Keyed_IsDeterministic()
+    {
+        var a = IntegrityHashService.Compute("t", "title", "body", EntryType.Pattern, Severity.Info, TestKey());
+        var b = IntegrityHashService.Compute("t", "title", "body", EntryType.Pattern, Severity.Info, TestKey());
+
+        a.Should().Be(b);
+    }
+
+    [Fact]
+    public void Compute_Keyed_DiffersFromUnkeyed()
+    {
+        var keyed = IntegrityHashService.Compute("t", "title", "body", EntryType.Pattern, Severity.Info, TestKey());
+        var unkeyed = IntegrityHashService.Compute("t", "title", "body", EntryType.Pattern, Severity.Info);
+
+        keyed.Should().NotBe(unkeyed);
+        keyed.Should().NotEndWith(unkeyed, "the MAC must not equal the plain hash even ignoring the prefix");
+    }
+
+    [Fact]
+    public void Compute_Keyed_DiffersByKeyMaterial()
+    {
+        var a = IntegrityHashService.Compute("t", "title", "body", EntryType.Pattern, Severity.Info, TestKey(fill: 0x01));
+        var b = IntegrityHashService.Compute("t", "title", "body", EntryType.Pattern, Severity.Info, TestKey(fill: 0x02));
+
+        a.Should().NotBe(b);
+    }
+
+    [Fact]
+    public void Compute_NullKey_MatchesLegacyOverload()
+    {
+        var explicitNull = IntegrityHashService.Compute(
+            "t", "title", "body", EntryType.Pattern, Severity.Info, key: null);
+        var legacy = IntegrityHashService.Compute("t", "title", "body", EntryType.Pattern, Severity.Info);
+
+        explicitNull.Should().Be(legacy);
+        legacy.Should().MatchRegex("^[0-9a-f]{64}$", "the legacy format is bare hex — no key-id prefix");
+    }
+
+    [Fact]
+    public void Compute_Keyed_EntryOverload_MatchesScalarOverload()
+    {
+        var entry = new ExpertiseEntry
+        {
+            Domain = "shared",
+            Tenant = "team-alpha",
+            Title = "Title",
+            Body = "Body",
+            EntryType = EntryType.Caveat,
+            Severity = Severity.Warning,
+            Source = "human",
+            AuthorPrincipal = "test"
+        };
+
+        IntegrityHashService.Compute(entry, TestKey()).Should().Be(
+            IntegrityHashService.Compute("team-alpha", "Title", "Body", EntryType.Caveat, Severity.Warning, TestKey()));
+    }
+
     [Fact]
     public void Compute_OverloadFromEntry_MatchesScalarOverload()
     {

--- a/tests/ExpertiseApi.Tests/Unit/IntegrityKeyProviderTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/IntegrityKeyProviderTests.cs
@@ -1,0 +1,128 @@
+using ExpertiseApi.Services;
+using Microsoft.Extensions.Configuration;
+
+namespace ExpertiseApi.Tests.Unit;
+
+/// <summary>
+/// ADR-020 key-loading contract: fail-closed when a key is configured but unusable,
+/// soft-require (null key) when nothing is configured, inline-wins-over-file per the
+/// EXPERTISE_API_TOKEN/_FILE idiom (#464).
+/// </summary>
+public class IntegrityKeyProviderTests : IDisposable
+{
+    private static readonly string ValidKeyBase64 =
+        Convert.ToBase64String(Enumerable.Repeat((byte)0x42, 32).ToArray());
+
+    private readonly string _workDir =
+        Directory.CreateTempSubdirectory("integrity-key-tests").FullName;
+
+    public void Dispose()
+    {
+        Directory.Delete(_workDir, recursive: true);
+        GC.SuppressFinalize(this);
+    }
+
+    private static IConfiguration Config(params (string Key, string Value)[] pairs) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(pairs.ToDictionary(p => p.Key, p => (string?)p.Value))
+            .Build();
+
+    [Fact]
+    public void Load_Unconfigured_ReturnsNullKey()
+    {
+        var provider = IntegrityKeyProvider.Load(Config());
+
+        provider.ActiveKey.Should().BeNull();
+    }
+
+    [Fact]
+    public void Load_InlineKey_ResolvesWithDefaultKeyId()
+    {
+        var provider = IntegrityKeyProvider.Load(Config(("Integrity:HmacKey", ValidKeyBase64)));
+
+        provider.ActiveKey.Should().NotBeNull();
+        provider.ActiveKey!.KeyId.Should().Be("k1");
+        provider.ActiveKey.Key.Should().HaveCount(32);
+    }
+
+    [Fact]
+    public void Load_KeyFile_ResolvesTrimmingWhitespace()
+    {
+        var path = Path.Combine(_workDir, "hmac.key");
+        File.WriteAllText(path, ValidKeyBase64 + "\n");
+
+        var provider = IntegrityKeyProvider.Load(Config(("Integrity:HmacKeyFile", path)));
+
+        provider.ActiveKey.Should().NotBeNull();
+        provider.ActiveKey!.Key.Should().Equal(Enumerable.Repeat((byte)0x42, 32));
+    }
+
+    [Fact]
+    public void Load_InlineWinsOverFile()
+    {
+        var path = Path.Combine(_workDir, "hmac-file.key");
+        File.WriteAllText(path, Convert.ToBase64String(Enumerable.Repeat((byte)0x01, 32).ToArray()));
+
+        var provider = IntegrityKeyProvider.Load(Config(
+            ("Integrity:HmacKey", ValidKeyBase64),
+            ("Integrity:HmacKeyFile", path)));
+
+        provider.ActiveKey!.Key.Should().Equal(Enumerable.Repeat((byte)0x42, 32));
+    }
+
+    [Fact]
+    public void Load_CustomActiveKeyId_IsApplied()
+    {
+        var provider = IntegrityKeyProvider.Load(Config(
+            ("Integrity:HmacKey", ValidKeyBase64),
+            ("Integrity:ActiveKeyId", "prod-2026a")));
+
+        provider.ActiveKey!.KeyId.Should().Be("prod-2026a");
+    }
+
+    [Fact]
+    public void Load_MissingKeyFile_FailsClosed()
+    {
+        var act = () => IntegrityKeyProvider.Load(Config(
+            ("Integrity:HmacKeyFile", Path.Combine(_workDir, "does-not-exist"))));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*missing file*");
+    }
+
+    [Fact]
+    public void Load_InvalidBase64_FailsClosed()
+    {
+        var act = () => IntegrityKeyProvider.Load(Config(("Integrity:HmacKey", "not-base64!!!")));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*not valid base64*");
+    }
+
+    [Fact]
+    public void Load_ShortKey_FailsClosed()
+    {
+        var shortKey = Convert.ToBase64String(new byte[16]);
+
+        var act = () => IntegrityKeyProvider.Load(Config(("Integrity:HmacKey", shortKey)));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*at least 32 bytes*");
+    }
+
+    [Theory]
+    [InlineData("has:colon")]
+    [InlineData("has space")]
+    [InlineData("way-too-long-key-identifier-value-over-32")]
+    public void Load_InvalidKeyId_FailsClosed(string keyId)
+    {
+        var act = () => IntegrityKeyProvider.Load(Config(
+            ("Integrity:HmacKey", ValidKeyBase64),
+            ("Integrity:ActiveKeyId", keyId)));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*ActiveKeyId*");
+    }
+
+    [Fact]
+    public void Unkeyed_SingletonHasNullKey()
+    {
+        IntegrityKeyProvider.Unkeyed.ActiveKey.Should().BeNull();
+    }
+}

--- a/tests/ExpertiseApi.Tests/Unit/IntegrityKeyProviderTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/IntegrityKeyProviderTests.cs
@@ -48,7 +48,7 @@ public class IntegrityKeyProviderTests : IDisposable
     [Fact]
     public void Load_KeyFile_ResolvesTrimmingWhitespace()
     {
-        var path = Path.Combine(_workDir, "hmac.key");
+        var path = Path.Join(_workDir, "hmac.key");
         File.WriteAllText(path, ValidKeyBase64 + "\n");
 
         var provider = IntegrityKeyProvider.Load(Config(("Integrity:HmacKeyFile", path)));
@@ -60,7 +60,7 @@ public class IntegrityKeyProviderTests : IDisposable
     [Fact]
     public void Load_InlineWinsOverFile()
     {
-        var path = Path.Combine(_workDir, "hmac-file.key");
+        var path = Path.Join(_workDir, "hmac-file.key");
         File.WriteAllText(path, Convert.ToBase64String(Enumerable.Repeat((byte)0x01, 32).ToArray()));
 
         var provider = IntegrityKeyProvider.Load(Config(
@@ -84,7 +84,7 @@ public class IntegrityKeyProviderTests : IDisposable
     public void Load_MissingKeyFile_FailsClosed()
     {
         var act = () => IntegrityKeyProvider.Load(Config(
-            ("Integrity:HmacKeyFile", Path.Combine(_workDir, "does-not-exist"))));
+            ("Integrity:HmacKeyFile", Path.Join(_workDir, "does-not-exist"))));
 
         act.Should().Throw<InvalidOperationException>().WithMessage("*missing file*");
     }

--- a/tests/ExpertiseApi.Tests/Unit/RepositoryQueryTranslationTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/RepositoryQueryTranslationTests.cs
@@ -3,6 +3,7 @@ using System.Security.Claims;
 using ExpertiseApi.Auth;
 using ExpertiseApi.Data;
 using ExpertiseApi.Models;
+using ExpertiseApi.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -45,7 +46,7 @@ public class RepositoryQueryTranslationTests
     }
 
     private static ExpertiseRepository NewRepository(ExpertiseDbContext db) =>
-        new(db, new HttpContextAccessor(), NullLogger<ExpertiseRepository>.Instance);
+        new(db, new HttpContextAccessor(), NullLogger<ExpertiseRepository>.Instance, IntegrityKeyProvider.Unkeyed);
 
     private static TenantContext Ctx() =>
         new("team-alpha", new ClaimsPrincipal(), Agent: null, new HashSet<string>());


### PR DESCRIPTION
## Summary

PR 1 of the #468 series (F3 from the #333 OWASP-AI review), implementing the hash-strength half of **ADR-020** (included in this PR). `IntegrityHash` — and therefore the audit log's `BeforeHash`/`AfterHash` — was an unsalted SHA-256 stored in the same mutable row: decorative tamper-evidence, since any database-level writer could recompute a matching value. It is now **HMAC-SHA256 under a server-held key**, stored as `{keyId}:{hex}` so rotation keeps old values attributable. A DB-only writer (SQLi, stolen DB credential, rogue DBA in split-credential deployments) can no longer forge it. The 5-field canonical set is untouched (dedup never hash-compares — verified in `DeduplicationService`), and the response field stays a plain string: **zero API/OpenAPI change**.

## Changes

- **`IntegrityKeyProvider`** (new): loads `Integrity:HmacKey` (inline base64) / `Integrity:HmacKeyFile` (path) — inline wins, the #464 idiom — with `ActiveKeyId` (default `k1`). Loaded eagerly in `Program.cs`: a configured-but-unusable key (missing file, bad base64, <32 bytes, malformed key id) **aborts boot** (ADR-015 posture). Unconfigured → legacy unkeyed SHA-256 + startup warning + `expertise_integrity_unkeyed` gauge (soft-require per the ADR-010 phasing precedent; hard-require flip tracked in **#490**).
- **`IntegrityHashService`**: keyed overloads over the identical canonical JSON; static `HMACSHA256.HashData`/`SHA256.HashData`; `Convert.ToHexStringLower` (drops the CA1308 suppression).
- **`ExpertiseRepository`**: injects the key provider; all 6 hash call sites keyed.
- **`rehash --force`**: recomputes **every** row (not just nulls) — the one-time rekey migration after configuring or rotating the key. Ships in this PR deliberately: without it the first verification run would report a false 100% mismatch.
- **Tests**: keyed-format/determinism/key-separation unit tests; key-provider fail-closed contract (11 cases); `rehash --force` integration test against real Postgres (populated legacy rows rekeyed to `k1:` format, non-forced runs never touch populated rows).

Verification itself (`verify` CLI, `AuditCheckpoints` Merkle chain) is **PR 2**; deployment surfaces (install.sh keygen, Helm/Compose wiring, timers, runbook) are **PR 3** — sequencing per ADR-020.

## Doc impact

| Surface | Classification | Notes |
|---|---|---|
| `adrs/020-integrity-verification.md` | in-scope | full design: threat model, HMAC + checkpoint-chain decisions, rejected options |
| `CLAUDE.md` | in-scope | data-model row + rehash `--force` |
| `appsettings.json` `Integrity` section | in-scope | `_comment` convention |
| README / DESIGN.md / Helm / install.sh | deferred to PR 3 | per ADR-020 phasing |
| Hard-require flip | tracked | #490 (filed as plan step 1) |

## Verification

- Design validated by a 3-agent fan-out (security-review-expert, expertise-api-owner, dotnet-expert) — claims table and disagreement resolutions recorded in the session; key catches: dedup does not hash-compare (enables in-place primitive swap), Data Protection API rejected as the key mechanism, checkpoint chain over strict per-row chain (write-path serialization risk under PgBouncer/multi-replica).
- Build 0 warnings (`AnalysisMode=All`); `dotnet format analyzers --verify-no-changes` clean; linter agent PASS.
- Full suite 466 passed / 0 failed × 3 consecutive runs (Testcontainers via podman).
- No OpenAPI diff expected — `IntegrityHash` remains `string?`.

Refs #468 · ADR-020 · follow-up #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)