### PR TITLE
feat(integrity): audit checkpoint chain and verify command (ADR-020 PR 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,13 @@ dotnet run --project src/ExpertiseApi -- reembed [--batch-size 50]
 # rotating Integrity:HmacKey (ADR-020) — run it once before trusting verification.
 dotnet run --project src/ExpertiseApi -- rehash [--batch-size 50] [--force]
 
+# ADR-020 integrity verification sweep: recompute every entry MAC (format prefix
+# decides keyed vs legacy; unknown key id = mismatch), re-verify every sealed audit
+# checkpoint (Merkle root + MAC + chain link), then seal a new checkpoint through the
+# latest audit row older than the grace window. Exit 0 clean / 1 mismatch (ALERT) /
+# 2 precondition. Schedule via OS timer/CronJob; wrapped as `expertise-apictl verify`.
+dotnet run --project src/ExpertiseApi -- verify [--batch-size 500] [--grace-seconds 300] [--no-seal]
+
 # Export all entries (every tenant + review state) + audit log as NDJSON with an
 # RFC 6962 Merkle manifest (ADR-012). Plain files only — signing/encryption is
 # scripts/expertise-apictl's job (backup-init | backup | restore subcommands).
@@ -218,6 +225,8 @@ calls are no-ops outside their host environment, so Docker / Helm /
 `dotnet run` paths remain identical.
 
 Daily-use control: `scripts/expertise-apictl {start|stop|restart|status|logs|health}`.
+
+Integrity verification (ADR-020): `expertise-apictl verify [--batch-size N] [--grace-seconds N] [--no-seal]` runs the sweep against the database (no service restart needed) and preserves the verb's exit codes — 0 clean, 1 integrity mismatch (alert on this), 2 precondition failure. Schedule it from a systemd timer / launchd / cron (templates land in ADR-020 PR 3).
 
 Human draft review (ADR-018/ADR-019): `expertise-apictl drafts [--json]` lists
 the pending queue; `expertise-apictl review` is the interactive
@@ -488,6 +497,8 @@ Indexes added: standalone B-tree on `Tenant`; composite B-tree on `(Tenant, Revi
 A separate **`ExpertiseAuditLog`** table records every state-changing operation: `{Id, Timestamp, Action, EntryId, Tenant, Principal, Agent?, BeforeHash, AfterHash, IpAddress, ActorClass, AuthMethod?, ActorClassHeader?}` (the last three added by ADR-008). FK to `ExpertiseEntries.Id` with `ON DELETE RESTRICT` (audit must survive entry deletion). Reads are not audited. Indexes on `(EntryId, Timestamp)` and `(Principal, Timestamp)`.
 
 A **`SyncStates`** singleton-row table (EmbeddingMetadata pattern) holds the spoke-side up-sync cursor: `{Id, LastSyncedUpdatedAt, LastSyncedId, LastSuccessAt}` (ADR-013).
+
+ADR-020 PR 2 adds the audit checkpoint chain: `ExpertiseAuditLog.Seq` (`bigint GENERATED ALWAYS AS IDENTITY`, unique — the stable ordinal checkpoint ranges are defined over; never set by app code, re-sequenced on restore so the chain restarts); an **`AuditCheckpoints`** table `{Id, SeqFrom, SeqTo, RowCount, MerkleRoot, PrevCheckpointMac?, CheckpointMac, CreatedAt}` (RFC 6962 root over the range's `BackupRecordHash.ComputeAudit` leaves, MAC'd + chained so a DB-only writer can neither rewrite nor re-seal a range; sole writer is the `verify` sweep — zero write-path contention); and an **`IntegrityVerificationStates`** singleton the API re-exposes as gauges (`expertise_integrity_checkpoint_age_seconds`, `expertise_integrity_last_verify_age_seconds`, `expertise_integrity_last_verify_mismatches` — a short-lived CLI's own counters are never scraped). `backup` exports the chain as `checkpoints.jsonl` + manifest root (off-host anchor); restore never imports it. After key rotation, move the old id→base64 into `Integrity:RetiredKeys` so `verify` keeps old values resolvable.
 
 The `ExpertiseDbContext` exposes these as `DbSet<>`. **`IExpertiseRepository` is the only sanctioned consumer of `ExpertiseDbContext` for entry data** — the architectural test in `tests/ExpertiseApi.Tests/Architecture/` enforces this for everything outside `Data/` and `Cli/`. CLI commands (`reembed`, `rehash`) are intentional exceptions because they need cursor-based paging the repository interface does not expose.
 

--- a/docs/operations/backup-restore-runbook.md
+++ b/docs/operations/backup-restore-runbook.md
@@ -149,6 +149,8 @@ scripts/expertise-apictl backup [--output DIR] [--instance-id ID]
 
 Preflight (tools, keys, config — every failure points at `backup-init`) → `ExpertiseApi backup` verb (NDJSON export under one RepeatableRead snapshot) → `tar -czf` → `age -e` → payload SHA injected into the manifest → `ssh-keygen -Y sign` (offline; `allowed_signers` is the trust root — ADR-012 Amendment 1) → single `expertise-backup-<instance>-<ts>.tar`, chmod 600. Plaintext intermediates live only in a `mktemp` dir removed on exit.
 
+The payload carries `entries.jsonl`, `audit.jsonl`, and — since ADR-020 PR 2 — `checkpoints.jsonl`, the audit checkpoint chain (`manifest.checkpointsMerkleRoot` covers it). The signed artifact is the chain's **off-host anchor**: a host-level attacker who rewrites the local chain cannot also rewrite a backup that has already left the host.
+
 ### Restore
 
 ```bash
@@ -156,6 +158,8 @@ scripts/expertise-apictl restore ARTIFACT.tar [--force-draft] [--i-accept-unsign
 ```
 
 Member allowlist on the outer tar → `ssh-keygen -Y verify` (fail-closed; `--i-accept-unsigned-backup` is the dev-only escape hatch) → payload SHA vs manifest → `age -d` → `ExpertiseApi restore` verb, which enforces: pending-migrations empty, empty target (replace mode), per-record hash verification (mismatch → imported as Draft + `RestoreQuarantined` audit row), Merkle roots matching the signed manifest (mismatch → abort, nothing imported), and embedding-model compatibility (mismatch → abort, run `reembed`). `--force-draft` re-gates every entry as Draft — required posture for seeding from someone else's backup.
+
+Restore deliberately does **not** import `checkpoints.jsonl`: restored audit rows get fresh `Seq` values (identity column), so old checkpoint ranges cannot apply. The chain restarts at the first post-restore `verify`. After restoring a backup taken under a different (or no) integrity key, run `rehash --force` before trusting `verify` output (ADR-020 migration notes).
 
 ### Key discipline
 

--- a/scripts/expertise-apictl
+++ b/scripts/expertise-apictl
@@ -11,6 +11,7 @@
 #   expertise-apictl logs [-f] [-n LINES]
 #   expertise-apictl health
 #   expertise-apictl reembed [--batch-size N]
+#   expertise-apictl verify [--batch-size N] [--grace-seconds N] [--no-seal]
 #   expertise-apictl backup-init [--install-deps]
 #   expertise-apictl backup [--output DIR] [--instance-id ID]
 #   expertise-apictl restore ARTIFACT [--force-draft] [--i-accept-unsigned-backup]
@@ -31,6 +32,11 @@
 # EXPERTISE_API_TOKEN or EXPERTISE_API_TOKEN_FILE (keep it distinct from any
 # agent write.draft token). Base URL comes from EXPERTISE_API_URL.
 #
+# verify runs the ADR-020 integrity sweep (entry MACs + audit checkpoint
+# chain) and seals a new checkpoint. Exit codes: 0 clean, 1 integrity
+# mismatch (ALERT), 2 precondition failure — schedule it from a systemd
+# timer / launchd / cron and alert on non-zero.
+#
 
 set -euo pipefail
 
@@ -43,7 +49,7 @@ READY_TIMEOUT="${EXPERTISE_API_READY_TIMEOUT:-30}"
 log() { printf '[expertise-apictl] %s\n' "$1"; }
 err() { printf '[expertise-apictl] ERROR: %s\n' "$1" >&2; exit 1; }
 
-usage() { sed -n '2,33p' "$0" | sed 's/^# \{0,1\}//'; }
+usage() { sed -n '2,38p' "$0" | sed 's/^# \{0,1\}//'; }
 
 detect_os() {
   case "$(uname -s)" in
@@ -85,7 +91,7 @@ _detect_install_scope() {
 # and drafts/review talk plain HTTP — never to launchd, so they work fine
 # against a --system install.
 case "${1:-}" in
-  backup-init|backup|restore|reembed|drafts|review) _lifecycle_cmd=0 ;;
+  backup-init|backup|restore|reembed|verify|drafts|review) _lifecycle_cmd=0 ;;
   *)                          _lifecycle_cmd=1 ;;
 esac
 
@@ -929,9 +935,10 @@ cmd_backup() {
     || err "export verb failed — nothing was signed or written to ${out_dir}"
 
   log "compressing + encrypting payload"
-  tar -czf "${workdir}/payload.tar.gz" -C "${workdir}/payload" entries.jsonl audit.jsonl
+  tar -czf "${workdir}/payload.tar.gz" -C "${workdir}/payload" entries.jsonl audit.jsonl checkpoints.jsonl
   age -e -R "${AGE_RECIPIENTS_FILE}" -o "${workdir}/payload.tar.gz.age" "${workdir}/payload.tar.gz"
-  rm -f "${workdir}/payload.tar.gz" "${workdir}/payload/entries.jsonl" "${workdir}/payload/audit.jsonl"
+  rm -f "${workdir}/payload.tar.gz" "${workdir}/payload/entries.jsonl" "${workdir}/payload/audit.jsonl" \
+        "${workdir}/payload/checkpoints.jsonl"
 
   # Bind the encrypted payload to the manifest BEFORE signing, so the
   # signature covers the payload hash (ADR-012 manifest schema).
@@ -957,6 +964,21 @@ cmd_reembed() {
   # completes, pre-existing entries are invisible to semantic/hybrid search.
   _run_api_verb reembed "$@" || err "reembed verb failed — see log output above"
   log "reembed: OK"
+}
+
+cmd_verify() {
+  # Pass-through to the ExpertiseApi verify verb (ADR-020): recompute every
+  # entry MAC, re-verify the audit checkpoint chain, seal a new checkpoint.
+  # Exit codes are preserved (not collapsed to err's exit 1) so a scheduled
+  # runner can distinguish 1=integrity mismatch (ALERT) from 2=precondition.
+  local rc=0
+  _run_api_verb verify "$@" || rc=$?
+  case "${rc}" in
+    0) log "verify: OK (clean)" ;;
+    1) printf '[expertise-apictl] ERROR: verify: INTEGRITY MISMATCH detected — see log output above\n' >&2 ;;
+    *) printf '[expertise-apictl] ERROR: verify: precondition failure (rc=%s) — see log output above\n' "${rc}" >&2 ;;
+  esac
+  return "${rc}"
 }
 
 cmd_restore() {
@@ -1030,6 +1052,7 @@ case "${1:-}" in
   backup)     shift; cmd_backup "$@" ;;
   restore)    shift; cmd_restore "$@" ;;
   reembed)    shift; cmd_reembed "$@" ;;
+  verify)     shift; cmd_verify "$@" ;;
   drafts)     shift; cmd_drafts "$@" ;;
   review)     shift; cmd_review "$@" ;;
   ''|-h|--help) usage ;;

--- a/src/ExpertiseApi/Cli/BackupCommand.cs
+++ b/src/ExpertiseApi/Cli/BackupCommand.cs
@@ -11,8 +11,9 @@ namespace ExpertiseApi.Cli;
 /// <summary>
 /// One-shot CLI verb that exports every expertise entry (all tenants, all review
 /// states) and the full audit log as NDJSON plus a manifest carrying RFC 6962
-/// Merkle roots (ADR-012). Emits three plain files into <c>--output</c>:
-/// <c>entries.jsonl</c>, <c>audit.jsonl</c>, <c>manifest.json</c>. Compression,
+/// Merkle roots (ADR-012). Emits four plain files into <c>--output</c>:
+/// <c>entries.jsonl</c>, <c>audit.jsonl</c>, <c>checkpoints.jsonl</c> (ADR-020 audit
+/// checkpoint chain — the off-host anchor), <c>manifest.json</c>. Compression,
 /// age encryption, and cosign signing are the orchestration wrapper's job
 /// (<c>scripts/expertise-apictl backup</c>) — the binary alone produces a valid
 /// unsigned payload for dev loops.
@@ -44,9 +45,10 @@ internal static class BackupCommand
             Directory.CreateDirectory(outputDir);
             var entriesPath = Path.Join(outputDir, "entries.jsonl");
             var auditPath = Path.Join(outputDir, "audit.jsonl");
+            var checkpointsPath = Path.Join(outputDir, "checkpoints.jsonl");
             var manifestPath = Path.Join(outputDir, "manifest.json");
 
-            foreach (var path in new[] { entriesPath, auditPath, manifestPath })
+            foreach (var path in new[] { entriesPath, auditPath, checkpointsPath, manifestPath })
             {
                 if (File.Exists(path))
                 {
@@ -157,6 +159,7 @@ internal static class BackupCommand
                             ActorClass = row.ActorClass.ToString(),
                             AuthMethod = row.AuthMethod,
                             ActorClassHeader = row.ActorClassHeader,
+                            Seq = row.Seq,
                             RecordHash = "",
                         };
                         record = record with { RecordHash = BackupRecordHash.ComputeAudit(record) };
@@ -170,6 +173,50 @@ internal static class BackupCommand
                 }
             }
 
+            // ADR-020: checkpoint chain export — the off-host anchor of the chain head.
+            // Restore never imports these (restored audit rows re-sequence; the chain
+            // restarts), but a signed backup that has left the host pins what the chain
+            // looked like at export time against a later local rewrite.
+            var checkpointHashes = new List<string>();
+            await using (var writer = new StreamWriter(File.Create(checkpointsPath), new UTF8Encoding(false)))
+            {
+                long lastCheckpointId = 0;
+                while (true)
+                {
+                    var checkpoints = await db.AuditCheckpoints
+                        .Where(c => c.Id > lastCheckpointId)
+                        .OrderBy(c => c.Id)
+                        .Take(batchSize)
+                        .AsNoTracking()
+                        .ToListAsync();
+                    if (checkpoints.Count == 0)
+                        break;
+
+                    foreach (var checkpoint in checkpoints)
+                    {
+                        var record = new BackupCheckpointRecord
+                        {
+                            Id = checkpoint.Id,
+                            SeqFrom = checkpoint.SeqFrom,
+                            SeqTo = checkpoint.SeqTo,
+                            RowCount = checkpoint.RowCount,
+                            MerkleRoot = checkpoint.MerkleRoot,
+                            PrevCheckpointMac = checkpoint.PrevCheckpointMac,
+                            CheckpointMac = checkpoint.CheckpointMac,
+                            CreatedAt = checkpoint.CreatedAt,
+                            RecordHash = "",
+                        };
+                        record = record with { RecordHash = BackupRecordHash.ComputeCheckpoint(record) };
+
+                        checkpointHashes.Add(record.RecordHash);
+                        await writer.WriteLineAsync(
+                            JsonSerializer.Serialize(record, BackupJsonContext.Default.BackupCheckpointRecord));
+                    }
+
+                    lastCheckpointId = checkpoints[^1].Id;
+                }
+            }
+
             var manifest = new BackupManifest
             {
                 SchemaVersion = 1,
@@ -179,6 +226,8 @@ internal static class BackupCommand
                 AuditCount = auditHashes.Count,
                 EntriesMerkleRoot = MerkleTree.ComputeRoot(entryHashes),
                 AuditMerkleRoot = MerkleTree.ComputeRoot(auditHashes),
+                CheckpointCount = checkpointHashes.Count,
+                CheckpointsMerkleRoot = MerkleTree.ComputeRoot(checkpointHashes),
                 DbSchemaVersion = dbSchemaVersion,
                 EmbeddingModel = embeddingMetadata is null
                     ? null
@@ -192,8 +241,8 @@ internal static class BackupCommand
                 new UTF8Encoding(false));
 
             logger.LogInformation(
-                "Backup: complete — {EntryCount} entries, {AuditCount} audit rows, schema {Schema}, output {Output}",
-                manifest.EntryCount, manifest.AuditCount, dbSchemaVersion ?? "(none)", outputDir);
+                "Backup: complete — {EntryCount} entries, {AuditCount} audit rows, {CheckpointCount} checkpoints, schema {Schema}, output {Output}",
+                manifest.EntryCount, manifest.AuditCount, manifest.CheckpointCount, dbSchemaVersion ?? "(none)", outputDir);
             return 0;
         }
         // Same narrowed-catch posture as MigrateCommand (process-fatal exceptions and

--- a/src/ExpertiseApi/Cli/BackupModels.cs
+++ b/src/ExpertiseApi/Cli/BackupModels.cs
@@ -63,6 +63,37 @@ internal sealed record BackupAuditRecord
     public string? AuthMethod { get; init; }
     public string? ActorClassHeader { get; init; }
 
+    /// <summary>
+    /// ADR-020 checkpoint ordinal, exported so a checkpoint's <c>[SeqFrom, SeqTo]</c>
+    /// range can be re-verified from the backup alone. Deliberately EXCLUDED from
+    /// <see cref="RecordHash"/>: it is a server-generated ordinal (like <c>xmin</c>),
+    /// regenerated on restore — and including it would change every audit RecordHash,
+    /// breaking verification of pre-PR2 backups. Null in pre-PR2 artifacts.
+    /// </summary>
+    public long? Seq { get; init; }
+
+    /// <inheritdoc cref="BackupEntryRecord.RecordHash"/>
+    public required string RecordHash { get; init; }
+}
+
+/// <summary>
+/// NDJSON line shape for one <see cref="Models.AuditCheckpoint"/> row (ADR-020).
+/// Exported as the off-host anchor of the checkpoint chain head: a local rewrite of
+/// the chain cannot also rewrite a signed backup that has left the host. Restore does
+/// NOT import checkpoints — restored audit rows re-sequence (identity column), so the
+/// chain restarts from the first post-restore <c>verify</c>.
+/// </summary>
+internal sealed record BackupCheckpointRecord
+{
+    public required long Id { get; init; }
+    public required long SeqFrom { get; init; }
+    public required long SeqTo { get; init; }
+    public required int RowCount { get; init; }
+    public required string MerkleRoot { get; init; }
+    public string? PrevCheckpointMac { get; init; }
+    public required string CheckpointMac { get; init; }
+    public required DateTime CreatedAt { get; init; }
+
     /// <inheritdoc cref="BackupEntryRecord.RecordHash"/>
     public required string RecordHash { get; init; }
 }
@@ -87,6 +118,13 @@ internal sealed record BackupManifest
     public required int AuditCount { get; init; }
     public required string EntriesMerkleRoot { get; init; }
     public required string AuditMerkleRoot { get; init; }
+
+    // ADR-020 checkpoint export. Nullable additive fields — SchemaVersion stays 1 so
+    // pre-PR2 binaries restore new artifacts (unknown fields ignored) and new binaries
+    // restore pre-PR2 artifacts (fields absent → null).
+    public int? CheckpointCount { get; init; }
+    public string? CheckpointsMerkleRoot { get; init; }
+
     public string? DbSchemaVersion { get; init; }
     public BackupEmbeddingModel? EmbeddingModel { get; init; }
     public string? PayloadSha256 { get; init; }
@@ -102,5 +140,6 @@ internal sealed record BackupManifest
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
 [JsonSerializable(typeof(BackupEntryRecord))]
 [JsonSerializable(typeof(BackupAuditRecord))]
+[JsonSerializable(typeof(BackupCheckpointRecord))]
 [JsonSerializable(typeof(BackupManifest))]
 internal sealed partial class BackupJsonContext : JsonSerializerContext;

--- a/src/ExpertiseApi/Cli/VerifyCommand.cs
+++ b/src/ExpertiseApi/Cli/VerifyCommand.cs
@@ -1,0 +1,74 @@
+using System.Data.Common;
+using ExpertiseApi.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace ExpertiseApi.Cli;
+
+/// <summary>
+/// One-shot CLI verb running the ADR-020 integrity verification sweep: recompute every
+/// entry MAC, re-verify every sealed audit checkpoint, seal a new checkpoint through
+/// the latest grace-aged audit row. Scheduling is an OS concern (systemd timer /
+/// launchd on A2, CronJob on k8s) — same posture as <c>backup</c> and <c>reembed</c>.
+/// Wrapped by <c>scripts/expertise-apictl verify</c>.
+/// </summary>
+internal static class VerifyCommand
+{
+    public static bool IsVerifyRequested(string[] args) =>
+        args.Length > 0 && args[0].Equals("verify", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Runs the verification sweep.</summary>
+    /// <returns>0 clean; 1 on any integrity mismatch; 2 on precondition failure (bad arguments or database error).</returns>
+    public static async Task<int> RunAsync(WebApplication app, string[] args)
+    {
+        using var scope = app.Services.CreateScope();
+        var logger = scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Verify");
+
+        var batchSize = GetIntOption(args, "--batch-size", 500);
+        var graceSeconds = GetIntOption(args, "--grace-seconds",
+            (int)IntegrityVerificationService.DefaultGraceWindow.TotalSeconds);
+        var seal = !Array.Exists(args, a => a.Equals("--no-seal", StringComparison.OrdinalIgnoreCase));
+
+        if (batchSize <= 0 || graceSeconds < 0)
+        {
+            logger.LogCritical("Verify: --batch-size must be positive and --grace-seconds non-negative.");
+            return 2;
+        }
+
+        try
+        {
+            var service = scope.ServiceProvider.GetRequiredService<IntegrityVerificationService>();
+            var result = await service.RunAsync(batchSize, TimeSpan.FromSeconds(graceSeconds), seal);
+
+            logger.LogInformation(
+                "Verify: {Entries} entries checked ({Legacy} legacy-format, {Unhashed} unhashed), " +
+                "{Checkpoints} checkpoints verified, sealed={Sealed} (through seq {SealedSeq}), mismatches={Mismatches}",
+                result.EntriesChecked, result.LegacyCount, result.UnhashedCount,
+                result.CheckpointsChecked, result.CheckpointSealed,
+                result.SealedThroughSeq?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "-",
+                result.TotalMismatches);
+
+            if (result.Clean)
+                return 0;
+
+            logger.LogCritical(
+                "Verify: FAILED — {EntryMac} entry MAC mismatch(es), {UnknownKey} unknown key id(s), {Checkpoint} checkpoint mismatch(es). See preceding log entries for row-level detail.",
+                result.EntryMacMismatches, result.UnknownKeyIds, result.CheckpointMismatches);
+            return 1;
+        }
+        // Same narrowed-catch posture as BackupCommand (process-fatal exceptions and
+        // OperationCanceledException propagate).
+        catch (Exception ex) when (ex is DbException or DbUpdateException or InvalidOperationException)
+        {
+            logger.LogCritical(ex, "Verify: precondition failure (full exception detail follows).");
+            return 2;
+        }
+    }
+
+    private static int GetIntOption(string[] args, string name, int fallback)
+    {
+        var idx = Array.IndexOf(args, name);
+        if (idx >= 0 && idx + 1 < args.Length && int.TryParse(args[idx + 1], out var value))
+            return value;
+        return fallback;
+    }
+}

--- a/src/ExpertiseApi/Data/ExpertiseDbContext.cs
+++ b/src/ExpertiseApi/Data/ExpertiseDbContext.cs
@@ -12,6 +12,8 @@ internal class ExpertiseDbContext(
     public DbSet<EmbeddingMetadata> EmbeddingMetadata => Set<EmbeddingMetadata>();
     public DbSet<ExpertiseAuditLog> ExpertiseAuditLogs => Set<ExpertiseAuditLog>();
     public DbSet<SyncState> SyncStates => Set<SyncState>();
+    public DbSet<AuditCheckpoint> AuditCheckpoints => Set<AuditCheckpoint>();
+    public DbSet<IntegrityVerificationState> IntegrityVerificationStates => Set<IntegrityVerificationState>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -146,6 +148,33 @@ internal class ExpertiseDbContext(
             // Supports the /audit?actor_class= filter introduced with C6. Composite with
             // Timestamp keeps the index aligned with the (Timestamp DESC, Id) sort order.
             entity.HasIndex(e => new { e.ActorClass, e.Timestamp });
+
+            // ADR-020 checkpoint ordinal. GENERATED ALWAYS AS IDENTITY: Postgres
+            // backfills existing rows on ADD COLUMN, rejects application-supplied
+            // values (restore re-sequences; the checkpoint chain restarts), and gives
+            // checkpoint ranges a stable ordering that neither the uuid PK nor the
+            // client-set Timestamp provides.
+            entity.Property(e => e.Seq).UseIdentityAlwaysColumn();
+            entity.HasIndex(e => e.Seq).IsUnique();
+        });
+
+        // ADR-020 audit checkpoint chain. Sole writer is IntegrityVerificationService
+        // (the verify CLI); the request write path never touches this table.
+        modelBuilder.Entity<AuditCheckpoint>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).UseIdentityAlwaysColumn();
+            entity.Property(e => e.MerkleRoot).IsRequired();
+            entity.Property(e => e.CheckpointMac).IsRequired();
+            entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+        });
+
+        // ADR-020 last-verify singleton (SyncState pattern: get-or-create at the call
+        // site, sole writer is the verification sweep).
+        modelBuilder.Entity<IntegrityVerificationState>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.LastResult).IsRequired();
         });
     }
 }

--- a/src/ExpertiseApi/Data/IntegrityVerificationService.cs
+++ b/src/ExpertiseApi/Data/IntegrityVerificationService.cs
@@ -276,7 +276,13 @@ internal sealed class IntegrityVerificationService(
 
         var (root, rowCount) = await ComputeRangeRootAsync(sealedThrough + 1, boundary.Value, batchSize, ct);
 
-        var createdAt = DateTime.UtcNow;
+        // The MAC binds CreatedAt, and verification recomputes it from the DB
+        // round-trip — Postgres timestamptz stores MICROSECOND precision, so the
+        // 100ns residue DateTime.UtcNow carries on Linux would be truncated on
+        // storage and every re-verify would report a false checkpoint_mac mismatch
+        // (macOS ticks are microsecond-aligned, which hides the bug locally).
+        var nowTicks = DateTime.UtcNow.Ticks;
+        var createdAt = new DateTime(nowTicks - (nowTicks % (TimeSpan.TicksPerMillisecond / 1000)), DateTimeKind.Utc);
         var checkpoint = new AuditCheckpoint
         {
             SeqFrom = sealedThrough + 1,

--- a/src/ExpertiseApi/Data/IntegrityVerificationService.cs
+++ b/src/ExpertiseApi/Data/IntegrityVerificationService.cs
@@ -1,0 +1,384 @@
+using System.Security.Cryptography;
+using System.Text;
+using ExpertiseApi.Cli;
+using ExpertiseApi.Models;
+using ExpertiseApi.Services;
+using Microsoft.EntityFrameworkCore;
+using Prometheus;
+
+namespace ExpertiseApi.Data;
+
+/// <summary>Aggregate outcome of one verification run (ADR-020).</summary>
+internal sealed record IntegrityVerificationResult
+{
+    public int EntriesChecked { get; init; }
+    public int EntryMacMismatches { get; init; }
+    public int UnknownKeyIds { get; init; }
+    public int LegacyCount { get; init; }
+    public int UnhashedCount { get; init; }
+    public int CheckpointsChecked { get; init; }
+    public int CheckpointMismatches { get; init; }
+    public bool CheckpointSealed { get; init; }
+    public long? SealedThroughSeq { get; init; }
+
+    public int TotalMismatches => EntryMacMismatches + UnknownKeyIds + CheckpointMismatches;
+    public bool Clean => TotalMismatches == 0;
+}
+
+/// <summary>
+/// The ADR-020 verification sweep (decision 3A): recomputes every entry's
+/// <c>IntegrityHash</c> per its format prefix, re-verifies every sealed audit
+/// checkpoint (Merkle root, MAC, chain link), then seals a new checkpoint through the
+/// latest grace-aged audit row. Invoked by the <c>verify</c> CLI verb; lives in
+/// <c>Data/</c> because it needs raw <see cref="ExpertiseDbContext"/> access
+/// (cross-tenant, cursor-paged sweeps the repository interface deliberately does not
+/// expose — same rationale as the CLI commands). Extracted from the CLI so an
+/// in-process sweep (ADR-020 option 3B) stays a registration away.
+/// </summary>
+internal sealed class IntegrityVerificationService(
+    ExpertiseDbContext db,
+    IIntegrityKeyProvider integrityKeys,
+    ILogger<IntegrityVerificationService> logger)
+{
+    private static readonly Counter RunsCounter = Metrics.CreateCounter(
+        "expertise_integrity_verify_runs_total",
+        "Total integrity verification runs (ADR-020).",
+        new CounterConfiguration { LabelNames = ["result"] });
+
+    private static readonly Counter MismatchCounter = Metrics.CreateCounter(
+        "expertise_integrity_mismatches_total",
+        "Total integrity mismatches detected by verification runs (ADR-020).",
+        new CounterConfiguration { LabelNames = ["kind"] });
+
+    /// <summary>Default settle time before an audit row becomes sealable — long enough that no request-scoped audit-writing transaction can still be in flight.</summary>
+    public static readonly TimeSpan DefaultGraceWindow = TimeSpan.FromSeconds(300);
+
+    public async Task<IntegrityVerificationResult> RunAsync(
+        int batchSize, TimeSpan graceWindow, bool seal, CancellationToken ct = default)
+    {
+        var (entriesChecked, entryMismatches, unknownKeys, legacy, unhashed) =
+            await VerifyEntriesAsync(batchSize, ct);
+
+        var (checkpointsChecked, checkpointMismatches) = await VerifyCheckpointsAsync(batchSize, ct);
+
+        var sealedThrough = (long?)null;
+        var sealedNow = false;
+        if (seal && checkpointMismatches == 0)
+        {
+            sealedThrough = await SealCheckpointAsync(batchSize, graceWindow, ct);
+            sealedNow = sealedThrough is not null;
+        }
+        else if (seal)
+        {
+            // Sealing on top of a tampered chain would launder the tampered state into
+            // a fresh, validly-MACed link. Leave the chain as evidence.
+            logger.LogWarning(
+                "Verify: skipping checkpoint seal — {Mismatches} checkpoint mismatch(es) must be investigated first",
+                checkpointMismatches);
+        }
+
+        var result = new IntegrityVerificationResult
+        {
+            EntriesChecked = entriesChecked,
+            EntryMacMismatches = entryMismatches,
+            UnknownKeyIds = unknownKeys,
+            LegacyCount = legacy,
+            UnhashedCount = unhashed,
+            CheckpointsChecked = checkpointsChecked,
+            CheckpointMismatches = checkpointMismatches,
+            CheckpointSealed = sealedNow,
+            SealedThroughSeq = sealedThrough,
+        };
+
+        await PersistStateAsync(result, ct);
+        RunsCounter.WithLabels(result.Clean ? "clean" : "mismatch").Inc();
+        return result;
+    }
+
+    private async Task<(int Checked, int Mismatches, int UnknownKeys, int Legacy, int Unhashed)>
+        VerifyEntriesAsync(int batchSize, CancellationToken ct)
+    {
+        int checkedCount = 0, mismatches = 0, unknownKeys = 0, legacy = 0, unhashed = 0;
+        Guid? lastId = null;
+
+        while (true)
+        {
+            // Cross-tenant sweep — bypass the EF tenant query filter explicitly (same
+            // rationale as ReembedCommand/RehashCommand).
+            var query = db.ExpertiseEntries
+                .IgnoreQueryFilters()
+                .OrderBy(e => e.Id)
+                .AsQueryable();
+
+            if (lastId is not null)
+                query = query.Where(e => e.Id > lastId.Value);
+
+            var entries = await query.Take(batchSize).AsNoTracking().ToListAsync(ct);
+            if (entries.Count == 0)
+                break;
+
+            foreach (var entry in entries)
+            {
+                checkedCount++;
+                var stored = entry.IntegrityHash;
+
+                if (stored is null)
+                {
+                    // Soft-require phase state — reported, non-fatal. Run `rehash`.
+                    unhashed++;
+                    continue;
+                }
+
+                var separator = stored.IndexOf(':', StringComparison.Ordinal);
+                if (separator < 0)
+                {
+                    // Legacy unkeyed format. A non-matching legacy hash is still a
+                    // detected inconsistency (content changed under the stored hash),
+                    // even though a legacy hash is forgeable by design.
+                    legacy++;
+                    if (!HashesEqual(IntegrityHashService.Compute(entry), stored))
+                    {
+                        mismatches++;
+                        MismatchCounter.WithLabels("entry_mac").Inc();
+                        logger.LogError("Verify: entry {Id} legacy IntegrityHash does not match recomputed content hash", entry.Id);
+                    }
+
+                    continue;
+                }
+
+                var key = integrityKeys.ResolveKey(stored[..separator]);
+                if (key is null)
+                {
+                    unknownKeys++;
+                    MismatchCounter.WithLabels("entry_unknown_key").Inc();
+                    logger.LogError(
+                        "Verify: entry {Id} IntegrityHash uses unknown key id '{KeyId}' — add it to Integrity:RetiredKeys or investigate",
+                        entry.Id, stored[..separator]);
+                    continue;
+                }
+
+                if (!HashesEqual(IntegrityHashService.Compute(entry, key), stored))
+                {
+                    mismatches++;
+                    MismatchCounter.WithLabels("entry_mac").Inc();
+                    logger.LogError("Verify: entry {Id} IntegrityHash MAC mismatch — content was modified without the key", entry.Id);
+                }
+            }
+
+            lastId = entries[^1].Id;
+        }
+
+        return (checkedCount, mismatches, unknownKeys, legacy, unhashed);
+    }
+
+    private async Task<(int Checked, int Mismatches)> VerifyCheckpointsAsync(int batchSize, CancellationToken ct)
+    {
+        var checkpoints = await db.AuditCheckpoints
+            .AsNoTracking()
+            .OrderBy(c => c.Id)
+            .ToListAsync(ct);
+
+        var mismatches = 0;
+        string? expectedPrevMac = null;
+
+        foreach (var checkpoint in checkpoints)
+        {
+            // Chain link: each checkpoint must reference its predecessor's MAC; the
+            // first link must reference nothing.
+            if (!string.Equals(checkpoint.PrevCheckpointMac, expectedPrevMac, StringComparison.Ordinal))
+            {
+                mismatches++;
+                MismatchCounter.WithLabels("checkpoint_chain").Inc();
+                logger.LogError(
+                    "Verify: checkpoint {Id} chain link broken — PrevCheckpointMac does not match the preceding checkpoint",
+                    checkpoint.Id);
+            }
+
+            if (!VerifyCheckpointMac(checkpoint))
+                mismatches++;
+
+            // Recompute the Merkle root over the rows currently in the sealed range.
+            var (root, rowCount) = await ComputeRangeRootAsync(checkpoint.SeqFrom, checkpoint.SeqTo, batchSize, ct);
+            if (rowCount != checkpoint.RowCount || !string.Equals(root, checkpoint.MerkleRoot, StringComparison.Ordinal))
+            {
+                mismatches++;
+                MismatchCounter.WithLabels("checkpoint_root").Inc();
+                logger.LogError(
+                    "Verify: checkpoint {Id} (seq {From}-{To}) Merkle root mismatch — sealed {SealedCount} rows, range now holds {LiveCount}; an audit row was edited, deleted, or inserted post-seal",
+                    checkpoint.Id, checkpoint.SeqFrom, checkpoint.SeqTo, checkpoint.RowCount, rowCount);
+            }
+
+            expectedPrevMac = checkpoint.CheckpointMac;
+        }
+
+        return (checkpoints.Count, mismatches);
+    }
+
+    private bool VerifyCheckpointMac(AuditCheckpoint checkpoint)
+    {
+        IntegrityKey? key = null;
+        var separator = checkpoint.CheckpointMac.IndexOf(':', StringComparison.Ordinal);
+        if (separator >= 0)
+        {
+            key = integrityKeys.ResolveKey(checkpoint.CheckpointMac[..separator]);
+            if (key is null)
+            {
+                MismatchCounter.WithLabels("checkpoint_mac").Inc();
+                logger.LogError(
+                    "Verify: checkpoint {Id} MAC uses unknown key id '{KeyId}'",
+                    checkpoint.Id, checkpoint.CheckpointMac[..separator]);
+                return false;
+            }
+        }
+
+        var recomputed = CheckpointMacService.Compute(
+            checkpoint.SeqFrom, checkpoint.SeqTo, checkpoint.RowCount, checkpoint.MerkleRoot,
+            checkpoint.PrevCheckpointMac, checkpoint.CreatedAt, key);
+
+        if (HashesEqual(recomputed, checkpoint.CheckpointMac))
+            return true;
+
+        MismatchCounter.WithLabels("checkpoint_mac").Inc();
+        logger.LogError(
+            "Verify: checkpoint {Id} MAC mismatch — the checkpoint row itself was modified",
+            checkpoint.Id);
+        return false;
+    }
+
+    private async Task<long?> SealCheckpointAsync(int batchSize, TimeSpan graceWindow, CancellationToken ct)
+    {
+        var lastCheckpoint = await db.AuditCheckpoints
+            .AsNoTracking()
+            .OrderByDescending(c => c.Id)
+            .FirstOrDefaultAsync(ct);
+
+        var sealedThrough = lastCheckpoint?.SeqTo ?? 0L;
+
+        // The grace window keeps in-flight audit-writing transactions out of the
+        // sealed range: a sequence value is assigned at INSERT time, before COMMIT, so
+        // sealing right up to max(Seq) could exclude a row that later commits inside
+        // the range and read as tampering. Audit writes are request-scoped
+        // (milliseconds); minutes of settle time make that race implausible.
+        var sealBefore = DateTime.UtcNow - graceWindow;
+
+        var boundary = await db.ExpertiseAuditLogs
+            .AsNoTracking()
+            .Where(a => a.Seq > sealedThrough && a.Timestamp < sealBefore)
+            .Select(a => (long?)a.Seq)
+            .MaxAsync(ct);
+
+        if (boundary is null)
+        {
+            if (logger.IsEnabled(LogLevel.Information))
+                logger.LogInformation("Verify: no grace-aged audit rows beyond seq {SealedThrough} — nothing to seal", sealedThrough);
+            return null;
+        }
+
+        var (root, rowCount) = await ComputeRangeRootAsync(sealedThrough + 1, boundary.Value, batchSize, ct);
+
+        var createdAt = DateTime.UtcNow;
+        var checkpoint = new AuditCheckpoint
+        {
+            SeqFrom = sealedThrough + 1,
+            SeqTo = boundary.Value,
+            RowCount = rowCount,
+            MerkleRoot = root,
+            PrevCheckpointMac = lastCheckpoint?.CheckpointMac,
+            CheckpointMac = CheckpointMacService.Compute(
+                sealedThrough + 1, boundary.Value, rowCount, root,
+                lastCheckpoint?.CheckpointMac, createdAt, integrityKeys.ActiveKey),
+            CreatedAt = createdAt,
+        };
+
+        db.AuditCheckpoints.Add(checkpoint);
+        await db.SaveChangesAsync(ct);
+        db.ChangeTracker.Clear();
+
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            logger.LogInformation(
+                "Verify: sealed checkpoint over seq {From}-{To} ({RowCount} rows, keyed={Keyed})",
+                checkpoint.SeqFrom, checkpoint.SeqTo, rowCount, integrityKeys.ActiveKey is not null);
+        }
+
+        return boundary;
+    }
+
+    private async Task<(string Root, int RowCount)> ComputeRangeRootAsync(
+        long seqFrom, long seqTo, int batchSize, CancellationToken ct)
+    {
+        var leaves = new List<string>();
+        var lastSeq = seqFrom - 1;
+
+        while (true)
+        {
+            var rows = await db.ExpertiseAuditLogs
+                .AsNoTracking()
+                .Where(a => a.Seq > lastSeq && a.Seq <= seqTo)
+                .OrderBy(a => a.Seq)
+                .Take(batchSize)
+                .ToListAsync(ct);
+
+            if (rows.Count == 0)
+                break;
+
+            foreach (var row in rows)
+                leaves.Add(BackupRecordHash.ComputeAudit(ToBackupRecord(row)));
+
+            lastSeq = rows[^1].Seq;
+        }
+
+        return (MerkleTree.ComputeRoot(leaves), leaves.Count);
+    }
+
+    /// <summary>
+    /// Checkpoint Merkle leaves reuse <see cref="BackupRecordHash.ComputeAudit"/> — one
+    /// canonicalization for audit rows everywhere (backup and chain agree on what a
+    /// row's hash is). <c>Seq</c> is deliberately not part of the canonical form (it is
+    /// a server-generated ordinal, regenerated on restore); range membership and leaf
+    /// ORDER are still bound by Seq, so swapping two rows' Seq values inside a sealed
+    /// range reorders the leaves and diverges the root.
+    /// </summary>
+    private static BackupAuditRecord ToBackupRecord(ExpertiseAuditLog row) => new()
+    {
+        Id = row.Id,
+        Timestamp = row.Timestamp,
+        Action = row.Action.ToString(),
+        EntryId = row.EntryId,
+        Tenant = row.Tenant,
+        Principal = row.Principal,
+        Agent = row.Agent,
+        BeforeHash = row.BeforeHash,
+        AfterHash = row.AfterHash,
+        IpAddress = row.IpAddress,
+        ActorClass = row.ActorClass.ToString(),
+        AuthMethod = row.AuthMethod,
+        ActorClassHeader = row.ActorClassHeader,
+        RecordHash = "",
+    };
+
+    private async Task PersistStateAsync(IntegrityVerificationResult result, CancellationToken ct)
+    {
+        var state = await db.IntegrityVerificationStates.FirstOrDefaultAsync(ct);
+        if (state is null)
+        {
+            state = new IntegrityVerificationState { LastResult = "" };
+            db.IntegrityVerificationStates.Add(state);
+        }
+
+        state.LastRunAt = DateTime.UtcNow;
+        state.LastResult = result.Clean ? "clean" : "mismatch";
+        state.MismatchCount = result.TotalMismatches;
+        state.LegacyCount = result.LegacyCount;
+        state.UnhashedCount = result.UnhashedCount;
+        await db.SaveChangesAsync(ct);
+    }
+
+    private static bool HashesEqual(string expected, string actual)
+    {
+        var expectedBytes = Encoding.UTF8.GetBytes(expected);
+        var actualBytes = Encoding.UTF8.GetBytes(actual);
+        return expectedBytes.Length == actualBytes.Length
+            && CryptographicOperations.FixedTimeEquals(expectedBytes, actualBytes);
+    }
+}

--- a/src/ExpertiseApi/Migrations/20260725204150_AddAuditCheckpointsAndSeq.Designer.cs
+++ b/src/ExpertiseApi/Migrations/20260725204150_AddAuditCheckpointsAndSeq.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using ExpertiseApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -14,9 +15,11 @@ using Pgvector;
 namespace ExpertiseApi.Migrations
 {
     [DbContext(typeof(ExpertiseDbContext))]
-    partial class ExpertiseDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260725204150_AddAuditCheckpointsAndSeq")]
+    partial class AddAuditCheckpointsAndSeq
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ExpertiseApi/Migrations/20260725204150_AddAuditCheckpointsAndSeq.cs
+++ b/src/ExpertiseApi/Migrations/20260725204150_AddAuditCheckpointsAndSeq.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace ExpertiseApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAuditCheckpointsAndSeq : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "Seq",
+                table: "ExpertiseAuditLogs",
+                type: "bigint",
+                nullable: false,
+                defaultValue: 0L)
+                .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityAlwaysColumn);
+
+            migrationBuilder.CreateTable(
+                name: "AuditCheckpoints",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityAlwaysColumn),
+                    SeqFrom = table.Column<long>(type: "bigint", nullable: false),
+                    SeqTo = table.Column<long>(type: "bigint", nullable: false),
+                    RowCount = table.Column<int>(type: "integer", nullable: false),
+                    MerkleRoot = table.Column<string>(type: "text", nullable: false),
+                    PrevCheckpointMac = table.Column<string>(type: "text", nullable: true),
+                    CheckpointMac = table.Column<string>(type: "text", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AuditCheckpoints", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "IntegrityVerificationStates",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    LastRunAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    LastResult = table.Column<string>(type: "text", nullable: false),
+                    MismatchCount = table.Column<int>(type: "integer", nullable: false),
+                    LegacyCount = table.Column<int>(type: "integer", nullable: false),
+                    UnhashedCount = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_IntegrityVerificationStates", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExpertiseAuditLogs_Seq",
+                table: "ExpertiseAuditLogs",
+                column: "Seq",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AuditCheckpoints");
+
+            migrationBuilder.DropTable(
+                name: "IntegrityVerificationStates");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ExpertiseAuditLogs_Seq",
+                table: "ExpertiseAuditLogs");
+
+            migrationBuilder.DropColumn(
+                name: "Seq",
+                table: "ExpertiseAuditLogs");
+        }
+    }
+}

--- a/src/ExpertiseApi/Models/AuditCheckpoint.cs
+++ b/src/ExpertiseApi/Models/AuditCheckpoint.cs
@@ -1,0 +1,48 @@
+namespace ExpertiseApi.Models;
+
+/// <summary>
+/// One sealed link of the audit-log checkpoint chain (ADR-020 decision 2B). Each
+/// checkpoint commits the audit rows with <c>Seq</c> in <c>[SeqFrom, SeqTo]</c> to an
+/// RFC 6962 Merkle root (leaf = the row's <see cref="Services.BackupRecordHash"/>
+/// canonical hash, Seq order) and chains to its predecessor via
+/// <see cref="PrevCheckpointMac"/>. <see cref="CheckpointMac"/> is a keyed HMAC over
+/// the checkpoint's own fields, so a database-only writer can neither rewrite a sealed
+/// range (root diverges) nor re-seal it (no key). Sealing and verification both happen
+/// in <see cref="Data.IntegrityVerificationService"/> — the request write path never
+/// touches this table (no serialization point; the rejected per-row chain is ADR-020
+/// option 2A).
+/// </summary>
+internal class AuditCheckpoint
+{
+    /// <summary>Chain position — identity column; strictly increasing.</summary>
+    public long Id { get; set; }
+
+    /// <summary>First audit <c>Seq</c> covered by this checkpoint (inclusive).</summary>
+    public long SeqFrom { get; set; }
+
+    /// <summary>Last audit <c>Seq</c> covered by this checkpoint (inclusive).</summary>
+    public long SeqTo { get; set; }
+
+    /// <summary>
+    /// Number of audit rows present in the range at seal time. Seq gaps from
+    /// rolled-back inserts are normal (sequence values are consumed on rollback), so
+    /// this is not <c>SeqTo - SeqFrom + 1</c>; a post-seal deletion changes the leaf
+    /// set and diverges <see cref="MerkleRoot"/> regardless.
+    /// </summary>
+    public int RowCount { get; set; }
+
+    /// <summary>RFC 6962 Merkle Tree Hash (lowercase hex) over the range's row hashes.</summary>
+    public required string MerkleRoot { get; set; }
+
+    /// <summary>The previous checkpoint's <see cref="CheckpointMac"/>; null for the first link.</summary>
+    public string? PrevCheckpointMac { get; set; }
+
+    /// <summary>
+    /// MAC over this checkpoint's canonical fields: <c>{keyId}:{hex}</c> HMAC-SHA256
+    /// when keyed, bare 64-hex SHA-256 in the unkeyed soft-require phase (the same
+    /// format contract as <c>ExpertiseEntry.IntegrityHash</c>).
+    /// </summary>
+    public required string CheckpointMac { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+}

--- a/src/ExpertiseApi/Models/ExpertiseAuditLog.cs
+++ b/src/ExpertiseApi/Models/ExpertiseAuditLog.cs
@@ -37,4 +37,11 @@ internal class ExpertiseAuditLog
     // the header was absent. Stored verbatim (truncated to 32 chars at write time) so a
     // mismatch between header and scope is forensically recoverable.
     public string? ActorClassHeader { get; set; }
+
+    // ADR-020 checkpoint ordinal. Postgres GENERATED ALWAYS AS IDENTITY — a stable,
+    // unique insertion ordinal that checkpoint ranges are defined over (the PK is a
+    // random uuid and Timestamp is client-set, so neither orders reliably). Never set
+    // by application code; regenerated on restore (the chain restarts — see ADR-020
+    // migration notes). Gaps from rolled-back inserts are normal.
+    public long Seq { get; set; }
 }

--- a/src/ExpertiseApi/Models/IntegrityVerificationState.cs
+++ b/src/ExpertiseApi/Models/IntegrityVerificationState.cs
@@ -1,0 +1,28 @@
+namespace ExpertiseApi.Models;
+
+/// <summary>
+/// Singleton-row record of the most recent integrity verification run (ADR-020).
+/// Written by the <c>verify</c> CLI so the API process — the only long-lived,
+/// scrapeable process — can surface last-run gauges; a short-lived CLI's own
+/// Prometheus counters die with it. Follows the <see cref="SyncState"/> singleton
+/// pattern: get-or-create at the call site, sole writer is the verification sweep.
+/// </summary>
+internal class IntegrityVerificationState
+{
+    public int Id { get; set; }
+
+    /// <summary>Wall-clock (UTC) when the last verification run finished.</summary>
+    public DateTime LastRunAt { get; set; }
+
+    /// <summary>Outcome of the last run: <c>clean</c> or <c>mismatch</c>.</summary>
+    public required string LastResult { get; set; }
+
+    /// <summary>Total mismatches (entry MACs + checkpoint root/MAC/chain) in the last run.</summary>
+    public int MismatchCount { get; set; }
+
+    /// <summary>Entries still carrying a legacy unkeyed (bare-hex) hash — non-fatal, reported.</summary>
+    public int LegacyCount { get; set; }
+
+    /// <summary>Entries with a null <c>IntegrityHash</c> — non-fatal, reported (run <c>rehash</c>).</summary>
+    public int UnhashedCount { get; set; }
+}

--- a/src/ExpertiseApi/Program.cs
+++ b/src/ExpertiseApi/Program.cs
@@ -365,6 +365,13 @@ builder.Services.AddSingleton<ExpertiseApi.Services.IIntegrityKeyProvider>(integ
 
 builder.Services.AddScoped<IExpertiseRepository, ExpertiseRepository>();
 builder.Services.AddScoped<ITenantContextAccessor, HttpTenantContextAccessor>();
+
+// ADR-020 PR 2: the verification sweep (verify CLI verb) and the API-side gauge
+// poller that re-exposes its persisted outcome (a short-lived CLI's own Prometheus
+// metrics are never scraped). Hosted services only start under app.Run, so CLI
+// verbs never spin the poller up.
+builder.Services.AddScoped<IntegrityVerificationService>();
+builder.Services.AddHostedService<ExpertiseApi.Services.IntegrityMetricsService>();
 builder.Services.AddExpertiseAuth(builder.Configuration, builder.Environment);
 
 // Part D C7 — response hygiene. Always-on for /expertise/* read responses per ADR-008.
@@ -561,6 +568,14 @@ if (BackupCommand.IsBackupRequested(args))
 if (RestoreCommand.IsRestoreRequested(args))
 {
     Environment.ExitCode = await RestoreCommand.RunAsync(app, args);
+    return;
+}
+
+if (VerifyCommand.IsVerifyRequested(args))
+{
+    // Exit code drives the scheduled runner (systemd timer / CronJob): 0 clean,
+    // 1 integrity mismatch (alert), 2 precondition failure (ADR-020).
+    Environment.ExitCode = await VerifyCommand.RunAsync(app, args);
     return;
 }
 

--- a/src/ExpertiseApi/Services/BackupRecordHash.cs
+++ b/src/ExpertiseApi/Services/BackupRecordHash.cs
@@ -86,6 +86,28 @@ internal static class BackupRecordHash
         return Convert.ToHexStringLower(SHA256.HashData(stream.ToArray()));
     }
 
+    public static string ComputeCheckpoint(BackupCheckpointRecord r)
+    {
+        ArgumentNullException.ThrowIfNull(r);
+
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("checkpointMac", r.CheckpointMac);
+            writer.WriteString("createdAt", Canonical(r.CreatedAt));
+            writer.WriteNumber("id", r.Id);
+            writer.WriteString("merkleRoot", r.MerkleRoot);
+            WriteNullable(writer, "prevCheckpointMac", r.PrevCheckpointMac);
+            writer.WriteNumber("rowCount", r.RowCount);
+            writer.WriteNumber("seqFrom", r.SeqFrom);
+            writer.WriteNumber("seqTo", r.SeqTo);
+            writer.WriteEndObject();
+        }
+
+        return Convert.ToHexStringLower(SHA256.HashData(stream.ToArray()));
+    }
+
     private static string Canonical(DateTime value) =>
         value.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture);
 

--- a/src/ExpertiseApi/Services/CheckpointMacService.cs
+++ b/src/ExpertiseApi/Services/CheckpointMacService.cs
@@ -1,0 +1,50 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+
+namespace ExpertiseApi.Services;
+
+/// <summary>
+/// MAC over an <see cref="Models.AuditCheckpoint"/>'s canonical fields (ADR-020). Same
+/// format contract as <see cref="IntegrityHashService"/>: keyed → <c>{keyId}:{hex}</c>
+/// HMAC-SHA256, unkeyed → bare-hex SHA-256 (soft-require phase); the colon tells
+/// verification which computation a stored value used. The MAC binds the range, root,
+/// row count, seal time, and the previous link's MAC, so a database-only writer cannot
+/// re-seal a rewritten range or splice the chain without the key.
+/// Canonicalization matches the codebase idiom: alphabetical keys via
+/// <see cref="Utf8JsonWriter"/> (RFC 8785-style).
+/// </summary>
+internal static class CheckpointMacService
+{
+    public static string Compute(
+        long seqFrom,
+        long seqTo,
+        int rowCount,
+        string merkleRoot,
+        string? prevCheckpointMac,
+        DateTime createdAt,
+        IntegrityKey? key)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("createdAt", createdAt.ToUniversalTime().ToString("O", System.Globalization.CultureInfo.InvariantCulture));
+            writer.WriteString("merkleRoot", merkleRoot);
+            if (prevCheckpointMac is null)
+                writer.WriteNull("prevCheckpointMac");
+            else
+                writer.WriteString("prevCheckpointMac", prevCheckpointMac);
+            writer.WriteNumber("rowCount", rowCount);
+            writer.WriteNumber("seqFrom", seqFrom);
+            writer.WriteNumber("seqTo", seqTo);
+            writer.WriteEndObject();
+        }
+
+        var canonical = stream.ToArray();
+
+        if (key is null)
+            return Convert.ToHexStringLower(SHA256.HashData(canonical));
+
+        return $"{key.KeyId}:{Convert.ToHexStringLower(HMACSHA256.HashData(key.Key, canonical))}";
+    }
+}

--- a/src/ExpertiseApi/Services/IntegrityKeyProvider.cs
+++ b/src/ExpertiseApi/Services/IntegrityKeyProvider.cs
@@ -18,15 +18,24 @@ internal interface IIntegrityKeyProvider
     /// per ADR-020, hard-require flip tracked in #490).
     /// </summary>
     IntegrityKey? ActiveKey { get; }
+
+    /// <summary>
+    /// Resolves a stored value's key-id prefix to the active key or an
+    /// <c>Integrity:RetiredKeys</c> entry; <c>null</c> when the id is unknown
+    /// (verification reports it as a mismatch, never a pass).
+    /// </summary>
+    IntegrityKey? ResolveKey(string keyId);
 }
 
 /// <summary>
-/// Loads the ADR-020 integrity HMAC key once at startup. Fail-closed when configured:
+/// Loads the ADR-020 integrity HMAC keys once at startup. Fail-closed when configured:
 /// a key that is present in config but unusable (missing file, invalid base64, too
 /// short, malformed key id) aborts boot — the ADR-015 posture — because silently
 /// falling back to the unkeyed hash would quietly write forgeable values. An entirely
-/// unconfigured key is the sanctioned soft-require state: legacy unkeyed hashing plus
-/// the <c>expertise_integrity_unkeyed</c> gauge and a startup warning.
+/// unconfigured active key is the sanctioned soft-require state: legacy unkeyed hashing
+/// plus the <c>expertise_integrity_unkeyed</c> gauge and a startup warning.
+/// <c>Integrity:RetiredKeys</c> (<c>{id: base64}</c>) keeps rotated-out keys resolvable
+/// so <c>verify</c> can check values sealed under a previous key.
 /// </summary>
 internal sealed class IntegrityKeyProvider : IIntegrityKeyProvider
 {
@@ -36,14 +45,35 @@ internal sealed class IntegrityKeyProvider : IIntegrityKeyProvider
 
     public IntegrityKey? ActiveKey { get; }
 
-    /// <summary>An always-unkeyed provider for tests and contexts with no configuration.</summary>
-    public static IntegrityKeyProvider Unkeyed { get; } = new(null);
+    private readonly IReadOnlyDictionary<string, IntegrityKey> _retiredKeys;
 
-    private IntegrityKeyProvider(IntegrityKey? activeKey) => ActiveKey = activeKey;
+    /// <summary>An always-unkeyed provider for tests and contexts with no configuration.</summary>
+    public static IntegrityKeyProvider Unkeyed { get; } =
+        new(null, new Dictionary<string, IntegrityKey>(StringComparer.Ordinal));
+
+    private IntegrityKeyProvider(
+        IntegrityKey? activeKey,
+        IReadOnlyDictionary<string, IntegrityKey> retiredKeys)
+    {
+        ActiveKey = activeKey;
+        _retiredKeys = retiredKeys;
+    }
+
+    public IntegrityKey? ResolveKey(string keyId)
+    {
+        ArgumentNullException.ThrowIfNull(keyId);
+
+        if (ActiveKey is not null && string.Equals(ActiveKey.KeyId, keyId, StringComparison.Ordinal))
+            return ActiveKey;
+
+        return _retiredKeys.TryGetValue(keyId, out var key) ? key : null;
+    }
 
     public static IntegrityKeyProvider Load(IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(configuration);
+
+        var retired = LoadRetiredKeys(configuration);
 
         var inline = configuration["Integrity:HmacKey"];
         var keyFile = configuration["Integrity:HmacKeyFile"];
@@ -72,7 +102,9 @@ internal sealed class IntegrityKeyProvider : IIntegrityKeyProvider
         else
         {
             UnkeyedGauge.Set(1);
-            return Unkeyed;
+            return retired.Count == 0
+                ? Unkeyed
+                : new IntegrityKeyProvider(null, retired);
         }
 
         if (!IsValidKeyId(keyId))
@@ -81,6 +113,45 @@ internal sealed class IntegrityKeyProvider : IIntegrityKeyProvider
                 $"Integrity:ActiveKeyId '{keyId}' is invalid — 1-32 chars of [A-Za-z0-9._-], no ':' (it prefixes stored hash values).");
         }
 
+        if (retired.ContainsKey(keyId))
+        {
+            throw new InvalidOperationException(
+                $"Integrity:RetiredKeys contains the active key id '{keyId}' — a retired id must not shadow the active key (ADR-020 fail-closed).");
+        }
+
+        var key = DecodeKeyMaterial(material, source);
+
+        UnkeyedGauge.Set(0);
+        return new IntegrityKeyProvider(new IntegrityKey(keyId, key), retired);
+    }
+
+    private static Dictionary<string, IntegrityKey> LoadRetiredKeys(IConfiguration configuration)
+    {
+        var retired = new Dictionary<string, IntegrityKey>(StringComparer.Ordinal);
+        foreach (var child in configuration.GetSection("Integrity:RetiredKeys").GetChildren())
+        {
+            var id = child.Key.Trim();
+            if (!IsValidKeyId(id))
+            {
+                throw new InvalidOperationException(
+                    $"Integrity:RetiredKeys key id '{child.Key}' is invalid — 1-32 chars of [A-Za-z0-9._-], no ':' (ADR-020 fail-closed).");
+            }
+
+            if (string.IsNullOrWhiteSpace(child.Value))
+            {
+                throw new InvalidOperationException(
+                    $"Integrity:RetiredKeys:{id} has empty key material (ADR-020 fail-closed).");
+            }
+
+            retired[id] = new IntegrityKey(
+                id, DecodeKeyMaterial(child.Value.Trim(), $"Integrity:RetiredKeys:{id}"));
+        }
+
+        return retired;
+    }
+
+    private static byte[] DecodeKeyMaterial(string material, string source)
+    {
         byte[] key;
         try
         {
@@ -97,8 +168,7 @@ internal sealed class IntegrityKeyProvider : IIntegrityKeyProvider
                 $"{source} must decode to at least 32 bytes (256-bit); got {key.Length} (ADR-020 fail-closed).");
         }
 
-        UnkeyedGauge.Set(0);
-        return new IntegrityKeyProvider(new IntegrityKey(keyId, key));
+        return key;
     }
 
     private static bool IsValidKeyId(string keyId) =>

--- a/src/ExpertiseApi/Services/IntegrityMetricsService.cs
+++ b/src/ExpertiseApi/Services/IntegrityMetricsService.cs
@@ -1,0 +1,108 @@
+using System.Data.Common;
+using ExpertiseApi.Data;
+using Microsoft.EntityFrameworkCore;
+using Prometheus;
+
+namespace ExpertiseApi.Services;
+
+/// <summary>
+/// Surfaces ADR-020 verification state as scrapeable gauges from the API process. The
+/// <c>verify</c> CLI is a short-lived process whose own Prometheus counters die
+/// unscraped, so it persists its outcome to the database
+/// (<c>IntegrityVerificationState</c>, <c>AuditCheckpoints</c>) and this poller
+/// re-exposes it: checkpoint staleness bounds the ADR-020 detection gap, last-verify
+/// age catches a dead timer/CronJob, and last-verify mismatches is the alerting
+/// signal. Gauges read <c>-1</c> until the first checkpoint / verify run exists.
+/// Follows the <see cref="Idempotency.IdempotencyGcService"/> background-service
+/// style: <see cref="PeriodicTimer"/> cadence, narrowed exception filter, OCE swallow
+/// during shutdown.
+/// </summary>
+internal sealed class IntegrityMetricsService : BackgroundService
+{
+    // Internal-static-mutable so integration tests can drop the cadence without a
+    // production knob (IdempotencyGcService convention).
+    internal static TimeSpan? OverrideInterval { get; set; }
+
+    private static readonly Gauge CheckpointAgeGauge = Metrics.CreateGauge(
+        "expertise_integrity_checkpoint_age_seconds",
+        "Seconds since the newest audit checkpoint was sealed (ADR-020 detection-gap bound); -1 until the first checkpoint exists.");
+
+    private static readonly Gauge LastVerifyAgeGauge = Metrics.CreateGauge(
+        "expertise_integrity_last_verify_age_seconds",
+        "Seconds since the last integrity verification run finished; -1 until the first run.");
+
+    private static readonly Gauge LastVerifyMismatchesGauge = Metrics.CreateGauge(
+        "expertise_integrity_last_verify_mismatches",
+        "Total mismatches reported by the last integrity verification run; -1 until the first run.");
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<IntegrityMetricsService> _logger;
+
+    public IntegrityMetricsService(IServiceScopeFactory scopeFactory, ILogger<IntegrityMetricsService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+        CheckpointAgeGauge.Set(-1);
+        LastVerifyAgeGauge.Set(-1);
+        LastVerifyMismatchesGauge.Set(-1);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            var interval = OverrideInterval ?? TimeSpan.FromMinutes(5);
+            using var timer = new PeriodicTimer(interval);
+            // Refresh once at startup so gauges are meaningful from the first scrape,
+            // then on cadence.
+            await RefreshOnceAsync(stoppingToken).ConfigureAwait(false);
+            while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false))
+            {
+                await RefreshOnceAsync(stoppingToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected during shutdown.
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+        {
+            _logger.LogError(ex, "IntegrityMetricsService loop faulted; gauges frozen until process restart");
+        }
+    }
+
+    // internal (not private) so tests can drive a single refresh deterministically
+    // without racing the PeriodicTimer loop (IdempotencyGcService convention, #354).
+    internal async Task RefreshOnceAsync(CancellationToken ct)
+    {
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ExpertiseDbContext>();
+            var now = DateTime.UtcNow;
+
+            var newestCheckpoint = await db.AuditCheckpoints
+                .AsNoTracking()
+                .OrderByDescending(c => c.Id)
+                .Select(c => (DateTime?)c.CreatedAt)
+                .FirstOrDefaultAsync(ct)
+                .ConfigureAwait(false);
+            CheckpointAgeGauge.Set(newestCheckpoint is null ? -1 : (now - newestCheckpoint.Value).TotalSeconds);
+
+            var state = await db.IntegrityVerificationStates
+                .AsNoTracking()
+                .FirstOrDefaultAsync(ct)
+                .ConfigureAwait(false);
+            LastVerifyAgeGauge.Set(state is null ? -1 : (now - state.LastRunAt).TotalSeconds);
+            LastVerifyMismatchesGauge.Set(state?.MismatchCount ?? -1);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is DbException or InvalidOperationException or TimeoutException)
+        {
+            _logger.LogWarning(ex, "Integrity metrics refresh failed; will retry on next cadence");
+        }
+    }
+}

--- a/src/ExpertiseApi/appsettings.json
+++ b/src/ExpertiseApi/appsettings.json
@@ -85,7 +85,9 @@
     "_comment": "ADR-020 keyed IntegrityHash (#468). Supply a 256-bit base64 key via HmacKeyFile (path — recommended) or HmacKey (inline; wins if both set, mirroring EXPERTISE_API_TOKEN/_FILE). Configured-but-unusable key fails boot; unconfigured falls back to legacy unkeyed SHA-256 with a startup warning and the expertise_integrity_unkeyed gauge (soft-require until #490). After configuring or rotating the key, run `dotnet run -- rehash --force` once — otherwise verification reports a false mass mismatch. ActiveKeyId prefixes stored values ({keyId}:{hex}) so rotation keeps old values attributable.",
     "HmacKey": "",
     "HmacKeyFile": "",
-    "ActiveKeyId": "k1"
+    "ActiveKeyId": "k1",
+    "_retiredKeysComment": "After rotating the key (new ActiveKeyId + material, then `rehash --force`), move the OLD id -> base64 material here so `verify` can still check values sealed under it. A retired id must not equal ActiveKeyId.",
+    "RetiredKeys": {}
   },
   "Sync": {
     "_comment": "ADR-013 aggregator up-sync. SPOKE role: set Enabled=true plus HubUrl/TokenEndpoint/ClientId (client_credentials against the shared IdP; supply Sync__ClientSecret via environment, never here). The spoke's hub credential must carry expertise.write.draft ONLY — the draft-only scope is the knowledge-supply-chain control. HUB role: leave Enabled=false and populate KnownInstances (authenticated client id -> origin instance id) so synced entries get server-side OriginInstanceId attribution. Startup guard fails boot when Enabled=true with missing/invalid connection fields.",

--- a/tests/ExpertiseApi.Tests/Integration/IntegrityVerificationTests.cs
+++ b/tests/ExpertiseApi.Tests/Integration/IntegrityVerificationTests.cs
@@ -1,0 +1,292 @@
+using ExpertiseApi.Auth;
+using ExpertiseApi.Cli;
+using ExpertiseApi.Data;
+using ExpertiseApi.Models;
+using ExpertiseApi.Services;
+using ExpertiseApi.Tests.Infrastructure;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Testcontainers.PostgreSql;
+
+namespace ExpertiseApi.Tests.Integration;
+
+/// <summary>
+/// ADR-020 PR 2 tamper-detection coverage: the <c>verify</c> verb against real
+/// Postgres, with tampering applied the way the threat model says it happens — direct
+/// database writes that bypass the repository (and therefore recompute no MAC and
+/// write no audit row). Owns its container (CliMaintenanceCommandTests pattern).
+/// </summary>
+public class IntegrityVerificationTests : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("pgvector/pgvector:pg17")
+        .WithDatabase("integrity_verify")
+        .WithUsername("test")
+        .WithPassword("test")
+        .Build();
+
+    private static readonly IntegrityKeyProvider Keyed = IntegrityKeyProvider.Load(
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Integrity:HmacKey"] = Convert.ToBase64String(Enumerable.Repeat((byte)0x42, 32).ToArray()),
+            })
+            .Build());
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+        await using var db = NewContext();
+        await db.Database.MigrateAsync();
+    }
+
+    public async Task DisposeAsync() => await _container.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task Verify_CleanRun_SealsAndChainsCheckpoints_ExitsZero()
+    {
+        await SeedEntriesWithAudit(3);
+
+        (await RunVerify()).Should().Be(0);
+
+        await using (var db = NewContext())
+        {
+            var first = await db.AuditCheckpoints.SingleAsync();
+            first.PrevCheckpointMac.Should().BeNull("the first link references nothing");
+            first.RowCount.Should().Be(3);
+            first.CheckpointMac.Should().StartWith("k1:", "sealing uses the active key");
+
+            var state = await db.IntegrityVerificationStates.SingleAsync();
+            state.LastResult.Should().Be("clean");
+            state.MismatchCount.Should().Be(0);
+        }
+
+        // New audit rows after the first seal: the second run must re-verify link 1
+        // clean and seal link 2 chained to it.
+        await SeedEntriesWithAudit(2);
+        (await RunVerify()).Should().Be(0);
+
+        await using (var db = NewContext())
+        {
+            var checkpoints = await db.AuditCheckpoints.OrderBy(c => c.Id).ToListAsync();
+            checkpoints.Should().HaveCount(2);
+            checkpoints[1].PrevCheckpointMac.Should().Be(checkpoints[0].CheckpointMac);
+            checkpoints[1].SeqFrom.Should().Be(checkpoints[0].SeqTo + 1);
+        }
+
+        // Nothing new to seal: idempotent clean run.
+        (await RunVerify()).Should().Be(0);
+        await using (var db = NewContext())
+            (await db.AuditCheckpoints.CountAsync()).Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Verify_EntryContentTamper_ExitsOne()
+    {
+        var ids = await SeedEntriesWithAudit(2);
+        (await RunVerify()).Should().Be(0);
+
+        // DB-only writer edits content without the key: the stored MAC no longer matches.
+        await using (var db = NewContext())
+        {
+            var entry = await db.ExpertiseEntries.IgnoreQueryFilters().SingleAsync(e => e.Id == ids[0]);
+            entry.Body = "tampered by a database-level writer";
+            await db.SaveChangesAsync();
+        }
+
+        (await RunVerify()).Should().Be(1);
+        await using (var verify = NewContext())
+            (await verify.IntegrityVerificationStates.SingleAsync()).LastResult.Should().Be("mismatch");
+    }
+
+    [Fact]
+    public async Task Verify_AuditRowEdit_InsideSealedRange_ExitsOne()
+    {
+        await SeedEntriesWithAudit(3);
+        (await RunVerify()).Should().Be(0);
+
+        await using (var db = NewContext())
+        {
+            var row = await db.ExpertiseAuditLogs.OrderBy(a => a.Seq).FirstAsync();
+            row.Principal = "rewritten-attribution";
+            await db.SaveChangesAsync();
+        }
+
+        (await RunVerify()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Verify_AuditRowDeletion_InsideSealedRange_ExitsOne()
+    {
+        await SeedEntriesWithAudit(3);
+        (await RunVerify()).Should().Be(0);
+
+        await using (var db = NewContext())
+        {
+            var row = await db.ExpertiseAuditLogs.OrderBy(a => a.Seq).FirstAsync();
+            db.ExpertiseAuditLogs.Remove(row);
+            await db.SaveChangesAsync();
+        }
+
+        (await RunVerify()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Verify_CheckpointRowTamper_ExitsOne()
+    {
+        await SeedEntriesWithAudit(2);
+        (await RunVerify()).Should().Be(0);
+
+        // Rewriting the sealed root to "legitimize" a tampered range fails without the
+        // key: the checkpoint MAC no longer verifies.
+        await using (var db = NewContext())
+        {
+            var checkpoint = await db.AuditCheckpoints.SingleAsync();
+            checkpoint.MerkleRoot = new string('0', 64);
+            await db.SaveChangesAsync();
+        }
+
+        (await RunVerify()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Verify_LegacyAndUnhashedEntries_AreReportedNonFatal()
+    {
+        // Soft-require states (ADR-020): a matching legacy bare-hex hash and a null
+        // hash are counted, not failed.
+        await using (var db = NewContext())
+        {
+            var legacy = TestHelpers.SeedEntry(domain: "iv", title: "legacy", body: "b");
+            legacy.IntegrityHash = IntegrityHashService.Compute(legacy);
+            var unhashed = TestHelpers.SeedEntry(domain: "iv", title: "unhashed", body: "b");
+            unhashed.IntegrityHash = null;
+            db.ExpertiseEntries.AddRange(legacy, unhashed);
+            await db.SaveChangesAsync();
+        }
+
+        (await RunVerify()).Should().Be(0);
+
+        await using var verifyDb = NewContext();
+        var state = await verifyDb.IntegrityVerificationStates.SingleAsync();
+        state.LastResult.Should().Be("clean");
+        state.LegacyCount.Should().Be(1);
+        state.UnhashedCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Verify_UnknownKeyId_ExitsOne()
+    {
+        await using (var db = NewContext())
+        {
+            var entry = TestHelpers.SeedEntry(domain: "iv", title: "orphan-key", body: "b");
+            entry.IntegrityHash = $"k9:{new string('a', 64)}";
+            db.ExpertiseEntries.Add(entry);
+            await db.SaveChangesAsync();
+        }
+
+        (await RunVerify()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Verify_NoSealAndGraceWindow_DoNotSeal()
+    {
+        // --no-seal never seals; a fresh row inside the grace window is not sealable
+        // either (in-flight-transaction guard, ADR-020).
+        await SeedEntriesWithAudit(1, timestampAge: TimeSpan.Zero);
+
+        (await RunVerify("--no-seal")).Should().Be(0);
+        (await RunVerifyArgs(["verify", "--grace-seconds", "300"])).Should().Be(0);
+
+        await using var db = NewContext();
+        (await db.AuditCheckpoints.CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Backup_ExportsCheckpointChain_WithManifestRoot()
+    {
+        await SeedEntriesWithAudit(2);
+        (await RunVerify()).Should().Be(0);
+
+        var outputDir = Path.Join(Path.GetTempPath(), $"integrity-backup-{Guid.NewGuid():N}");
+        try
+        {
+            await using (var app = BuildApp())
+                (await BackupCommand.RunAsync(app, ["backup", "--output", outputDir])).Should().Be(0);
+
+            var checkpointLines = await File.ReadAllLinesAsync(Path.Join(outputDir, "checkpoints.jsonl"));
+            checkpointLines.Should().HaveCount(1);
+            checkpointLines[0].Should().Contain("\"checkpointMac\":\"k1:");
+
+            var manifest = await File.ReadAllTextAsync(Path.Join(outputDir, "manifest.json"));
+            manifest.Should().Contain("\"checkpointCount\":1");
+            manifest.Should().MatchRegex("\"checkpointsMerkleRoot\":\"[0-9a-f]{64}\"");
+        }
+        finally
+        {
+            if (Directory.Exists(outputDir))
+                Directory.Delete(outputDir, recursive: true);
+        }
+    }
+
+    // ---- Helpers ----------------------------------------------------------
+
+    /// <summary>Seeds keyed entries each with one audit row aged out of the grace window.</summary>
+    private async Task<List<Guid>> SeedEntriesWithAudit(int count, TimeSpan? timestampAge = null)
+    {
+        var ids = new List<Guid>();
+        var timestamp = DateTime.UtcNow - (timestampAge ?? TimeSpan.FromMinutes(10));
+        for (var i = 0; i < count; i++)
+        {
+            await using var db = NewContext();
+            var entry = TestHelpers.SeedEntry(domain: "iv", title: $"entry {Guid.NewGuid():N}", body: $"body {i}");
+            entry.IntegrityHash = IntegrityHashService.Compute(entry, Keyed.ActiveKey);
+            db.ExpertiseEntries.Add(entry);
+            await db.SaveChangesAsync(); // Id is DB-generated — the FK below needs it materialized
+            db.ExpertiseAuditLogs.Add(new ExpertiseAuditLog
+            {
+                Timestamp = timestamp,
+                Action = AuditAction.Created,
+                EntryId = entry.Id,
+                Tenant = entry.Tenant,
+                Principal = "seed-principal",
+                AfterHash = entry.IntegrityHash,
+                ActorClass = ActorClass.Service,
+            });
+            await db.SaveChangesAsync();
+            ids.Add(entry.Id);
+        }
+
+        return ids;
+    }
+
+    private async Task<int> RunVerify(params string[] extraArgs) =>
+        await RunVerifyArgs(["verify", "--grace-seconds", "0", .. extraArgs]);
+
+    private async Task<int> RunVerifyArgs(string[] args)
+    {
+        await using var app = BuildApp();
+        return await VerifyCommand.RunAsync(app, args);
+    }
+
+    private ExpertiseDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<ExpertiseDbContext>()
+            .UseNpgsql(_container.GetConnectionString(), o => o.UseVector())
+            .Options;
+        return new ExpertiseDbContext(options, new NoOpTenantContextAccessor());
+    }
+
+    private WebApplication BuildApp()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        builder.Services.AddSingleton<IIntegrityKeyProvider>(Keyed);
+        builder.Services.AddSingleton<ITenantContextAccessor, NoOpTenantContextAccessor>();
+        builder.Services.AddDbContext<ExpertiseDbContext>(o =>
+            o.UseNpgsql(_container.GetConnectionString(), x => x.UseVector()));
+        builder.Services.AddScoped<IntegrityVerificationService>();
+        return builder.Build();
+    }
+}

--- a/tests/ExpertiseApi.Tests/Unit/CheckpointMacServiceTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/CheckpointMacServiceTests.cs
@@ -1,0 +1,69 @@
+using ExpertiseApi.Services;
+
+namespace ExpertiseApi.Tests.Unit;
+
+/// <summary>
+/// ADR-020 checkpoint MAC format contract: keyed → <c>{keyId}:{hex}</c> HMAC, unkeyed →
+/// bare-hex SHA-256, and every canonical field (range, root, row count, seal time,
+/// previous link) must influence the value — a field the MAC ignores is a field a
+/// database-only writer can rewrite undetected.
+/// </summary>
+public class CheckpointMacServiceTests
+{
+    private static readonly DateTime CreatedAt = new(2026, 7, 25, 12, 0, 0, DateTimeKind.Utc);
+
+    private static IntegrityKey TestKey(string keyId = "k1", byte fill = 0x42)
+    {
+        var key = new byte[32];
+        Array.Fill(key, fill);
+        return new IntegrityKey(keyId, key);
+    }
+
+    private static string Compute(
+        long seqFrom = 1, long seqTo = 10, int rowCount = 10, string root = "aa",
+        string? prevMac = null, DateTime? createdAt = null, IntegrityKey? key = null) =>
+        CheckpointMacService.Compute(seqFrom, seqTo, rowCount, root, prevMac, createdAt ?? CreatedAt, key);
+
+    [Fact]
+    public void Compute_Keyed_HasKeyIdPrefixAndHexMac()
+    {
+        Compute(key: TestKey()).Should().MatchRegex("^k1:[0-9a-f]{64}$");
+    }
+
+    [Fact]
+    public void Compute_Unkeyed_IsBareHex()
+    {
+        Compute().Should().MatchRegex("^[0-9a-f]{64}$");
+    }
+
+    [Fact]
+    public void Compute_IsDeterministic()
+    {
+        Compute(key: TestKey()).Should().Be(Compute(key: TestKey()));
+        Compute().Should().Be(Compute());
+    }
+
+    [Fact]
+    public void Compute_EveryCanonicalField_InfluencesTheMac()
+    {
+        var baseline = Compute(key: TestKey());
+
+        Compute(seqFrom: 2, key: TestKey()).Should().NotBe(baseline);
+        Compute(seqTo: 11, key: TestKey()).Should().NotBe(baseline);
+        Compute(rowCount: 9, key: TestKey()).Should().NotBe(baseline);
+        Compute(root: "bb", key: TestKey()).Should().NotBe(baseline);
+        Compute(prevMac: "cc", key: TestKey()).Should().NotBe(baseline);
+        Compute(createdAt: CreatedAt.AddSeconds(1), key: TestKey()).Should().NotBe(baseline);
+    }
+
+    [Fact]
+    public void Compute_DiffersByKeyMaterial_AndFromUnkeyed()
+    {
+        var a = Compute(key: TestKey(fill: 0x01));
+        var b = Compute(key: TestKey(fill: 0x02));
+        var unkeyed = Compute();
+
+        a.Should().NotBe(b);
+        a.Should().NotEndWith(unkeyed, "the MAC must not equal the plain hash even ignoring the prefix");
+    }
+}

--- a/tests/ExpertiseApi.Tests/Unit/IntegrityKeyProviderTests.cs
+++ b/tests/ExpertiseApi.Tests/Unit/IntegrityKeyProviderTests.cs
@@ -125,4 +125,85 @@ public class IntegrityKeyProviderTests : IDisposable
     {
         IntegrityKeyProvider.Unkeyed.ActiveKey.Should().BeNull();
     }
+
+    // --- ADR-020 PR 2: retired keys + ResolveKey ---------------------------------
+
+    private static readonly string RetiredKeyBase64 =
+        Convert.ToBase64String(Enumerable.Repeat((byte)0x07, 32).ToArray());
+
+    [Fact]
+    public void ResolveKey_ActiveKeyId_ReturnsActiveKey()
+    {
+        var provider = IntegrityKeyProvider.Load(Config(("Integrity:HmacKey", ValidKeyBase64)));
+
+        provider.ResolveKey("k1").Should().BeSameAs(provider.ActiveKey);
+    }
+
+    [Fact]
+    public void ResolveKey_RetiredKeyId_ReturnsRetiredKey()
+    {
+        var provider = IntegrityKeyProvider.Load(Config(
+            ("Integrity:HmacKey", ValidKeyBase64),
+            ("Integrity:RetiredKeys:k0", RetiredKeyBase64)));
+
+        var resolved = provider.ResolveKey("k0");
+        resolved.Should().NotBeNull();
+        resolved!.KeyId.Should().Be("k0");
+        resolved.Key.Should().Equal(Enumerable.Repeat((byte)0x07, 32));
+    }
+
+    [Fact]
+    public void ResolveKey_UnknownKeyId_ReturnsNull()
+    {
+        var provider = IntegrityKeyProvider.Load(Config(
+            ("Integrity:HmacKey", ValidKeyBase64),
+            ("Integrity:RetiredKeys:k0", RetiredKeyBase64)));
+
+        provider.ResolveKey("k9").Should().BeNull();
+        IntegrityKeyProvider.Unkeyed.ResolveKey("k1").Should().BeNull();
+    }
+
+    [Fact]
+    public void Load_RetiredKeysWithoutActiveKey_StaysUnkeyedButResolvable()
+    {
+        // A rotated-out instance may retire its key without configuring a new one —
+        // verify must still resolve old values while new writes go unkeyed.
+        var provider = IntegrityKeyProvider.Load(Config(("Integrity:RetiredKeys:k0", RetiredKeyBase64)));
+
+        provider.ActiveKey.Should().BeNull();
+        provider.ResolveKey("k0").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Load_RetiredKeyShadowingActiveKeyId_FailsClosed()
+    {
+        var act = () => IntegrityKeyProvider.Load(Config(
+            ("Integrity:HmacKey", ValidKeyBase64),
+            ("Integrity:RetiredKeys:k1", RetiredKeyBase64)));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*must not shadow*");
+    }
+
+    [Theory]
+    [InlineData("has:colon")]
+    [InlineData("way-too-long-key-identifier-value-over-32")]
+    public void Load_InvalidRetiredKeyId_FailsClosed(string keyId)
+    {
+        var act = () => IntegrityKeyProvider.Load(Config(
+            ($"Integrity:RetiredKeys:{keyId}", RetiredKeyBase64)));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*RetiredKeys*");
+    }
+
+    [Fact]
+    public void Load_RetiredKeyBadMaterial_FailsClosed()
+    {
+        var badBase64 = () => IntegrityKeyProvider.Load(Config(
+            ("Integrity:RetiredKeys:k0", "not-base64!!!")));
+        badBase64.Should().Throw<InvalidOperationException>().WithMessage("*not valid base64*");
+
+        var shortKey = () => IntegrityKeyProvider.Load(Config(
+            ("Integrity:RetiredKeys:k0", Convert.ToBase64String(new byte[16]))));
+        shortKey.Should().Throw<InvalidOperationException>().WithMessage("*at least 32 bytes*");
+    }
 }


### PR DESCRIPTION
## Summary

PR 2 of the ADR-020 series (#468, from #333 Finding 3): the audit-log checkpoint chain and the `verify` path. PR 1 (#491) made `IntegrityHash` unforgeable by a database-only writer; this PR makes audit-row **deletion and edits detectable** and ships the sweep that actually checks everything.

### Schema (`AddAuditCheckpointsAndSeq`)

- `ExpertiseAuditLog.Seq` — `bigint GENERATED ALWAYS AS IDENTITY` + unique index. The uuid PK and client-set `Timestamp` order nothing reliably; checkpoint ranges need a stable ordinal. Postgres backfills existing rows on `ADD COLUMN`; restore never sets it (identity-always), so restored rows re-sequence and the chain restarts.
- `AuditCheckpoints` — `{Id, SeqFrom, SeqTo, RowCount, MerkleRoot, PrevCheckpointMac?, CheckpointMac, CreatedAt}`. RFC 6962 root (existing `MerkleTree`, leaf = `BackupRecordHash.ComputeAudit` — one canonicalization for audit rows everywhere) over the sealed range; `CheckpointMac` (same `{keyId}:{hex}` format contract as `IntegrityHash`) binds range + root + row count + seal time + previous link, so a DB-only writer can neither rewrite a sealed range nor re-seal it. Sole writer is the verify sweep — the request write path is untouched (the rejected per-row chain is ADR-020 option 2A).
- `IntegrityVerificationStates` — last-run singleton (SyncState pattern) so the API process can expose the outcome.

### Verification (`verify`)

`IntegrityVerificationService` (in `Data/` per the DbContext-encapsulation guard) runs three legs: entry MAC sweep (format-prefix dispatch: keyed → resolve key + `FixedTimeEquals`; bare hex → legacy, counted non-fatal; null → unhashed, counted; unknown key id → mismatch), checkpoint verification (root + MAC + chain link), then seals a new checkpoint through the latest audit row older than the grace window (default 300 s — keeps in-flight audit transactions out of sealed ranges). Sealing is skipped over a tampered chain so mismatches are never laundered into a fresh link.

- CLI: `dotnet run -- verify [--batch-size 500] [--grace-seconds 300] [--no-seal]`, exit 0 clean / 1 mismatch / 2 precondition.
- `expertise-apictl verify` preserves those exit codes for timers/CronJobs (templates are PR 3).
- Metrics: `expertise_integrity_verify_runs_total{result}` / `expertise_integrity_mismatches_total{kind}` per the ADR, plus API-side gauges (`expertise_integrity_checkpoint_age_seconds`, `expertise_integrity_last_verify_age_seconds`, `expertise_integrity_last_verify_mismatches`) via a polling `IntegrityMetricsService` — a short-lived CLI's own Prometheus counters are never scraped, so the API re-exposes DB-persisted state.

### Rotation + backup

- `Integrity:RetiredKeys` (`{id: base64}`) + `IIntegrityKeyProvider.ResolveKey` — fail-closed loading; a retired id shadowing the active id aborts boot.
- `backup` now emits `checkpoints.jsonl` + `checkpointCount`/`checkpointsMerkleRoot` manifest fields (nullable additive; SchemaVersion stays 1 both directions). The signed artifact is the chain's off-host anchor. `BackupAuditRecord` gains export-only `Seq`, deliberately excluded from `RecordHash` so pre-PR2 backups still verify. Restore is unchanged — it ignores checkpoints; the chain restarts post-restore (runbook note).

## Tests

- 488 passed / 0 failed locally (Testcontainers via podman), `dotnet format analyzers` clean, 0 build warnings, shellcheck/markdownlint/JSON lint clean.
- New integration class `IntegrityVerificationTests` (9 tests) tampers the way the threat model says it happens — direct DB writes bypassing the repository: entry content edit, audit-row edit/deletion inside a sealed range, checkpoint-row rewrite (all exit 1); clean runs seal + chain checkpoints; legacy/unhashed counted non-fatal; unknown key id fails; grace window + `--no-seal` don't seal; backup exports the chain.
- New unit tests: `CheckpointMacServiceTests` (every canonical field influences the MAC), retired-key resolution/fail-closed cases.
- `MigrationReversibilityTests` covers the new migration's `Down()`.

## Doc impact

| Surface | Classification | Notes |
|---|---|---|
| `CLAUDE.md` (verify verb, apictl, data model) | in-scope | updated |
| `docs/operations/backup-restore-runbook.md` | in-scope | checkpoints.jsonl + post-restore chain restart |
| README / install.sh keygen / Helm-Compose wiring / timer templates / DESIGN.md sweep | out-of-scope — tracked | ADR-020 PR 3, under #468 |
| ADR | not-a-thing | executes accepted ADR-020; no new decision |

Part of #468 (PR 2 of 3 — do not close on merge). Related: #490 (hard-require flip, gated on the full series + `expertise_integrity_unkeyed` at 0).
