### PR TITLE
fix(config): update appsettings integrity comment for hard-require

### DIFF
--- a/src/ExpertiseApi/appsettings.json
+++ b/src/ExpertiseApi/appsettings.json
@@ -82,7 +82,8 @@
     "Enabled": true
   },
   "Integrity": {
-    "_comment": "ADR-020 keyed IntegrityHash (#468). Supply a 256-bit base64 key via HmacKeyFile (path — recommended) or HmacKey (inline; wins if both set, mirroring EXPERTISE_API_TOKEN/_FILE). Configured-but-unusable key fails boot; unconfigured falls back to legacy unkeyed SHA-256 with a startup warning and the expertise_integrity_unkeyed gauge (soft-require until #490). After configuring or rotating the key, run `dotnet run -- rehash --force` once — otherwise verification reports a false mass mismatch. ActiveKeyId prefixes stored values ({keyId}:{hex}) so rotation keeps old values attributable.",
+    "_comment": "ADR-020 keyed IntegrityHash (#468). Supply a 256-bit base64 key via HmacKeyFile (path — recommended) or HmacKey (inline; wins if both set, mirroring EXPERTISE_API_TOKEN/_FILE). Configured-but-unusable key fails boot. RequireKey is hard-on by default since #490 (ADR-020 Amendment 1): an unconfigured key aborts boot outside Development; set RequireKey to false only as a temporary rollback overlay (legacy unkeyed SHA-256 with a startup warning and expertise_integrity_unkeyed gauge = 1). After configuring or rotating the key, run `dotnet run -- rehash --force` once — otherwise verification reports a false mass mismatch. ActiveKeyId prefixes stored values ({keyId}:{hex}) so rotation keeps old values attributable.",
+    "RequireKey": true,
     "HmacKey": "",
     "HmacKeyFile": "",
     "ActiveKeyId": "k1",


### PR DESCRIPTION
## Summary

Pre-v3.0.0 hygiene, surfaced as the sole Warning by the full-solution `/review`: the #496 flip updated every documentation surface **except the shipped config file itself** — `appsettings.json`'s `Integrity._comment` still described soft-require and the section had no `RequireKey` key (unlike the sibling `Idempotency` section).

- Rewrites the comment for the hard-require default (#490, ADR-020 Amendment 1) including the `RequireKey=false` rollback overlay.
- Adds explicit `"RequireKey": true` mirroring the `Idempotency` section. Behavior-neutral — `true` is the code default.

## Testing

- `jq empty` JSON validity; `dotnet build` 0 errors; IntegrityKeyProvider tests 24/24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)